### PR TITLE
feat(api): add prisma-backed task repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,26 +31,31 @@ taskforge/
    cp infra/env/api.env.example apps/api/.env
    cp infra/env/web.env.example apps/web/.env
    ```
-3. **Run static checks**
+3. **Apply Prisma migrations (required for the task repository)**
+   ```bash
+   pnpm -C apps/api prisma migrate dev
+   ```
+   Re-run this whenever the Prisma schema changes to keep your local database aligned.
+4. **Run static checks**
    ```bash
    pnpm lint
    pnpm typecheck
    ```
-4. **Start the Docker services (Postgres + MailHog + app containers)**
+5. **Start the Docker services (Postgres + MailHog + app containers)**
    ```bash
    make up
    # when finished
    make down
    ```
-5. **Run dev servers locally (hot reload)**
+6. **Run dev servers locally (hot reload)**
    ```bash
    pnpm -C apps/api dev
    pnpm -C apps/web dev
    ```
-6. **Smoke test**
+7. **Smoke test**
    - API health: `curl http://localhost:4000/api/taskforge/v1/health`
    - Web UI: http://localhost:3000
-7. **Docker auth smoke test**
+8. **Docker auth smoke test**
    ```bash
    make auth-smoke
    ```
@@ -98,8 +103,10 @@ Keep `.env` files in sync with the templates in `infra/env/`. The table below hi
 Run Prisma migrations whenever the schema changes:
 
 ```bash
-pnpm -C apps/api prisma migrate deploy
+pnpm -C apps/api prisma migrate dev
 ```
+
+Use `pnpm -C apps/api prisma migrate deploy` when applying the same migrations to managed environments or the Dockerised Postgres service.
 
 Seed the deterministic demo user (`demo@taskforge.dev` / `Demo1234!` by default) for QA flows:
 
@@ -148,4 +155,4 @@ Screenshots of the login flow and protected dashboard live in the design referen
 - DB: Neon or Supabase
 - Email (dev): MailHog; (prod) any free SMTP (e.g., Brevo, Resend, Postmark trial)
 
-**Note:** This scaffold uses an in-memory store in the API for now—wire up Prisma (see PRD) before production.
+**Note:** Task data (including tag assignments) now persists through Prisma. Run `pnpm -C apps/api prisma migrate dev` before exercising the API locally to ensure the task repository has the required tables.

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -61,9 +61,16 @@ export function createApp(options: CreateAppOptions = {}) {
 
   app.use('/api/taskforge/docs', swaggerUi.serve, swaggerUi.setup(openApiDocument));
 
-  const prisma = getPrismaClient();
-  const userStore = options.userStore ?? new PrismaUserStore(prisma);
-  const taskRepository = options.taskRepository ?? createTaskRepository(prisma);
+  let prisma: ReturnType<typeof getPrismaClient> | undefined;
+  const getOrCreatePrisma = (): ReturnType<typeof getPrismaClient> => {
+    if (!prisma) {
+      prisma = getPrismaClient();
+    }
+    return prisma;
+  };
+
+  const userStore = options.userStore ?? new PrismaUserStore(getOrCreatePrisma());
+  const taskRepository = options.taskRepository ?? createTaskRepository(getOrCreatePrisma());
   const authRouterFactory = createAuthRouter({
     jwtSecret: options.jwtSecret,
     userStore,

--- a/apps/api/src/repositories/task-mapper.ts
+++ b/apps/api/src/repositories/task-mapper.ts
@@ -1,0 +1,69 @@
+import type { Prisma } from '@prisma/client';
+import type { TaskRecordDTO } from '@taskforge/shared';
+
+export const taskWithTagsInclude = {
+  TaskTag: {
+    include: {
+      tag: true,
+    },
+  },
+} as const;
+
+export type TaskWithTags = Prisma.TaskGetPayload<{
+  include: typeof taskWithTagsInclude;
+}>;
+
+export function toTaskRecordDTO(task: TaskWithTags): TaskRecordDTO {
+  const tags = task.TaskTag.map(({ tag }) => tag.label).sort((a: string, b: string) =>
+    a.localeCompare(b, undefined, { sensitivity: 'base' }),
+  );
+
+  return {
+    id: task.id,
+    title: task.title,
+    description: task.description ?? undefined,
+    status: task.status,
+    priority: task.priority,
+    dueDate: task.dueDate?.toISOString(),
+    tags,
+    createdAt: task.createdAt.toISOString(),
+    updatedAt: task.updatedAt.toISOString(),
+  };
+}
+
+export function normalizeTagLabels(tags?: string[]): string[] {
+  if (!tags?.length) {
+    return [];
+  }
+
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+
+  for (const label of tags) {
+    const trimmed = label.trim();
+    if (!trimmed) {
+      continue;
+    }
+    const key = trimmed;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    normalized.push(trimmed);
+  }
+
+  return normalized.sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }));
+}
+
+export function parseDueDate(input?: string): Date | undefined {
+  if (!input) {
+    return undefined;
+  }
+
+  const date = new Date(input);
+  if (Number.isNaN(date.getTime())) {
+    return undefined;
+  }
+
+  return date;
+}

