### PR TITLE
feat: return JWT tokens from auth endpoints

### DIFF
--- a/apps/api/src/auth/token.ts
+++ b/apps/api/src/auth/token.ts
@@ -1,22 +1,78 @@
-import jwt from 'jsonwebtoken';
+import jwt, { type SignOptions } from 'jsonwebtoken';
 
-export interface TokenService {
-  createToken(userId: string): Promise<string>;
-  verifyToken(token: string): Promise<{ sub: string }>;
+export interface TokenIssue {
+  accessToken: string;
+  refreshToken: string;
+  accessTokenExpiresAt: string;
+  refreshTokenExpiresAt: string;
+  tokenType: 'Bearer';
 }
 
-export function createTokenService(secret: string): TokenService {
+export interface TokenServiceOptions {
+  accessSecret: string;
+  refreshSecret?: string;
+  accessExpiresIn?: string | number;
+  refreshExpiresIn?: string | number;
+}
+
+export interface TokenService {
+  issueTokens(userId: string): Promise<TokenIssue>;
+  verifyAccessToken(token: string): Promise<{ sub: string }>;
+  verifyRefreshToken(token: string): Promise<{ sub: string }>;
+}
+
+function decodeExpiration(token: string): string {
+  const payload = jwt.decode(token);
+  if (typeof payload !== 'object' || payload === null || typeof payload.exp !== 'number') {
+    throw new Error('Unable to decode token expiration');
+  }
+  return new Date(payload.exp * 1000).toISOString();
+}
+
+function verifyToken(token: string, secret: string): { sub: string } {
+  const payload = jwt.verify(token, secret);
+  if (typeof payload !== 'object' || payload === null || typeof payload.sub !== 'string') {
+    throw new Error('Invalid token payload');
+  }
+  return { sub: payload.sub };
+}
+
+export function createTokenService(options: TokenServiceOptions): TokenService {
+  const refreshSecret = options.refreshSecret ?? options.accessSecret;
+  const accessExpiresIn = options.accessExpiresIn ?? '1h';
+  const refreshExpiresIn = options.refreshExpiresIn ?? '7d';
+
   return {
-    createToken(userId) {
-      return Promise.resolve(jwt.sign({ sub: userId }, secret, { expiresIn: '1h' }));
+    async issueTokens(userId) {
+      const accessToken = jwt.sign(
+        { sub: userId },
+        options.accessSecret,
+        { expiresIn: accessExpiresIn as SignOptions['expiresIn'] },
+      );
+      const refreshToken = jwt.sign(
+        { sub: userId },
+        refreshSecret,
+        { expiresIn: refreshExpiresIn as SignOptions['expiresIn'] },
+      );
+
+      return {
+        accessToken,
+        refreshToken,
+        accessTokenExpiresAt: decodeExpiration(accessToken),
+        refreshTokenExpiresAt: decodeExpiration(refreshToken),
+        tokenType: 'Bearer',
+      };
     },
-    verifyToken(token) {
+    verifyAccessToken(token) {
       try {
-        const payload = jwt.verify(token, secret);
-        if (typeof payload !== 'object' || !payload || typeof payload.sub !== 'string') {
-          throw new Error('Invalid token payload');
-        }
-        return Promise.resolve({ sub: payload.sub });
+        return Promise.resolve(verifyToken(token, options.accessSecret));
+      } catch (error) {
+        return Promise.reject(error);
+      }
+    },
+    verifyRefreshToken(token) {
+      try {
+        return Promise.resolve(verifyToken(token, refreshSecret));
       } catch (error) {
         return Promise.reject(error);
       }

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -25,7 +25,7 @@ export function createAuthMiddleware({ tokenService, userStore }: AuthMiddleware
     }
 
     try {
-      const payload = await tokenService.verifyToken(token);
+      const payload = await tokenService.verifyAccessToken(token);
       const user = await userStore.findById(payload.sub);
       if (!user) {
         return res.status(401).json({ error: 'Unauthorized' });

--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -33,6 +33,18 @@ const authUser: OpenAPIV3.SchemaObject = {
   required: ['id', 'email', 'createdAt'],
 };
 
+const authTokens: OpenAPIV3.SchemaObject = {
+  type: 'object',
+  properties: {
+    tokenType: { type: 'string', enum: ['Bearer'] },
+    accessToken: { type: 'string', description: 'Short-lived JWT used for API requests.' },
+    refreshToken: { type: 'string', description: 'Long-lived JWT used to request new access tokens.' },
+    accessTokenExpiresAt: { type: 'string', format: 'date-time' },
+    refreshTokenExpiresAt: { type: 'string', format: 'date-time' },
+  },
+  required: ['tokenType', 'accessToken', 'refreshToken', 'accessTokenExpiresAt', 'refreshTokenExpiresAt'],
+};
+
 export const openApiDocument: OpenAPIV3.Document = {
   openapi: '3.0.3',
   info: {
@@ -51,13 +63,14 @@ export const openApiDocument: OpenAPIV3.Document = {
     },
     schemas: {
       AuthCredentials: authCredentials,
+      AuthTokens: authTokens,
       AuthSuccessResponse: {
         type: 'object',
         properties: {
-          token: { type: 'string', description: 'Bearer token for authenticated requests.' },
+          tokens: { $ref: '#/components/schemas/AuthTokens' },
           user: authUser,
         },
-        required: ['token', 'user'],
+        required: ['tokens', 'user'],
       },
       AuthMeResponse: {
         type: 'object',

--- a/apps/api/tests/auth.e2e.test.ts
+++ b/apps/api/tests/auth.e2e.test.ts
@@ -20,7 +20,13 @@ describe('Auth API', () => {
     expect(response.body).toEqual(
       expect.objectContaining({
         user: expect.objectContaining({ email: 'new-user@example.com' }),
-        token: expect.any(String),
+        tokens: expect.objectContaining({
+          accessToken: expect.any(String),
+          refreshToken: expect.any(String),
+          tokenType: 'Bearer',
+          accessTokenExpiresAt: expect.any(String),
+          refreshTokenExpiresAt: expect.any(String),
+        }),
       }),
     );
   });
@@ -57,7 +63,11 @@ describe('Auth API', () => {
     expect(login.body).toEqual(
       expect.objectContaining({
         user: expect.objectContaining({ email: 'login@example.com' }),
-        token: expect.any(String),
+        tokens: expect.objectContaining({
+          accessToken: expect.any(String),
+          refreshToken: expect.any(String),
+          tokenType: 'Bearer',
+        }),
       }),
     );
   });
@@ -86,7 +96,7 @@ describe('Auth API', () => {
 
     const profile = await agent
       .get('/api/taskforge/v1/auth/me')
-      .set('Authorization', `Bearer ${body.token}`)
+      .set('Authorization', `Bearer ${body.tokens.accessToken}`)
       .expect(200);
 
     expect(profile.body).toEqual(

--- a/apps/api/tests/auth.http
+++ b/apps/api/tests/auth.http
@@ -18,8 +18,8 @@ Content-Type: application/json
 
 ### Fetch current user with token
 GET http://localhost:4000/api/taskforge/v1/auth/me
-Authorization: Bearer {{token}}
+Authorization: Bearer {{accessToken}}
 
 ### Logout (requires token)
 POST http://localhost:4000/api/taskforge/v1/auth/logout
-Authorization: Bearer {{token}}
+Authorization: Bearer {{accessToken}}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -9,3 +9,26 @@ export interface TaskDTO {
   dueDate?: string;
   tags?: string[];
 }
+
+export interface AuthUserDTO {
+  id: string;
+  email: string;
+  createdAt: string;
+}
+
+export interface AuthTokensDTO {
+  tokenType: 'Bearer';
+  accessToken: string;
+  refreshToken: string;
+  accessTokenExpiresAt: string;
+  refreshTokenExpiresAt: string;
+}
+
+export interface AuthSuccessResponseDTO {
+  user: AuthUserDTO;
+  tokens: AuthTokensDTO;
+}
+
+export interface AuthMeResponseDTO {
+  user: AuthUserDTO | null;
+}


### PR DESCRIPTION
## Summary
- update the token service to issue and validate access/refresh JWTs with expiration metadata
- return the token bundle from the auth register/login routes and refresh shared API documentation/types
- adjust auth tests and examples to cover the new token response contract

## Testing
- pnpm --filter @taskforge/api test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911af4fc3408322bd4b864337480d28)