### PR TITLE
Update CI pipeline for auth coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,29 @@ on:
 jobs:
   build-test:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: taskforge
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d taskforge"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/taskforge?schema=public
+      JWT_SECRET: ${{ secrets.CI_JWT_SECRET || 'test-jwt-secret' }}
+      JWT_REFRESH_SECRET: ${{ secrets.CI_JWT_REFRESH_SECRET || 'test-jwt-refresh-secret' }}
+      SESSION_BRIDGE_SECRET: ${{ secrets.CI_SESSION_BRIDGE_SECRET || 'test-bridge-secret' }}
+      NEXTAUTH_SECRET: ${{ secrets.CI_NEXTAUTH_SECRET || 'test-nextauth-secret' }}
+      NEXTAUTH_URL: http://localhost:3000
+      API_BASE_URL: http://localhost:4000/api/taskforge
+      NEXT_PUBLIC_API_BASE_URL: http://localhost:4000/api/taskforge
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -15,8 +38,16 @@ jobs:
         with:
           node-version: 20
           cache: 'pnpm'
-      - run: pnpm install
-      - run: make lint || true
-      - run: make typecheck || true
-      - run: make test
+      - run: pnpm install --frozen-lockfile
+      - name: Generate Prisma client
+        run: pnpm --filter @taskforge/api exec prisma generate
+      - name: Apply database migrations
+        run: pnpm --filter @taskforge/api exec prisma migrate deploy
+      - run: make lint
+      - run: make typecheck
+      - name: Run API tests
+        run: pnpm -C apps/api test
+      - name: Run frontend tests
+        working-directory: apps/web
+        run: pnpm test --if-present
       - run: make build

--- a/README.md
+++ b/README.md
@@ -125,6 +125,14 @@ Running the seed multiple times is safe—it upserts the user and respects `SEED
 
 Screenshots of the login flow and protected dashboard live in the design references inside the PRD and ADR linked above. Capture fresh UI snapshots for release notes or marketing updates as needed.
 
+## Continuous Integration
+- The GitHub Actions workflow (`.github/workflows/ci.yml`) provisions a PostgreSQL service, runs `prisma generate`, and applies
+  migrations via `prisma migrate deploy` before executing the auth-focused Jest suite in `apps/api`.
+- Frontend auth tests should be exposed through `pnpm test` in `apps/web`; the CI job runs that script automatically when it is
+  present so browser coverage can gate merges alongside the API checks.
+- Configure repository secrets (`CI_JWT_SECRET`, `CI_JWT_REFRESH_SECRET`, `CI_SESSION_BRIDGE_SECRET`, `CI_NEXTAUTH_SECRET`) to
+  override the CI-safe defaults used in the workflow when running against staging infrastructure.
+
 ### Accessing session state in code
 - Server components read the active session via `getCurrentUser()` (`apps/web/lib/server-auth.ts`).
 - Client components use `useAuth()` (`apps/web/lib/use-auth.ts`), a thin wrapper around `next-auth/react`’s `useSession()` hook.


### PR DESCRIPTION
## Summary
- provision a PostgreSQL service in CI and run Prisma generate/migrate before the auth suite
- execute the API auth tests along with any frontend auth tests exposed by apps/web
- document the new CI expectations and secret overrides in the README

