### PR TITLE
docs: refresh auth documentation

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -11,7 +11,8 @@
 - Deployed FE/BE/DB on free tiers. OAuth login, CRUD tasks (tags + due dates), Kanban, filters/search, basic email digest, Swagger at `/api/taskforge/docs`, 10–20 tests, `.http` suite, Docker + CI, README + ADRs.
 
 ## Scope
-- Auth: NextAuth (GitHub/Google), optional credentials.
+- Auth: NextAuth (GitHub/Google) backed by Prisma, credential login against the API, and a session bridge that exchanges
+  NextAuth sessions for API `tf_session` cookies via `SESSION_BRIDGE_SECRET`.
 - Tasks: title, description (MD), status, priority, **tags**, **dueDate**.
 - Kanban: DnD with optimistic UI.
 - Filters/search: tag/status/due range/text.
@@ -24,8 +25,10 @@
 - Multi-tenant orgs, role assignment, real-time, advanced analytics.
 
 ## Architecture
-- FE: Next.js App Router (TS), NextAuth, calls API with bearer.
-- BE: Express (TS), Zod validation, Prisma (Postgres), Swagger.
+- FE: Next.js App Router (TS) with NextAuth database sessions, OAuth providers, and a server-side session bridge that mints
+  API cookies before rendering protected routes.
+- BE: Express (TS), Zod validation, Prisma (Postgres), Swagger. Auth router issues JWT access/refresh pairs, maintains
+  `tf_session` HttpOnly cookies, and exposes a `session-bridge` endpoint for trusted frontends.
 - DB: Neon/Supabase Postgres; Prisma migrations + seed.
 - Email: Nodemailer; dev via MailHog.
 - Infra: Dockerfiles + docker-compose; CI with GitHub Actions.
@@ -86,7 +89,7 @@ enum TaskPriority { LOW MEDIUM HIGH }
 - Docs: `GET /api/taskforge/docs`
 
 ## ADR Summary
-- Auth: NextAuth + backend JWT verification.
+- Auth: NextAuth + backend JWT verification with dedicated session bridge and shared Prisma adapter.
 - Backend: Express TS + Zod + Swagger.
 - DB: Postgres (Neon/Supabase) + Prisma.
 - Email: Nodemailer adapter; MailHog dev; free SMTP prod.
@@ -94,13 +97,42 @@ enum TaskPriority { LOW MEDIUM HIGH }
 
 ## Milestones (7 days)
 - **Day 1:** Monorepo setup, Tailwind + shadcn/ui, Express + Prisma scaffold, Dockerfiles, compose, CI skeleton.
-- **Day 2:** Frontend OAuth (GitHub/Google) with NextAuth, guarded routes, session UI. `/me` endpoint + JWT bridge lands later.
+- **Day 2:** Frontend OAuth (GitHub/Google) with NextAuth, guarded routes, session UI, and the `/auth/session-bridge` flow to mint API cookies.
 - **Day 3:** `/tasks` CRUD + Zod + tests; FE list + dialogs; OpenAPI draft.
 - **Day 4:** Kanban DnD, `/tags`, optimistic UI, `.http` pack.
 - **Day 5:** Search, due filters, priority; email digest (node-cron + Nodemailer).
 - **Day 6:** Helmet/CORS/rate-limit; finalize Swagger; ADRs + README; CI docker build.
 - **Day 7:** Provision Neon/Supabase; deploy API (Render/Railway) + Web (Vercel); smoke test; v1 release.
 
