### PR TITLE
feat: add google oauth linking to auth flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ taskforge/
    GOOGLE_SECRET=<google-oauth-client-secret>
    ```
    Leaving these blank keeps the login screen in a safe “No providers configured” state for development demos.
+   - **Google Cloud setup**
+     1. Create an OAuth consent screen (External) in [Google Cloud Console](https://console.cloud.google.com/apis/credentials).
+     2. Add an OAuth 2.0 Client ID (Web application) with authorized origins `http://localhost:3000` and redirect URI `http://localhost:3000/api/auth/callback/google` for local dev.
+     3. Copy the generated **Client ID** and **Client Secret** into the environment variables above. Restart the Next.js server so NextAuth picks up the provider.
+     4. In production, repeat with your deployed domains and update the allowed origins/redirects to match.
+   - Accounts created through Google reuse existing credential users when the email matches, so users can link social login after registering with a password.
 3. **Run Prisma migrations** – make sure the shared database has the auth tables NextAuth expects:
    ```bash
    pnpm -C apps/api prisma migrate deploy

--- a/apps/web/lib/auth-config.ts
+++ b/apps/web/lib/auth-config.ts
@@ -235,45 +235,30 @@ export const authConfig = {
       }
 
       const emailVerifiedRaw = typedProfile.email_verified;
-      let isEmailVerified = false;
+      const emailVerified =
+        typeof emailVerifiedRaw === 'boolean'
+          ? emailVerifiedRaw
+          : typeof emailVerifiedRaw === 'string'
+            ? emailVerifiedRaw.toLowerCase() === 'true'
+            : null;
 
       if (account.provider === 'google') {
-        const emailVerified =
-          typeof emailVerifiedRaw === 'boolean'
-            ? emailVerifiedRaw
-            : typeof emailVerifiedRaw === 'string'
-              ? emailVerifiedRaw.toLowerCase() === 'true'
-              : true;
-
-        if (!emailVerified) {
+        if (emailVerified !== true) {
           console.warn('[auth] Google sign-in rejected due to unverified email', {
             email: normalizedEmail,
           });
           return false;
         }
-
-        isEmailVerified = true;
-      } else {
-        const emailVerified =
-          typeof emailVerifiedRaw === 'boolean'
-            ? emailVerifiedRaw
-            : typeof emailVerifiedRaw === 'string'
-              ? emailVerifiedRaw.toLowerCase() === 'true'
-              : null;
-
-        if (emailVerified !== true) {
-          console.warn('[auth] OAuth sign-in rejected due to unverifiable email', {
-            provider: account.provider,
-            email: normalizedEmail,
-          });
-          return false;
-        }
-
-        isEmailVerified = true;
+      } else if (emailVerified === false) {
+        console.warn('[auth] OAuth sign-in rejected due to explicitly unverified email', {
+          provider: account.provider,
+          email: normalizedEmail,
+        });
+        return false;
       }
 
       user.email = normalizedEmail;
-      user.emailVerified = isEmailVerified ? new Date() : null;
+      user.emailVerified = emailVerified ? new Date() : null;
 
       return true;
     },

--- a/apps/web/lib/auth-config.ts
+++ b/apps/web/lib/auth-config.ts
@@ -92,6 +92,39 @@ function mapAccountToPrisma(account: AdapterAccount) {
 async function ensureAccountLink(account: AdapterAccount) {
   const data = mapAccountToPrisma(account);
 
+  const update: Parameters<typeof prisma.account.upsert>[0]['update'] = {
+    userId: data.userId,
+    type: data.type,
+  };
+
+  if (typeof account.refresh_token !== 'undefined') {
+    update.refreshToken = data.refreshToken;
+  }
+
+  if (typeof account.access_token !== 'undefined') {
+    update.accessToken = data.accessToken;
+  }
+
+  if (typeof account.expires_at !== 'undefined') {
+    update.expiresAt = data.expiresAt;
+  }
+
+  if (typeof account.token_type !== 'undefined') {
+    update.tokenType = data.tokenType;
+  }
+
+  if (typeof account.scope !== 'undefined') {
+    update.scope = data.scope;
+  }
+
+  if (typeof account.id_token !== 'undefined') {
+    update.idToken = data.idToken;
+  }
+
+  if (typeof account.session_state !== 'undefined') {
+    update.sessionState = data.sessionState;
+  }
+
   return prisma.account.upsert({
     where: {
       provider_providerAccountId: {
@@ -100,17 +133,7 @@ async function ensureAccountLink(account: AdapterAccount) {
       },
     },
     create: data,
-    update: {
-      userId: data.userId,
-      type: data.type,
-      refreshToken: data.refreshToken,
-      accessToken: data.accessToken,
-      expiresAt: data.expiresAt,
-      tokenType: data.tokenType,
-      scope: data.scope,
-      idToken: data.idToken,
-      sessionState: data.sessionState,
-    },
+    update,
   });
 }
 

--- a/apps/web/lib/auth-config.ts
+++ b/apps/web/lib/auth-config.ts
@@ -1,6 +1,8 @@
 import 'server-only';
 
-import type { NextAuthConfig } from 'next-auth';
+import type { Account, NextAuthConfig, Session } from 'next-auth';
+import type { Adapter, AdapterAccount, AdapterUser } from 'next-auth/adapters';
+import type { JWT } from 'next-auth/jwt';
 import { PrismaAdapter } from '@auth/prisma-adapter';
 import Credentials from 'next-auth/providers/credentials';
 import GitHub from 'next-auth/providers/github';
@@ -61,8 +63,139 @@ const providers =
 
 const prisma = getPrismaClient();
 
+function normalizeEmail(value: string | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+
+  return value.trim().toLowerCase();
+}
+
+function mapAccountToPrisma(account: AdapterAccount) {
+  const expiresAt = typeof account.expires_at === 'number' ? Math.floor(account.expires_at) : null;
+
+  return {
+    userId: account.userId,
+    type: account.type,
+    provider: account.provider,
+    providerAccountId: account.providerAccountId,
+    refreshToken: account.refresh_token ?? null,
+    accessToken: account.access_token ?? null,
+    expiresAt,
+    tokenType: account.token_type ?? null,
+    scope: account.scope ?? null,
+    idToken: account.id_token ?? null,
+    sessionState: account.session_state ?? null,
+  };
+}
+
+async function ensureAccountLink(account: AdapterAccount) {
+  const data = mapAccountToPrisma(account);
+
+  return prisma.account.upsert({
+    where: {
+      provider_providerAccountId: {
+        provider: data.provider,
+        providerAccountId: data.providerAccountId,
+      },
+    },
+    create: data,
+    update: {
+      userId: data.userId,
+      type: data.type,
+      refreshToken: data.refreshToken,
+      accessToken: data.accessToken,
+      expiresAt: data.expiresAt,
+      tokenType: data.tokenType,
+      scope: data.scope,
+      idToken: data.idToken,
+      sessionState: data.sessionState,
+    },
+  });
+}
+
+async function resolveUserForOAuth(user: AdapterUser) {
+  const normalizedEmail = normalizeEmail(user.email ?? null);
+
+  if (!normalizedEmail) {
+    return null;
+  }
+
+  const existingUser = await prisma.user.findUnique({ where: { email: normalizedEmail } });
+
+  if (!existingUser) {
+    return null;
+  }
+
+  const updates: {
+    name?: string;
+    image?: string;
+    emailVerified?: Date | null;
+  } = {};
+
+  if (user.name && !existingUser.name) {
+    updates.name = user.name;
+  }
+
+  if (user.image && !existingUser.image) {
+    updates.image = user.image;
+  }
+
+  if (user.emailVerified && !existingUser.emailVerified) {
+    updates.emailVerified = user.emailVerified;
+  }
+
+  if (Object.keys(updates).length > 0) {
+    const updated = await prisma.user.update({
+      where: { id: existingUser.id },
+      data: updates,
+    });
+
+    return updated;
+  }
+
+  return existingUser;
+}
+
+const baseAdapter = PrismaAdapter(prisma);
+
+const adapter: Adapter = {
+  ...baseAdapter,
+  async createUser(user: AdapterUser) {
+    const resolved = await resolveUserForOAuth(user);
+
+    if (resolved) {
+      console.info('[auth] Reusing existing user for OAuth sign-in', {
+        userId: resolved.id,
+        email: resolved.email,
+      });
+
+      return resolved;
+    }
+
+    const normalizedEmail = normalizeEmail(user.email ?? null);
+    const payload: AdapterUser = normalizedEmail ? { ...user, email: normalizedEmail } : user;
+
+    if (!baseAdapter.createUser) {
+      throw new Error('Prisma adapter does not implement createUser');
+    }
+
+    return baseAdapter.createUser(payload);
+  },
+  async linkAccount(account: AdapterAccount) {
+    const linked = await ensureAccountLink(account);
+
+    console.info('[auth] OAuth account linked', {
+      userId: linked.userId,
+      provider: linked.provider,
+    });
+
+    return linked;
+  },
+};
+
 export const authConfig = {
-  adapter: PrismaAdapter(prisma),
+  adapter,
   providers,
   pages: {
     signIn: '/login',
@@ -73,7 +206,56 @@ export const authConfig = {
   secret: process.env.NEXTAUTH_SECRET,
   trustHost: true,
   callbacks: {
-    async jwt({ token, user }) {
+    async signIn({
+      user,
+      account,
+      profile,
+    }: {
+      user: AdapterUser;
+      account: Account | null;
+      profile?: Record<string, unknown> | null;
+    }) {
+      if (!account || account.type !== 'oauth') {
+        return true;
+      }
+
+      const typedProfile = (profile ?? {}) as {
+        email?: unknown;
+        email_verified?: unknown;
+      };
+
+      const profileEmail = typeof typedProfile.email === 'string' ? typedProfile.email : null;
+      const normalizedEmail = normalizeEmail(user?.email ?? profileEmail);
+
+      if (!normalizedEmail) {
+        console.warn('[auth] OAuth sign-in missing email', {
+          provider: account.provider,
+        });
+        return false;
+      }
+
+      if (account.provider === 'google') {
+        const emailVerifiedRaw = typedProfile.email_verified;
+        const emailVerified =
+          typeof emailVerifiedRaw === 'boolean'
+            ? emailVerifiedRaw
+            : typeof emailVerifiedRaw === 'string'
+              ? emailVerifiedRaw.toLowerCase() === 'true'
+              : true;
+
+        if (!emailVerified) {
+          console.warn('[auth] Google sign-in rejected due to unverified email', {
+            email: normalizedEmail,
+          });
+          return false;
+        }
+      }
+
+      user.email = normalizedEmail;
+
+      return true;
+    },
+    async jwt({ token, user }: { token: JWT; user?: AdapterUser | null }) {
       if (user?.id) {
         token.sub = user.id;
         console.info('[auth] JWT callback user matched', {
@@ -83,7 +265,15 @@ export const authConfig = {
 
       return token;
     },
-    async session({ session, user, token }) {
+    async session({
+      session,
+      user,
+      token,
+    }: {
+      session: Session;
+      user?: AdapterUser | null;
+      token: JWT;
+    }) {
       let resolvedUserId = user?.id ?? token?.sub ?? session.user?.id;
 
       if (!resolvedUserId && session.user?.email) {
@@ -107,13 +297,19 @@ export const authConfig = {
     },
   },
   events: {
-    async signIn({ user, isNewUser }) {
+    async signIn({
+      user,
+      isNewUser,
+    }: {
+      user: AdapterUser;
+      isNewUser?: boolean;
+    }) {
       console.info('[auth] Sign-in completed', {
         userId: user.id,
         isNewUser,
       });
     },
-    async linkAccount({ user }) {
+    async linkAccount({ user }: { user: AdapterUser }) {
       console.info('[auth] Account linked for user', user.id);
     },
   },


### PR DESCRIPTION
## Summary
- extend the NextAuth Prisma adapter to reuse existing credential users and upsert OAuth accounts safely
- normalize OAuth email handling, enforce Google email verification, and expose provider configuration only when credentials exist
- document Google Cloud setup steps so GOOGLE_ID/GOOGLE_SECRET can be provisioned for social sign-in

## Testing
- pnpm -C apps/web lint
- pnpm -C apps/web typecheck *(fails: local TypeScript configuration cannot resolve workspace module declarations)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69125382655083228087f655fff085cb)