--- a/apps/api/src/repositories/task-repository.ts
+++ b/apps/api/src/repositories/task-repository.ts
@@ -1,0 +1,164 @@
+import type {
+  Prisma,
+  PrismaClient,
+  TaskPriority as PrismaTaskPriority,
+  TaskStatus as PrismaTaskStatus,
+} from '@prisma/client';
+import type {
+  TaskPriority as SharedTaskPriority,
+  TaskStatus as SharedTaskStatus,
+  TaskRecordDTO,
+} from '@taskforge/shared';
+
+import { normalizeTagLabels, parseDueDate, taskWithTagsInclude, toTaskRecordDTO } from './task-mapper';
+
+export interface TaskCreateInput {
+  title: string;
+  description?: string;
+  status?: SharedTaskStatus;
+  priority?: SharedTaskPriority;
+  dueDate?: string;
+  tags?: string[];
+}
+
+export type TaskUpdateInput = Partial<TaskCreateInput>;
+
+export interface TaskRepository {
+  listTasks(userId: string): Promise<TaskRecordDTO[]>;
+  createTask(userId: string, input: TaskCreateInput): Promise<TaskRecordDTO>;
+  updateTask(
+    userId: string,
+    taskId: string,
+    input: TaskUpdateInput,
+  ): Promise<TaskRecordDTO | null>;
+  deleteTask(userId: string, taskId: string): Promise<TaskRecordDTO | null>;
+}
+
+export function createTaskRepository(prisma: PrismaClient): TaskRepository {
+  return {
+    async listTasks(userId) {
+      const tasks = await prisma.task.findMany({
+        where: { userId },
+        orderBy: { createdAt: 'asc' },
+        include: taskWithTagsInclude,
+      });
+
+      return tasks.map(toTaskRecordDTO);
+    },
+
+    async createTask(userId, input) {
+      const normalizedTags = normalizeTagLabels(input.tags);
+      const task = await prisma.task.create({
+        data: {
+          title: input.title,
+          description: input.description ?? null,
+          status: (input.status ?? 'TODO') as PrismaTaskStatus,
+          priority: (input.priority ?? 'MEDIUM') as PrismaTaskPriority,
+          dueDate: parseDueDate(input.dueDate),
+          user: { connect: { id: userId } },
+          TaskTag: normalizedTags.length
+            ? {
+                create: normalizedTags.map(label => ({
+                  tag: {
+                    connectOrCreate: {
+                      where: { label },
+                      create: { label },
+                    },
+                  },
+                })),
+              }
+            : undefined,
+        },
+        include: taskWithTagsInclude,
+      });
+
+      return toTaskRecordDTO(task);
+    },
+
+    async updateTask(userId, taskId, input) {
+      return prisma.$transaction(async (tx: Prisma.TransactionClient) => {
+        const existing = await tx.task.findFirst({ where: { id: taskId, userId } });
+        if (!existing) {
+          return null;
+        }
+
+        const updateData: Prisma.TaskUpdateInput = {};
+        if (input.title !== undefined) {
+          updateData.title = input.title;
+        }
+        if (input.description !== undefined) {
+          updateData.description = input.description;
+        }
+        if (input.status !== undefined) {
+          updateData.status = input.status as PrismaTaskStatus;
+        }
+        if (input.priority !== undefined) {
+          updateData.priority = input.priority as PrismaTaskPriority;
+        }
+        if (input.dueDate !== undefined) {
+          const dueDate = parseDueDate(input.dueDate);
+          updateData.dueDate = dueDate ?? null;
+        }
+
+        if (Object.keys(updateData).length > 0) {
+          await tx.task.update({ where: { id: taskId }, data: updateData });
+        }
+
+        if (input.tags !== undefined) {
+          const normalizedTags = normalizeTagLabels(input.tags);
+          await replaceTaskTags(tx, taskId, normalizedTags);
+        }
+
+        const updated = await tx.task.findUnique({
+          where: { id: taskId },
+          include: taskWithTagsInclude,
+        });
+
+        return updated ? toTaskRecordDTO(updated) : null;
+      });
+    },
+
+    async deleteTask(userId, taskId) {
+      return prisma.$transaction(async (tx: Prisma.TransactionClient) => {
+        const existing = await tx.task.findFirst({
+          where: { id: taskId, userId },
+          include: taskWithTagsInclude,
+        });
+
+        if (!existing) {
+          return null;
+        }
+
+        await tx.task.delete({ where: { id: taskId } });
+        return toTaskRecordDTO(existing);
+      });
+    },
+  };
+}
+
+async function replaceTaskTags(
+  tx: Prisma.TransactionClient,
+  taskId: string,
+  labels: string[],
+): Promise<void> {
+  await tx.taskTag.deleteMany({ where: { taskId } });
+
+  if (!labels.length) {
+    return;
+  }
+
+  for (const label of labels) {
+    const tag = await tx.tag.upsert({
+      where: { label },
+      update: {},
+      create: { label },
+    });
+
+    await tx.taskTag.create({
+      data: {
+        taskId,
+        tagId: tag.id,
+      },
+    });
+  }
+}

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -9,9 +9,8 @@ import {
   type TaskUpdateInput,
 } from '../repositories/task-repository';
 
