### PR TITLE
Add automated auth endpoint smoke tests

### DIFF
--- a/apps/api/tests/auth.e2e.test.ts
+++ b/apps/api/tests/auth.e2e.test.ts
@@ -1,25 +1,42 @@
-import request from 'supertest';
+import { randomUUID } from 'node:crypto';
+
+import type { SuperTest, Test } from 'supertest';
 
 import { InMemoryUserStore } from '../src/auth/user-store';
-import { createApp } from '../src/app';
+import { createTestAgent } from './utils/test-app';
+
+const defaultPassword = 'Secret123!';
+
+function uniqueEmail(prefix = 'user'): string {
+  return `${prefix}-${randomUUID()}@example.com`;
+}
 
 describe('Auth API', () => {
-  const createTestAgent = () => {
-    const app = createApp({ jwtSecret: 'test-secret', userStore: new InMemoryUserStore() });
-    return request(app);
-  };
+  let agent: SuperTest<Test>;
+  let userStore: InMemoryUserStore;
 
-  it('registers a user and returns a token', async () => {
-    const agent = createTestAgent();
+  beforeEach(() => {
+    const context = createTestAgent();
+    agent = context.agent;
+    userStore = context.userStore;
+  });
 
-    const response = await agent
+  afterEach(async () => {
+    await userStore.clear();
+  });
+
+  const register = async (email = uniqueEmail('user'), password = defaultPassword) =>
+    agent
       .post('/api/taskforge/v1/auth/register')
-      .send({ email: 'new-user@example.com', password: 'Secret123!' })
+      .send({ email, password })
       .expect(201);
+
+  it('registers a user, returns tokens, and issues a session cookie', async () => {
+    const response = await register();
 
     expect(response.body).toEqual(
       expect.objectContaining({
-        user: expect.objectContaining({ email: 'new-user@example.com' }),
+        user: expect.objectContaining({ email: expect.stringContaining('@example.com') }),
         tokens: expect.objectContaining({
           accessToken: expect.any(String),
           refreshToken: expect.any(String),
@@ -29,40 +46,46 @@ describe('Auth API', () => {
         }),
       }),
     );
+    expect(response.headers['set-cookie']).toEqual(
+      expect.arrayContaining([expect.stringContaining('tf_session=')]),
+    );
+  });
+
+  it('rejects invalid registration payloads', async () => {
+    const invalid = await agent
+      .post('/api/taskforge/v1/auth/register')
+      .send({ email: 'not-an-email', password: 'short' })
+      .expect(400);
+
+    expect(invalid.body).toEqual(
+      expect.objectContaining({ error: 'Invalid payload' }),
+    );
   });
 
   it('prevents duplicate registrations', async () => {
-    const agent = createTestAgent();
-
-    await agent
-      .post('/api/taskforge/v1/auth/register')
-      .send({ email: 'dupe@example.com', password: 'Secret123!' })
-      .expect(201);
+    const email = uniqueEmail('dupe');
+    await register(email);
 
     const duplicate = await agent
       .post('/api/taskforge/v1/auth/register')
-      .send({ email: 'dupe@example.com', password: 'Secret123!' })
+      .send({ email, password: defaultPassword })
       .expect(409);
 
     expect(duplicate.body).toEqual(expect.objectContaining({ error: 'User already exists' }));
   });
 
-  it('logs in an existing user and returns a new token', async () => {
-    const agent = createTestAgent();
-
-    await agent
-      .post('/api/taskforge/v1/auth/register')
-      .send({ email: 'login@example.com', password: 'Secret123!' })
-      .expect(201);
+  it('logs in an existing user and returns a new token set', async () => {
+    const email = uniqueEmail('login');
+    await register(email);
 
     const login = await agent
       .post('/api/taskforge/v1/auth/login')
-      .send({ email: 'login@example.com', password: 'Secret123!' })
+      .send({ email, password: defaultPassword })
       .expect(200);
 
     expect(login.body).toEqual(
       expect.objectContaining({
-        user: expect.objectContaining({ email: 'login@example.com' }),
+        user: expect.objectContaining({ email }),
         tokens: expect.objectContaining({
           accessToken: expect.any(String),
           refreshToken: expect.any(String),
@@ -72,27 +95,26 @@ describe('Auth API', () => {
     );
   });
 
-  it('rejects invalid login attempts', async () => {
-    const agent = createTestAgent();
-
+  it('rejects login attempts for unknown users', async () => {
     await agent
-      .post('/api/taskforge/v1/auth/register')
-      .send({ email: 'invalid@example.com', password: 'Secret123!' })
-      .expect(201);
+      .post('/api/taskforge/v1/auth/login')
+      .send({ email: uniqueEmail('missing'), password: defaultPassword })
+      .expect(401);
+  });
+
+  it('rejects invalid login attempts', async () => {
+    const email = uniqueEmail('invalid');
+    await register(email);
 
     await agent
       .post('/api/taskforge/v1/auth/login')
-      .send({ email: 'invalid@example.com', password: 'WrongPassword1' })
+      .send({ email, password: 'WrongPassword1' })
       .expect(401);
   });
 
   it('returns the authenticated user for /auth/me', async () => {
-    const agent = createTestAgent();
-
-    const { body } = await agent
-      .post('/api/taskforge/v1/auth/register')
-      .send({ email: 'profile@example.com', password: 'Secret123!' })
-      .expect(201);
+    const email = uniqueEmail('profile');
+    const { body } = await register(email);
 
     const profile = await agent
       .get('/api/taskforge/v1/auth/me')
@@ -101,16 +123,48 @@ describe('Auth API', () => {
 
     expect(profile.body).toEqual(
       expect.objectContaining({
-        user: expect.objectContaining({ email: 'profile@example.com' }),
+        user: expect.objectContaining({ email }),
       }),
     );
   });
 
+  it('allows access to tasks when authenticated', async () => {
+    const { body } = await register();
+
+    const tasks = await agent
+      .get('/api/taskforge/v1/tasks')
+      .set('Authorization', `Bearer ${body.tokens.accessToken}`)
+      .expect(200);
+
+    expect(tasks.body).toEqual(expect.objectContaining({ items: expect.any(Array) }));
+  });
+
   it('rejects protected requests without a token', async () => {
-    const agent = createTestAgent();
-
     await agent.get('/api/taskforge/v1/auth/me').expect(401);
-
     await agent.get('/api/taskforge/v1/tasks').expect(401);
+  });
+
+  it('rejects protected requests with a malformed token', async () => {
+    const { body } = await register();
+    const invalidToken = `${body.tokens.accessToken}tampered`;
+
+    await agent
+      .get('/api/taskforge/v1/auth/me')
+      .set('Authorization', `Bearer ${invalidToken}`)
+      .expect(401);
+  });
+
+  it('logs out the user and clears the session cookie', async () => {
+    const { body } = await register();
+
+    const logout = await agent
+      .post('/api/taskforge/v1/auth/logout')
+      .set('Authorization', `Bearer ${body.tokens.accessToken}`)
+      .expect(200);
+
+    expect(logout.body).toEqual({ success: true });
+    expect(logout.headers['set-cookie']).toEqual(
+      expect.arrayContaining([expect.stringContaining('tf_session=;')]),
+    );
   });
 });

--- a/apps/api/tests/auth.http
+++ b/apps/api/tests/auth.http
@@ -1,25 +1,106 @@
 ### Register a new user
+# @name register
 POST http://localhost:4000/api/taskforge/v1/auth/register
 Content-Type: application/json
 
 {
-  "email": "demo@example.com",
+  "email": "smoke-{{$timestamp}}@example.com",
   "password": "Secret123!"
 }
 
+> {%
+client.test('register returns tokens', () => {
+  client.assert(response.status === 201, 'expected 201 Created');
+  client.assert(response.body.user.email.includes('@example.com'), 'email is echoed back');
+  client.assert(response.body.tokens.accessToken, 'access token is present');
+  client.assert(response.body.tokens.refreshToken, 'refresh token is present');
+  client.global.set('accessToken', response.body.tokens.accessToken);
+  client.global.set('smokeEmail', response.body.user.email);
+  client.global.set('smokePassword', 'Secret123!');
+});
+%}
+
 ### Login with existing user
+# @name login
 POST http://localhost:4000/api/taskforge/v1/auth/login
 Content-Type: application/json
 
 {
-  "email": "demo@example.com",
-  "password": "Secret123!"
+  "email": "{{smokeEmail}}",
+  "password": "{{smokePassword}}"
 }
 
+> {%
+client.test('login succeeds and refreshes tokens', () => {
+  client.assert(response.status === 200, 'expected 200 OK');
+  client.assert(response.body.tokens.accessToken, 'access token is present');
+  client.assert(response.body.tokens.refreshToken, 'refresh token is present');
+  client.global.set('accessToken', response.body.tokens.accessToken);
+});
+%}
+
+### Login with wrong password should fail
+# @name loginFailure
+POST http://localhost:4000/api/taskforge/v1/auth/login
+Content-Type: application/json
+
+{
+  "email": "{{smokeEmail}}",
+  "password": "WrongPassword1"
+}
+
+> {%
+client.test('login fails with 401', () => {
+  client.assert(response.status === 401, 'expected 401 Unauthorized');
+  client.assert(response.body.error === 'Invalid credentials', 'invalid credentials error message');
+});
+%}
+
 ### Fetch current user with token
+# @name me
 GET http://localhost:4000/api/taskforge/v1/auth/me
 Authorization: Bearer {{accessToken}}
 
+> {%
+client.test('me endpoint returns authenticated user', () => {
+  client.assert(response.status === 200, 'expected 200 OK');
+  client.assert(response.body.user.email === client.global.get('smokeEmail'), 'returned email matches login');
+});
+%}
+
 ### Logout (requires token)
+# @name logout
 POST http://localhost:4000/api/taskforge/v1/auth/logout
 Authorization: Bearer {{accessToken}}
+
+> {%
+client.test('logout clears session cookie', () => {
+  client.assert(response.status === 200, 'expected 200 OK');
+  const cookies = response.headers['set-cookie'];
+  client.assert(Array.isArray(cookies) && cookies.some(cookie => cookie.includes('tf_session=')), 'session cookie is returned');
+  client.assert(cookies.some(cookie => cookie.includes('tf_session=;')), 'session cookie is cleared');
+});
+%}
+
+### Access protected tasks endpoint with token
+# @name tasks
+GET http://localhost:4000/api/taskforge/v1/tasks
+Authorization: Bearer {{accessToken}}
+
+> {%
+client.test('tasks endpoint responds for authenticated user', () => {
+  client.assert(response.status === 200, 'expected 200 OK');
+  client.assert(Array.isArray(response.body.items), 'returns items array');
+});
+%}
+
+### Access protected tasks endpoint without token should fail
+# @name tasksUnauthorized
+GET http://localhost:4000/api/taskforge/v1/tasks
+
+> {%
+client.test('tasks endpoint rejects unauthenticated user', () => {
+  client.assert(response.status === 401, 'expected 401 Unauthorized');
+  client.assert(response.body.error === 'Unauthorized', 'unauthorized error message');
+});
+%}

--- a/apps/api/tests/utils/test-app.ts
+++ b/apps/api/tests/utils/test-app.ts
@@ -1,0 +1,24 @@
+import request, { type SuperTest, type Test } from 'supertest';
+
+import { InMemoryUserStore } from '../../src/auth/user-store';
+import { createApp } from '../../src/app';
+
+export interface TestAgentContext {
+  agent: SuperTest<Test>;
+  userStore: InMemoryUserStore;
+}
+
+export interface CreateTestAgentOptions {
+  jwtSecret?: string;
+  userStore?: InMemoryUserStore;
+}
+
+export function createTestAgent(
+  options: CreateTestAgentOptions = {},
+): TestAgentContext {
+  const userStore = options.userStore ?? new InMemoryUserStore();
+  const jwtSecret = options.jwtSecret ?? 'test-secret';
+  const app = createApp({ jwtSecret, userStore });
+
+  return { agent: request(app), userStore };
+}


### PR DESCRIPTION
## Summary
- add a reusable Supertest helper to spin up the API with an isolated user store
- expand auth end-to-end tests to cover success and failure cases, including logout and protected routes
- enrich the REST client smoke collection with assertions for token handling and unauthorized access

## Testing
- pnpm -C apps/api test

------