-### Auth Status (Day 2)
-- [Done] Web: NextAuth route at /api/auth/[...nextauth], SessionProvider + useAuth hook, custom /login + /register, protected layout redirects, and Prisma auth models/seed in place.
-- [Open] API /auth/* responses must return JWTs, OAuth logins need Prisma-backed session bridging to issue tf_session, docs require updates, Docker/CI smoke tests are missing, and the UI still needs credential forms plus dashboard data.
+## Authentication Experience
+- Users can authenticate with GitHub or Google through NextAuth (Auth.js) using the Prisma adapter to reuse shared user records. Verified OAuth logins trigger the server-side session bridge to call `/api/taskforge/v1/auth/session-bridge`, which returns JWTs and sets the API-managed `tf_session` cookie so backend routes trust the request.
+- Email/password login remains available via `/api/taskforge/v1/auth/login`. The Next.js login form posts to the API, receives validation errors, and relies on the `tf_session` cookie for subsequent navigation without duplicating NextAuth.
+- Authenticated layouts call `getCurrentUser()` server-side. If the NextAuth session exists it is used; otherwise the layout resolves the API user from the `tf_session` cookie and, when needed, exchanges it for a fresh token using the session bridge helper.
+- Signing out from the web app clears both the NextAuth session and the API cookie through the `/api/auth/logout` Next.js route, which invokes the API logout endpoint and expires `tf_session` on the server.
+
+### Auth Lifecycle Diagram
+```mermaid
+sequenceDiagram
+    participant Browser
+    participant NextAuth as Next.js (NextAuth)
+    participant API as Express API
+    participant DB as Prisma/Postgres
+
+    Browser->>NextAuth: OAuth callback (GitHub/Google)
+    NextAuth->>DB: Link/update user via Prisma adapter
+    NextAuth-->>Browser: NextAuth session cookie
+    NextAuth->>API: POST /auth/session-bridge (user id/email, secret)
+    API->>DB: Lookup user, issue JWTs
+    API-->>Browser: Set tf_session HttpOnly cookie
+    Browser->>API: Authenticated request with tf_session
+    API-->>Browser: Protected data
+
+    Browser->>API: POST /auth/login (credentials)
+    API->>DB: Verify password
+    API-->>Browser: Set tf_session HttpOnly cookie
+```
+
+## Auth Decisions & Deviations
+- **Session bridge implemented earlier than planned:** The original milestone assumed the JWT bridge would land after initial OAuth wiring. In practice, the bridge was required to make protected routes render reliably in Docker and to share auth between OAuth and credential logins, so `/auth/session-bridge` shipped alongside the OAuth integration.
+- **Database-backed NextAuth sessions:** Instead of the default JWT session mode we keep the Prisma adapter’s session table so OAuth and credentials reuse the same user IDs that the API expects, avoiding mismatched subject claims.
+- **Shared sign-out path:** A dedicated Next.js `/api/auth/logout` route coordinates clearing both the NextAuth session and the API cookie to prevent stale `tf_session` values after OAuth sign-out.

--- a/docs/adr/0001-auth-strategy-nextauth-+-backend-jwt.md
+++ b/docs/adr/0001-auth-strategy-nextauth-+-backend-jwt.md
@@ -1,14 +1,33 @@
 # ADR 0001 — Auth Strategy (NextAuth + backend JWT)
 
-**Status:** Accepted
+**Status:** Accepted — updated after NextAuth/Next.js ↔ API bridge landed
 
 ## Context
-We need OAuth (GitHub/Google) on FE with minimal friction and a way for the API to trust requests.
+- The web app must offer GitHub and Google OAuth alongside email/password login without duplicating identity stores.
+- Backend APIs expect JWT Bearer tokens (surfaced as the HttpOnly `tf_session` cookie) to authorize requests and must
+  continue to work for direct credential logins from the web forms and scripted clients.
+- Docker deployments exposed cross-origin concerns that required a deterministic way for the Next.js app to obtain API
+  cookies after OAuth hand-offs.
 
 ## Decision
-Use **NextAuth (Auth.js)** in the Next.js app for OAuth, store session securely, and forward a **Bearer JWT** to the API on requests. API validates JWT with shared secret.
+- Continue using **NextAuth (Auth.js)** with the Prisma adapter so OAuth and credential users share the same user IDs that
+  the API encodes inside JWTs.
+- Keep NextAuth in **database session** mode; the adapter updates the shared `User`, `Account`, and `Session` tables and
+  normalizes OAuth email casing/verification before issuing sessions.
+- Introduce a trusted **session bridge**: the Next.js server exchanges the signed-in NextAuth user for API tokens by
+  calling `POST /api/taskforge/v1/auth/session-bridge` with a shared `SESSION_BRIDGE_SECRET`. The API reuses its token
+  service to mint access/refresh tokens, sets the `tf_session` HttpOnly cookie, and returns the payload for observability.
+- Preserve the existing `/api/taskforge/v1/auth/login` credential flow. The Next.js login form posts directly to the API
+  and depends on the same cookie path, keeping parity with CLI and integration tests.
+- Coordinate sign-out through the App Router endpoint `/api/auth/logout`, which calls the API logout route and expires
+  both cookies, ensuring OAuth and JWT sessions terminate together.
 
 ## Consequences
-- Easy provider setup, free/open-source.
-- Clear separation FE session vs. API auth.
-- Requires key management (NEXTAUTH_SECRET, JWT_SECRET).
+- ✅ **Unified identity:** A single user record spans OAuth and credentials, preventing mismatched `sub` claims between
+  NextAuth and API tokens.
+- ✅ **Portable session bridge:** Protected routes work in dev, Docker, and production by reissuing API cookies on demand
+  without leaking API secrets to the browser.
+- ⚠️ **Secret management:** Operations must distribute `NEXTAUTH_SECRET`, `JWT_SECRET`, and `SESSION_BRIDGE_SECRET` to
+  both apps and rotate them together.
+- ⚠️ **Bridge availability:** If the API is down during OAuth callback, the Next.js app must handle bridge failures and
+  prompt users to retry (implemented via session-bridge route guards).


### PR DESCRIPTION
## Summary
- update the PRD auth scope, architecture, and lifecycle details to match the implemented session bridge and sign-in flows
- refresh ADR 0001 with context and decisions covering the NextAuth Prisma adapter, session bridge, and coordinated logout

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912c6fcc3d08322b31f1d9f73e2ca52)