### PR TITLE
Harden auth configuration and add refresh endpoint

### DIFF
--- a/apps/api/jest.config.ts
+++ b/apps/api/jest.config.ts
@@ -6,6 +6,7 @@ const config: Config = {
   roots: ['<rootDir>/tests'],
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
+    '@taskforge/shared': '<rootDir>/../../packages/shared/src',
   },
   setupFilesAfterEnv: ['<rootDir>/tests/setup.ts'],
   transform: {

--- a/apps/api/src/auth/token.ts
+++ b/apps/api/src/auth/token.ts
@@ -63,19 +63,11 @@ export function createTokenService(options: TokenServiceOptions): TokenService {
         tokenType: 'Bearer',
       };
     },
-    verifyAccessToken(token) {
-      try {
-        return Promise.resolve(verifyToken(token, options.accessSecret));
-      } catch (error) {
-        return Promise.reject(error);
-      }
+    async verifyAccessToken(token) {
+      return verifyToken(token, options.accessSecret);
     },
-    verifyRefreshToken(token) {
-      try {
-        return Promise.resolve(verifyToken(token, refreshSecret));
-      } catch (error) {
-        return Promise.reject(error);
-      }
+    async verifyRefreshToken(token) {
+      return verifyToken(token, refreshSecret);
     },
   };
 }

--- a/apps/api/src/auth/user-store.ts
+++ b/apps/api/src/auth/user-store.ts
@@ -40,11 +40,6 @@ export class InMemoryUserStore implements UserStore {
   }
 }
 
-/* eslint-disable
-  @typescript-eslint/no-unsafe-assignment,
-  @typescript-eslint/no-unsafe-call,
-  @typescript-eslint/no-unsafe-member-access
-*/
 export class PrismaUserStore implements UserStore {
   constructor(private readonly prisma: PrismaClient) {}
 
@@ -85,10 +80,4 @@ export class PrismaUserStore implements UserStore {
     };
   }
 }
-/* eslint-enable
-  @typescript-eslint/no-unsafe-assignment,
-  @typescript-eslint/no-unsafe-call,
-  @typescript-eslint/no-unsafe-member-access
-*/
-
 type PrismaUserRecord = NonNullable<Awaited<ReturnType<PrismaClient['user']['findUnique']>>>;

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -1,5 +1,7 @@
 import type { Request, Response, NextFunction } from 'express';
 
+import { getSessionCookieName } from '@taskforge/shared';
+
 import type { TokenService } from '../auth/token';
 import type { UserStore } from '../auth/user-store';
 