-export function createTaskRouter(
-  taskRepository: TaskRepository = createTaskRepository(getPrismaClient()),
-) {
+export function createTaskRouter(taskRepository?: TaskRepository) {
+  const repository = taskRepository ?? createTaskRepository(getPrismaClient());
   const router = Router();
 
   router.get('/', async (req, res, next) => {
@@ -21,7 +20,7 @@ export function createTaskRouter(
         return res.status(401).json({ error: 'Unauthorized' });
       }
 
-      const tasks = await taskRepository.listTasks(user.id);
+      const tasks = await repository.listTasks(user.id);
       res.json({ items: tasks });
     } catch (error) {
       next(error);
@@ -41,7 +40,7 @@ export function createTaskRouter(
       }
 
       const payload: TaskCreateInput = parsed.data;
-      const task = await taskRepository.createTask(user.id, payload);
+      const task = await repository.createTask(user.id, payload);
       res.status(201).json(task);
     } catch (error) {
       next(error);
@@ -61,7 +60,7 @@ export function createTaskRouter(
       }
 
       const payload: TaskUpdateInput = parsed.data;
-      const updated = await taskRepository.updateTask(user.id, req.params.id, payload);
+      const updated = await repository.updateTask(user.id, req.params.id, payload);
       if (!updated) {
         return res.status(404).json({ error: 'Not found' });
       }
@@ -79,7 +78,7 @@ export function createTaskRouter(
         return res.status(401).json({ error: 'Unauthorized' });
       }
 
-      const deleted = await taskRepository.deleteTask(user.id, req.params.id);
+      const deleted = await repository.deleteTask(user.id, req.params.id);
       if (!deleted) {
         return res.status(404).json({ error: 'Not found' });
       }
@@ -92,5 +91,3 @@ export function createTaskRouter(
 
   return router;
 }
-
-export const router = createTaskRouter();

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -1,59 +1,96 @@
 import { Router } from 'express';
 
-import type { TaskDTO, TaskPriority, TaskStatus } from '@taskforge/shared';
-
+import { getPrismaClient } from '../prisma';
 import { TaskCreateSchema, TaskUpdateSchema } from '../schemas/task';
+import {
+  createTaskRepository,
+  type TaskCreateInput,
+  type TaskRepository,
+  type TaskUpdateInput,
+} from '../repositories/task-repository';
 
-export const router = Router();
+export function createTaskRouter(
+  taskRepository: TaskRepository = createTaskRepository(getPrismaClient()),
+) {
+  const router = Router();
 
-type TaskRecord = TaskDTO & {
-  id: string;
-  status: TaskStatus;
-  priority: TaskPriority;
-};
+  router.get('/', async (req, res, next) => {
+    try {
+      const user = res.locals.user;
+      if (!user) {
+        return res.status(401).json({ error: 'Unauthorized' });
+      }
 
-const tasks: TaskRecord[] = [];
+      const tasks = await taskRepository.listTasks(user.id);
+      res.json({ items: tasks });
+    } catch (error) {
+      next(error);
+    }
+  });
 
-router.get('/', (_req, res) => {
-  res.json({ items: tasks });
-});
+  router.post('/', async (req, res, next) => {
+    const parsed = TaskCreateSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json(parsed.error);
+    }
 
-router.post('/', (req, res) => {
-  const parsed = TaskCreateSchema.safeParse(req.body);
-  if (!parsed.success) return res.status(400).json(parsed.error);
+    try {
+      const user = res.locals.user;
+      if (!user) {
+        return res.status(401).json({ error: 'Unauthorized' });
+      }
 
-  const task: TaskRecord = {
-    id: String(Date.now()),
-    status: parsed.data.status ?? 'TODO',
-    priority: parsed.data.priority ?? 'MEDIUM',
-    ...parsed.data,
-  };
+      const payload: TaskCreateInput = parsed.data;
+      const task = await taskRepository.createTask(user.id, payload);
+      res.status(201).json(task);
+    } catch (error) {
+      next(error);
+    }
+  });
 
-  tasks.push(task);
-  res.status(201).json(task);
-});
+  router.patch('/:id', async (req, res, next) => {
+    const parsed = TaskUpdateSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json(parsed.error);
+    }
 
-router.patch('/:id', (req, res) => {
-  const parsed = TaskUpdateSchema.safeParse(req.body);
-  if (!parsed.success) return res.status(400).json(parsed.error);
+    try {
+      const user = res.locals.user;
+      if (!user) {
+        return res.status(401).json({ error: 'Unauthorized' });
+      }
 
-  const index = tasks.findIndex(task => task.id === req.params.id);
-  if (index < 0) return res.status(404).json({ error: 'Not found' });
+      const payload: TaskUpdateInput = parsed.data;
+      const updated = await taskRepository.updateTask(user.id, req.params.id, payload);
+      if (!updated) {
+        return res.status(404).json({ error: 'Not found' });
+      }
 
-  tasks[index] = {
-    ...tasks[index],
-    ...parsed.data,
-    status: parsed.data.status ?? tasks[index].status,
-    priority: parsed.data.priority ?? tasks[index].priority,
-  };
+      res.json(updated);
+    } catch (error) {
+      next(error);
+    }
+  });
 
-  res.json(tasks[index]);
-});
+  router.delete('/:id', async (req, res, next) => {
+    try {
+      const user = res.locals.user;
+      if (!user) {
+        return res.status(401).json({ error: 'Unauthorized' });
+      }
 
-router.delete('/:id', (req, res) => {
-  const index = tasks.findIndex(task => task.id === req.params.id);
-  if (index < 0) return res.status(404).json({ error: 'Not found' });
+      const deleted = await taskRepository.deleteTask(user.id, req.params.id);
+      if (!deleted) {
+        return res.status(404).json({ error: 'Not found' });
+      }
 
-  const [deleted] = tasks.splice(index, 1);
-  res.json(deleted);
-});
+      res.json(deleted);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  return router;
+}
+
+export const router = createTaskRouter();

--- a/apps/api/tests/utils/in-memory-task-repository.ts
+++ b/apps/api/tests/utils/in-memory-task-repository.ts
@@ -1,0 +1,87 @@
+import { randomUUID } from 'node:crypto';
+
+import type { TaskRecordDTO } from '@taskforge/shared';
+
+import {
+  type TaskCreateInput,
+  type TaskRepository,
+  type TaskUpdateInput,
+} from '../../src/repositories/task-repository';
+import { normalizeTagLabels } from '../../src/repositories/task-mapper';
+
+interface StoredTask extends TaskRecordDTO {
+  userId: string;
+}
+
+export class InMemoryTaskRepository implements TaskRepository {
+  private readonly tasks = new Map<string, StoredTask>();
+
+  async listTasks(userId: string): Promise<TaskRecordDTO[]> {
+    return Array.from(this.tasks.values())
+      .filter(task => task.userId === userId)
+      .sort((a, b) => a.createdAt.localeCompare(b.createdAt))
+      .map(task => ({ ...task }));
+  }
+
+  async createTask(userId: string, input: TaskCreateInput): Promise<TaskRecordDTO> {
+    const now = new Date().toISOString();
+    const task: StoredTask = {
+      id: randomUUID(),
+      title: input.title,
+      description: input.description,
+      status: input.status ?? 'TODO',
+      priority: input.priority ?? 'MEDIUM',
+      dueDate: input.dueDate,
+      tags: normalizeTagLabels(input.tags),
+      createdAt: now,
+      updatedAt: now,
+      userId,
+    };
+
+    this.tasks.set(task.id, task);
+    return { ...task };
+  }
+
+  async updateTask(
+    userId: string,
+    taskId: string,
+    input: TaskUpdateInput,
+  ): Promise<TaskRecordDTO | null> {
+    const existing = this.tasks.get(taskId);
+    if (!existing || existing.userId !== userId) {
+      return null;
+    }
+
+    if (input.title !== undefined) {
+      existing.title = input.title;
+    }
+    if (input.description !== undefined) {
+      existing.description = input.description;
+    }
+    if (input.status !== undefined) {
+      existing.status = input.status;
+    }
+    if (input.priority !== undefined) {
+      existing.priority = input.priority;
+    }
+    if (input.dueDate !== undefined) {
+      existing.dueDate = input.dueDate;
+    }
+    if (input.tags !== undefined) {
+      existing.tags = normalizeTagLabels(input.tags);
+    }
+
+    existing.updatedAt = new Date().toISOString();
+    return { ...existing };
+  }
+
+  async deleteTask(userId: string, taskId: string): Promise<TaskRecordDTO | null> {
+    const existing = this.tasks.get(taskId);
+    if (!existing || existing.userId !== userId) {
+      return null;
+    }
+
+    this.tasks.delete(taskId);
+    return { ...existing };
+  }
+}

--- a/apps/api/tests/utils/test-app.ts
+++ b/apps/api/tests/utils/test-app.ts
@@ -2,24 +2,34 @@ import request, { type SuperTest, type Test } from 'supertest';
 
 import { InMemoryUserStore } from '../../src/auth/user-store';
 import { createApp } from '../../src/app';
+import type { TaskRepository } from '../../src/repositories/task-repository';
+import { InMemoryTaskRepository } from './in-memory-task-repository';
 
 export interface TestAgentContext {
   agent: SuperTest<Test>;
   userStore: InMemoryUserStore;
+  taskRepository: TaskRepository;
 }
 
 export interface CreateTestAgentOptions {
   jwtSecret?: string;
   userStore?: InMemoryUserStore;
   sessionBridgeSecret?: string;
+  taskRepository?: TaskRepository;
 }
 
 export function createTestAgent(
   options: CreateTestAgentOptions = {},
 ): TestAgentContext {
   const userStore = options.userStore ?? new InMemoryUserStore();
+  const taskRepository = options.taskRepository ?? new InMemoryTaskRepository();
   const jwtSecret = options.jwtSecret ?? 'test-secret';
-  const app = createApp({ jwtSecret, userStore, sessionBridgeSecret: options.sessionBridgeSecret });
+  const app = createApp({
+    jwtSecret,
+    userStore,
+    sessionBridgeSecret: options.sessionBridgeSecret,
+    taskRepository,
+  });
 
-  return { agent: request(app), userStore };
+  return { agent: request(app), userStore, taskRepository };
 }

--- a/docs/adr/0002-database-postgres-+-prisma.md
+++ b/docs/adr/0002-database-postgres-+-prisma.md
@@ -12,3 +12,4 @@ Use **PostgreSQL** (Neon/Supabase free tiers) with **Prisma ORM** for DX, migrat
 - SQL reliability; generous free tiers.
 - Prisma generates types; simple migrations.
 - Cold-starts on free tiers may add latency.
+- Tasks, tags, and their join table (`TaskTag`) back the API repository so every task read/write stays scoped to the authenticated user via Prisma transactions.

--- a/docs/tasks/milestone3/01-api-prisma-foundation.md
+++ b/docs/tasks/milestone3/01-api-prisma-foundation.md
@@ -4,16 +4,22 @@
 - Replace the ad-hoc in-memory store with a dedicated Prisma-backed `taskRepository` that scopes every read/write to the authenticated user.
 - Centralize DTO ↔ Prisma conversions (tags, enums, timestamps) so subsequent API handlers and tests can reuse the same helpers.
 
-**Status:** New.  
+**Status:** Completed.
 **Concurrency:** Blocks every other milestone-3 task; land this before touching any API route logic.
 
 ## Acceptance Criteria
-- [ ] A new repository/service module exposes `listTasks`, `createTask`, `updateTask`, and `deleteTask` helpers that all require a `userId`.
-- [ ] Repository methods normalize enums, tags, and ISO timestamps so downstream layers consume consistent DTOs.
-- [ ] Shared DTO/types module exports any new interfaces needed for Prisma-backed records.
-- [ ] README/ADR updates capture the switch from in-memory storage to Prisma for tasks, including any schema tweaks.
-- [ ] Developer docs include guidance on running `pnpm -C apps/api prisma migrate dev` before exercising the new repository.
+- [x] A new repository/service module exposes `listTasks`, `createTask`, `updateTask`, and `deleteTask` helpers that all require a `userId`.
+- [x] Repository methods normalize enums, tags, and ISO timestamps so downstream layers consume consistent DTOs.
+- [x] Shared DTO/types module exports any new interfaces needed for Prisma-backed records.
+- [x] README/ADR updates capture the switch from in-memory storage to Prisma for tasks, including any schema tweaks.
+- [x] Developer docs include guidance on running `pnpm -C apps/api prisma migrate dev` before exercising the new repository.
 
 ## Notes
 - Reuse the seeded demo user for manual verification while CI runs against SQLite or a dockerized Postgres.
 - Consider extracting lightweight mapping utilities so tests can stub Prisma without re-implementing DTO hygiene.
+
+## Implementation Notes
+- Added `apps/api/src/repositories/task-repository.ts` with Prisma-backed helpers plus shared mapping utilities (`task-mapper.ts`) that normalize enums, ISO timestamps, and tag order.
+- Updated `packages/shared/src/index.ts` to export `TaskRecordDTO`, giving downstream layers typed access to persisted metadata.
+- `createApp` now accepts an injected `taskRepository`, enabling Jest to swap in the in-memory test double defined in `apps/api/tests/utils/in-memory-task-repository.ts`.
+- Developer docs call out `pnpm -C apps/api prisma migrate dev` as the default local workflow so the new repository has its tables before exercising `/tasks` endpoints.

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,5 +1,6 @@
 export type TaskStatus = 'TODO' | 'IN_PROGRESS' | 'DONE';
 export type TaskPriority = 'LOW' | 'MEDIUM' | 'HIGH';
+
 export interface TaskDTO {
   id?: string;
   title: string;
@@ -8,6 +9,18 @@ export interface TaskDTO {
   priority?: TaskPriority;
   dueDate?: string;
   tags?: string[];
+}
+
+export interface TaskRecordDTO {
+  id: string;
+  title: string;
+  description?: string;
+  status: TaskStatus;
+  priority: TaskPriority;
+  dueDate?: string;
+  tags: string[];
+  createdAt: string;
+  updatedAt: string;
 }
 
 export interface AuthUserDTO {


### PR DESCRIPTION
## Summary
- add a Prisma-based task repository with shared DTO mappers so tasks are scoped per user and tags are normalized
- update the Express app and task routes to inject the repository while providing an in-memory test double
- document the new TaskRecord DTO alongside migration guidance in the README and ADR