@@ -9,9 +11,10 @@ export interface AuthMiddlewareOptions {
 }
 
 export function createAuthMiddleware({ tokenService, userStore }: AuthMiddlewareOptions) {
+  const sessionCookieName = getSessionCookieName();
   return async function authMiddleware(req: Request, res: Response, next: NextFunction) {
     // Try to get token from HttpOnly cookie first, then fallback to Authorization header
-    let token = req.cookies?.tf_session;
+    let token = req.cookies?.[sessionCookieName];
     
     if (!token) {
       const header = req.headers.authorization;

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -1,7 +1,10 @@
 import { randomUUID } from 'node:crypto';
 
 import { Router } from 'express';
+import rateLimit from 'express-rate-limit';
 import { z } from 'zod';
+
+import { getSessionCookieName, resolveCookieDomain } from '@taskforge/shared';
 
 import { createPasswordHasher, PasswordHasher } from '../auth/password';
 import { createTokenService, TokenService } from '../auth/token';
@@ -19,39 +22,6 @@ const sessionBridgeSchema = z.object({
   email: z.string().email().optional(),
 });
 
-// Helper function to get cookie domain for cross-subdomain sharing
-function getCookieDomain(): string | undefined {
-  const domain = process.env.COOKIE_DOMAIN;
-  if (domain) {
-    return domain;
-  }
-  
-  // In production, use shared parent domain for cross-subdomain cookies
-  if (process.env.NODE_ENV === 'production') {
-    // Extract domain from API_BASE_URL or use default
-    const apiUrl = process.env.API_BASE_URL || process.env.NEXT_PUBLIC_API_BASE_URL;
-    if (apiUrl) {
-      try {
-        const url = new URL(apiUrl);
-        const hostname = url.hostname;
-        
-        // If it's a subdomain like api.taskforge.app, return .taskforge.app
-        const parts = hostname.split('.');
-        if (parts.length >= 3) {
-          return '.' + parts.slice(-2).join('.');
-        }
-        // If it's already a root domain, use it as-is
-        return '.' + hostname;
-      } catch {
-        // Fallback if URL parsing fails
-      }
-    }
-  }
-  
-  // For development, don't set domain (defaults to current host)
-  return undefined;
-}
-
 // Helper function to get cookie options
 function getCookieOptions() {
   return {
@@ -59,9 +29,24 @@ function getCookieOptions() {
     secure: process.env.NODE_ENV === 'production',
     sameSite: 'lax' as const,
     maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days
-    domain: getCookieDomain(),
+    domain: resolveCookieDomain(process.env),
   };
 }
+
+const SESSION_COOKIE_NAME = getSessionCookieName();
+
+const authAttemptLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 5,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: req => req.ip ?? req.socket.remoteAddress ?? 'global',
+  handler: (_req, res) => {
+    res
+      .status(429)
+      .json({ error: 'Too many authentication attempts. Please try again later.' });
+  },
+});
 
 export interface AuthRouterOptions {
   userStore?: UserStore;
@@ -101,7 +86,14 @@ export function createAuthRouter(options: AuthRouterOptions = {}) {
   const store = options.userStore ?? new InMemoryUserStore();
   const saltRounds = resolveSaltRounds(options.bcryptSaltRounds);
   const hasher = options.passwordHasher ?? createPasswordHasher(saltRounds);
-  const secret = options.jwtSecret ?? process.env.JWT_SECRET ?? 'dev-secret';
+  if (store instanceof InMemoryUserStore && process.env.NODE_ENV === 'production') {
+    throw new Error('In-memory user store cannot be used in production. Configure a persistent store.');
+  }
+
+  const secret = options.jwtSecret ?? process.env.JWT_SECRET;
+  if (!secret) {
+    throw new Error('JWT_SECRET is required to initialize authentication routes.');
+  }
   const refreshSecret = options.jwtRefreshSecret ?? process.env.JWT_REFRESH_SECRET;
   const accessExpiresIn = resolveExpiresIn(
     options.accessTokenExpiresIn,
@@ -122,11 +114,14 @@ export function createAuthRouter(options: AuthRouterOptions = {}) {
       refreshExpiresIn,
     });
   const bridgeSecret = options.sessionBridgeSecret ?? process.env.SESSION_BRIDGE_SECRET;
+  if (!bridgeSecret) {
+    console.warn('Session bridge endpoint disabled: SESSION_BRIDGE_SECRET is not configured.');
+  }
   const authMiddleware = createAuthMiddleware({ tokenService: tokens, userStore: store });
 
   const router = Router();
 
-  router.post('/register', async (req, res) => {
+  router.post('/register', authAttemptLimiter, async (req, res) => {
     const parse = registerSchema.safeParse(req.body);
     if (!parse.success) {
       return res.status(400).json({ error: 'Invalid payload', details: parse.error.flatten() });
@@ -148,7 +143,7 @@ export function createAuthRouter(options: AuthRouterOptions = {}) {
     const issuedTokens = await tokens.issueTokens(user.id);
 
     // Set HttpOnly cookie with shared domain for cross-subdomain access
-    res.cookie('tf_session', issuedTokens.accessToken, getCookieOptions());
+    res.cookie(SESSION_COOKIE_NAME, issuedTokens.accessToken, getCookieOptions());
 
     return res.status(201).json({
       user: { id: user.id, email: user.email, createdAt: user.createdAt.toISOString() },
@@ -156,7 +151,7 @@ export function createAuthRouter(options: AuthRouterOptions = {}) {
     });
   });
 
-  router.post('/login', async (req, res) => {
+  router.post('/login', authAttemptLimiter, async (req, res) => {
     const parse = loginSchema.safeParse(req.body);
     if (!parse.success) {
       return res.status(400).json({ error: 'Invalid payload', details: parse.error.flatten() });
@@ -175,7 +170,7 @@ export function createAuthRouter(options: AuthRouterOptions = {}) {
     const issuedTokens = await tokens.issueTokens(user.id);
 
     // Set HttpOnly cookie with shared domain for cross-subdomain access
-    res.cookie('tf_session', issuedTokens.accessToken, getCookieOptions());
+    res.cookie(SESSION_COOKIE_NAME, issuedTokens.accessToken, getCookieOptions());
 
     return res.json({
       user: { id: user.id, email: user.email, createdAt: user.createdAt.toISOString() },
@@ -188,55 +183,84 @@ export function createAuthRouter(options: AuthRouterOptions = {}) {
     const cookieOptions = getCookieOptions();
     // Remove maxAge for clearing
     const { maxAge, ...clearOptions } = cookieOptions;
-    res.clearCookie('tf_session', clearOptions);
+    res.clearCookie(SESSION_COOKIE_NAME, clearOptions);
     return res.status(200).json({ success: true });
   });
 
-  router.post('/session-bridge', async (req, res) => {
-    if (!bridgeSecret) {
-      return res.status(503).json({ error: 'Session bridge is not configured' });
-    }
+  if (bridgeSecret) {
+    router.post('/session-bridge', authAttemptLimiter, async (req, res) => {
+      const providedSecret = req.get('x-session-bridge-secret');
 
-    const providedSecret = req.get('x-session-bridge-secret');
+      if (!providedSecret || providedSecret !== bridgeSecret) {
+        return res.status(401).json({ error: 'Unauthorized' });
+      }
 
-    if (!providedSecret || providedSecret !== bridgeSecret) {
-      return res.status(401).json({ error: 'Unauthorized' });
-    }
+      const parse = sessionBridgeSchema.safeParse(req.body);
 
-    const parse = sessionBridgeSchema.safeParse(req.body);
+      if (!parse.success) {
+        return res.status(400).json({ error: 'Invalid payload', details: parse.error.flatten() });
+      }
+
+      const { userId, email } = parse.data;
+
+      let user = await store.findById(userId);
+
+      if (!user && email) {
+        user = await store.findByEmail(email);
+      }
+
+      if (!user) {
+        return res.status(404).json({ error: 'User not found' });
+      }
+
+      if (email && user.email.toLowerCase() !== email.toLowerCase()) {
+        return res.status(409).json({ error: 'User email mismatch' });
+      }
+
+      const issuedTokens = await tokens.issueTokens(user.id);
+
+      res.cookie(SESSION_COOKIE_NAME, issuedTokens.accessToken, getCookieOptions());
+
+      return res.json({
+        user: { id: user.id, email: user.email, createdAt: user.createdAt.toISOString() },
+        tokens: issuedTokens,
+      });
+    });
+  }
+
+  const refreshSchema = z.object({
+    refreshToken: z.string().min(1),
+  });
+
+  router.post('/refresh', authAttemptLimiter, async (req, res) => {
+    const parse = refreshSchema.safeParse(req.body);
 
     if (!parse.success) {
       return res.status(400).json({ error: 'Invalid payload', details: parse.error.flatten() });
     }
 
-    const { userId, email } = parse.data;
+    try {
+      const payload = await tokens.verifyRefreshToken(parse.data.refreshToken);
+      const user = await store.findById(payload.sub);
 
-    let user = await store.findById(userId);
+      if (!user) {
+        return res.status(401).json({ error: 'Invalid refresh token' });
+      }
 
-    if (!user && email) {
-      user = await store.findByEmail(email);
+      const issuedTokens = await tokens.issueTokens(user.id);
+      res.cookie(SESSION_COOKIE_NAME, issuedTokens.accessToken, getCookieOptions());
+
+      return res.json({
+        user: { id: user.id, email: user.email, createdAt: user.createdAt.toISOString() },
+        tokens: issuedTokens,
+      });
+    } catch {
+      return res.status(401).json({ error: 'Invalid refresh token' });
     }
-
-    if (!user) {
-      return res.status(404).json({ error: 'User not found' });
-    }
-
-    if (email && user.email.toLowerCase() !== email.toLowerCase()) {
-      return res.status(409).json({ error: 'User email mismatch' });
-    }
-
-    const issuedTokens = await tokens.issueTokens(user.id);
-
-    res.cookie('tf_session', issuedTokens.accessToken, getCookieOptions());
-
-    return res.json({
-      user: { id: user.id, email: user.email, createdAt: user.createdAt.toISOString() },
-      tokens: issuedTokens,
-    });
   });
 
   router.get('/me', authMiddleware, (_req, res) => {
-    const authUser = res.locals.user as { id: string; email: string; createdAt: string } | undefined;
+    const authUser = res.locals.user;
     if (!authUser) {
       return res.status(401).json({ error: 'Unauthorized' });
     }

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -24,12 +24,19 @@ const sessionBridgeSchema = z.object({
 
 // Helper function to get cookie options
 function getCookieOptions() {
+  const domain = resolveCookieDomain({
+    COOKIE_DOMAIN: process.env.COOKIE_DOMAIN,
+    NODE_ENV: process.env.NODE_ENV,
+    API_BASE_URL: process.env.API_BASE_URL,
+    NEXT_PUBLIC_API_BASE_URL: process.env.NEXT_PUBLIC_API_BASE_URL,
+  });
+
   return {
     httpOnly: true,
     secure: process.env.NODE_ENV === 'production',
     sameSite: 'lax' as const,
     maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days
-    domain: resolveCookieDomain(process.env),
+    domain,
   };
 }
 

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1,7 +1,11 @@
 import { createApp } from './app';
 
 const port = Number.parseInt(process.env.PORT ?? '4000', 10);
-const jwtSecret = process.env.JWT_SECRET ?? 'dev-secret';
+const jwtSecret = process.env.JWT_SECRET;
+
+if (!jwtSecret) {
+  throw new Error('JWT_SECRET must be set before starting the API server.');
+}
 
 const app = createApp({ jwtSecret });
 

--- a/apps/api/src/types/express.d.ts
+++ b/apps/api/src/types/express.d.ts
@@ -1,0 +1,12 @@
+import type { AuthUserDTO } from '@taskforge/shared';
+
+declare global {
+  namespace Express {
+    interface Locals {
+      user?: AuthUserDTO;
+      token?: string;
+    }
+  }
+}
+
+export {};

--- a/apps/web/lib/env.ts
+++ b/apps/web/lib/env.ts
@@ -1,3 +1,5 @@
+import { getSessionCookieName } from '@taskforge/shared';
+
 export function getApiBaseUrl() {
   const fromPublic = process.env.NEXT_PUBLIC_API_BASE_URL;
   const fromServer = process.env.API_BASE_URL;
@@ -15,4 +17,4 @@ export function getApiUrl(path: string) {
   return `${getApiBaseUrl()}/${normalizedPath}`;
 }
 
-export const SESSION_COOKIE_NAME = 'tf_session';
+export const SESSION_COOKIE_NAME = getSessionCookieName();

--- a/apps/web/lib/session-bridge.ts
+++ b/apps/web/lib/session-bridge.ts
@@ -10,6 +10,13 @@ import type { AuthenticatedUser } from './server-auth';
 const SESSION_COOKIE_NAME = getSessionCookieName();
 
 export function getSessionCookieOptions() {
+  const domain = resolveCookieDomain({
+    COOKIE_DOMAIN: process.env.COOKIE_DOMAIN,
+    NODE_ENV: process.env.NODE_ENV,
+    API_BASE_URL: process.env.API_BASE_URL,
+    NEXT_PUBLIC_API_BASE_URL: process.env.NEXT_PUBLIC_API_BASE_URL,
+  });
+
   return {
     name: SESSION_COOKIE_NAME,
     httpOnly: true,
@@ -17,7 +24,7 @@ export function getSessionCookieOptions() {
     secure: process.env.NODE_ENV === 'production',
     path: '/',
     maxAge: 7 * 24 * 60 * 60,
-    domain: resolveCookieDomain(process.env),
+    domain,
   } as const;
 }
 

--- a/apps/web/lib/session-bridge.ts
+++ b/apps/web/lib/session-bridge.ts
@@ -2,34 +2,12 @@ import 'server-only';
 
 import { cookies } from 'next/headers';
 
-import { getApiUrl, SESSION_COOKIE_NAME } from './env';
+import { getSessionCookieName, resolveCookieDomain } from '@taskforge/shared';
+
+import { getApiUrl } from './env';
 import type { AuthenticatedUser } from './server-auth';
 
-function resolveCookieDomain(): string | undefined {
-  const explicit = process.env.COOKIE_DOMAIN;
-  if (explicit) {
-    return explicit;
-  }
-
-  if (process.env.NODE_ENV === 'production') {
-    const apiUrl = process.env.API_BASE_URL || process.env.NEXT_PUBLIC_API_BASE_URL;
-    if (apiUrl) {
-      try {
-        const url = new URL(apiUrl);
-        const hostname = url.hostname;
-        const parts = hostname.split('.');
-        if (parts.length >= 3) {
-          return `.${parts.slice(-2).join('.')}`;
-        }
-        return `.${hostname}`;
-      } catch {
-        // ignore parse errors
-      }
-    }
-  }
-
-  return undefined;
-}
+const SESSION_COOKIE_NAME = getSessionCookieName();
 
 export function getSessionCookieOptions() {
   return {
@@ -39,7 +17,7 @@ export function getSessionCookieOptions() {
     secure: process.env.NODE_ENV === 'production',
     path: '/',
     maxAge: 7 * 24 * 60 * 60,
-    domain: resolveCookieDomain(),
+    domain: resolveCookieDomain(process.env),
   } as const;
 }
 

--- a/packages/shared/src/auth/cookies.ts
+++ b/packages/shared/src/auth/cookies.ts
@@ -1,0 +1,40 @@
+const SESSION_COOKIE_NAME = 'tf_session' as const;
+
+export interface CookieDomainEnv {
+  COOKIE_DOMAIN?: string;
+  NODE_ENV?: string;
+  API_BASE_URL?: string;
+  NEXT_PUBLIC_API_BASE_URL?: string;
+}
+
+export function resolveCookieDomain(env: CookieDomainEnv): string | undefined {
+  const explicit = env.COOKIE_DOMAIN;
+  if (explicit) {
+    return explicit;
+  }
+
+  if (env.NODE_ENV === 'production') {
+    const apiUrl = env.API_BASE_URL ?? env.NEXT_PUBLIC_API_BASE_URL;
+    if (apiUrl) {
+      try {
+        const url = new URL(apiUrl);
+        const hostname = url.hostname;
+        const parts = hostname.split('.');
+
+        if (parts.length >= 3) {
+          return `.${parts.slice(-2).join('.')}`;
+        }
+
+        return `.${hostname}`;
+      } catch {
+        // If the URL cannot be parsed we fall through to the undefined case
+      }
+    }
+  }
+
+  return undefined;
+}
+
+export function getSessionCookieName(): typeof SESSION_COOKIE_NAME {
+  return SESSION_COOKIE_NAME;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -32,3 +32,5 @@ export interface AuthSuccessResponseDTO {
 export interface AuthMeResponseDTO {
   user: AuthUserDTO | null;
 }
+
+export { resolveCookieDomain, getSessionCookieName } from './auth/cookies';


### PR DESCRIPTION
## Summary
- require explicit JWT secrets and prevent in-memory user storage in production
- disable the session bridge when not configured and tighten rate limiting for auth routes
- centralize cookie domain logic, add a refresh endpoint, and share session cookie constants

## Testing
- pnpm --filter @taskforge/api test *(fails: cross-env binary unavailable in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912f9815b808322b37efa18f531a498)