### PR TITLE
Implement task list and create endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,28 @@ Running the seed multiple times is safe—it upserts the user and respects `SEED
 
 Screenshots of the login flow and protected dashboard live in the design references inside the PRD and ADR linked above. Capture fresh UI snapshots for release notes or marketing updates as needed.
 
+## Tasks API
+The task routes live under `/api/taskforge/v1/tasks` and require the authenticated user's JWT. You can supply the token either as a Bearer header or via the shared `tf_session` cookie issued during login/registration.
+
+```bash
+# 1) Start the API locally
+pnpm -C apps/api dev
+
+# 2) Authenticate (see apps/api/tests/auth.http for detailed flows)
+
+# 3) List the first page of tasks (defaults: page=1, pageSize=20)
+curl -b "tf_session=$ACCESS_TOKEN" -H "Authorization: Bearer $ACCESS_TOKEN" \
+  "http://localhost:4000/api/taskforge/v1/tasks?page=1&pageSize=10"
+
+# 4) Create a task for the signed-in user
+curl -b "tf_session=$ACCESS_TOKEN" -H "Authorization: Bearer $ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"title":"Draft release notes","tags":["docs"]}' \
+  http://localhost:4000/api/taskforge/v1/tasks
+```
+
+Responses use the shared DTOs from `packages/shared`, returning timestamps, status/priority defaults, and the normalized tag list. Validation failures mirror the auth endpoints by responding with `{"error":"Invalid payload","details":...}`.
+
 ## Continuous Integration
 - The GitHub Actions workflow (`.github/workflows/ci.yml`) provisions a PostgreSQL service, runs `prisma generate`, and applies
   migrations via `prisma migrate deploy` before executing the auth-focused Jest suite in `apps/api`.

--- a/apps/api/src/schemas/task.ts
+++ b/apps/api/src/schemas/task.ts
@@ -1,12 +1,12 @@
 import { z } from 'zod';
 
 export const TaskCreateSchema = z.object({
-  title: z.string().min(1),
-  description: z.string().optional(),
-  status: z.enum(['TODO','IN_PROGRESS','DONE']).optional(),
-  priority: z.enum(['LOW','MEDIUM','HIGH']).optional(),
+  title: z.string().trim().min(1),
+  description: z.string().trim().min(1).optional(),
+  status: z.enum(['TODO', 'IN_PROGRESS', 'DONE']).optional(),
+  priority: z.enum(['LOW', 'MEDIUM', 'HIGH']).optional(),
   dueDate: z.string().datetime().optional(),
-  tags: z.array(z.string()).optional()
+  tags: z.array(z.string().trim().min(1)).optional(),
 });
 
 export const TaskUpdateSchema = TaskCreateSchema.partial();

--- a/apps/api/tests/tasks.e2e.test.ts
+++ b/apps/api/tests/tasks.e2e.test.ts
@@ -1,0 +1,126 @@
+import { randomUUID } from 'node:crypto';
+
+import type { SuperTest, Test } from 'supertest';
+
+import { InMemoryUserStore } from '../src/auth/user-store';
+import { type TaskRepository } from '../src/repositories/task-repository';
+import { createTestAgent } from './utils/test-app';
+
+const defaultPassword = 'Secret123!';
+
+function uniqueEmail(prefix = 'user'): string {
+  return `${prefix}-${randomUUID()}@example.com`;
+}
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+describe('Tasks API', () => {
+  let agent: SuperTest<Test>;
+  let userStore: InMemoryUserStore;
+  let taskRepository: TaskRepository;
+
+  beforeEach(() => {
+    const context = createTestAgent({ sessionBridgeSecret: 'test-bridge-secret' });
+    agent = context.agent;
+    userStore = context.userStore;
+    taskRepository = context.taskRepository;
+  });
+
+  afterEach(async () => {
+    await userStore.clear();
+  });
+
+  async function register() {
+    const email = uniqueEmail('tasks');
+    const response = await agent
+      .post('/api/taskforge/v1/auth/register')
+      .send({ email, password: defaultPassword })
+      .expect(201);
+
+    return {
+      email,
+      accessToken: response.body.tokens.accessToken as string,
+      userId: response.body.user.id as string,
+    };
+  }
+
+  it('returns paginated tasks for the authenticated user', async () => {
+    const { accessToken, userId } = await register();
+
+    await taskRepository.createTask(userId, { title: 'First' });
+    await sleep(2);
+    await taskRepository.createTask(userId, { title: 'Second' });
+    await sleep(2);
+    await taskRepository.createTask(userId, { title: 'Third' });
+    await taskRepository.createTask('someone-else', { title: 'Should not appear' });
+
+    const response = await agent
+      .get('/api/taskforge/v1/tasks?page=1&pageSize=2')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(200);
+
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        page: 1,
+        pageSize: 2,
+        total: 3,
+        items: [
+          expect.objectContaining({ title: 'Third' }),
+          expect.objectContaining({ title: 'Second' }),
+        ],
+      }),
+    );
+  });
+
+  it('creates a task with defaults and returns the record', async () => {
+    const { accessToken } = await register();
+
+    const createResponse = await agent
+      .post('/api/taskforge/v1/tasks')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ title: 'Write docs', tags: ['docs', 'work'] })
+      .expect(201);
+
+    expect(createResponse.body).toEqual(
+      expect.objectContaining({
+        id: expect.any(String),
+        title: 'Write docs',
+        status: 'TODO',
+        priority: 'MEDIUM',
+        tags: ['docs', 'work'],
+        createdAt: expect.any(String),
+        updatedAt: expect.any(String),
+      }),
+    );
+  });
+
+  it('rejects invalid payloads with the standard error envelope', async () => {
+    const { accessToken } = await register();
+
+    const response = await agent
+      .post('/api/taskforge/v1/tasks')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ title: '  ' })
+      .expect(400);
+
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        error: 'Invalid payload',
+        details: expect.any(Object),
+      }),
+    );
+  });
+
+  it('validates pagination parameters', async () => {
+    const { accessToken } = await register();
+
+    const response = await agent
+      .get('/api/taskforge/v1/tasks?page=0&pageSize=-1')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(400);
+
+    expect(response.body).toEqual(
+      expect.objectContaining({ error: 'Invalid payload' }),
+    );
+  });
+});

--- a/apps/api/tests/tasks.http
+++ b/apps/api/tests/tasks.http
@@ -1,13 +1,17 @@
 GET http://localhost:4000/api/taskforge/v1/health
 
 ###
-GET http://localhost:4000/api/taskforge/v1/tasks
-Authorization: Bearer demo
+# Replace {{accessToken}} with the tf_session cookie value returned by auth.http flows.
+
+GET http://localhost:4000/api/taskforge/v1/tasks?page=1&pageSize=10
+Authorization: Bearer {{accessToken}}
+Cookie: tf_session={{accessToken}}
 
 ###
 POST http://localhost:4000/api/taskforge/v1/tasks
 Content-Type: application/json
-Authorization: Bearer demo
+Authorization: Bearer {{accessToken}}
+Cookie: tf_session={{accessToken}}
 
 {
   "title": "Write docs",

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -218,6 +218,197 @@
             "formErrors": []
           }
         }
+      },
+      "TaskRecord": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "TODO",
+              "IN_PROGRESS",
+              "DONE"
+            ]
+          },
+          "priority": {
+            "type": "string",
+            "enum": [
+              "LOW",
+              "MEDIUM",
+              "HIGH"
+            ]
+          },
+          "dueDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "status",
+          "priority",
+          "tags",
+          "createdAt",
+          "updatedAt"
+        ],
+        "example": {
+          "id": "9e22c508-1383-4609-9bbd-2e09b7a2d108",
+          "title": "Draft project brief",
+          "description": "Summarize goals and milestones for the release",
+          "status": "IN_PROGRESS",
+          "priority": "HIGH",
+          "dueDate": "2024-07-10T16:00:00.000Z",
+          "tags": [
+            "planning",
+            "product"
+          ],
+          "createdAt": "2024-06-01T12:00:00.000Z",
+          "updatedAt": "2024-06-03T09:30:00.000Z"
+        }
+      },
+      "TaskCreateInput": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "TODO",
+              "IN_PROGRESS",
+              "DONE"
+            ]
+          },
+          "priority": {
+            "type": "string",
+            "enum": [
+              "LOW",
+              "MEDIUM",
+              "HIGH"
+            ]
+          },
+          "dueDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "required": [
+          "title"
+        ],
+        "example": {
+          "title": "Book product sync",
+          "description": "Coordinate roadmap review with stakeholders",
+          "priority": "HIGH",
+          "tags": [
+            "planning"
+          ],
+          "dueDate": "2024-07-05T15:00:00.000Z"
+        }
+      },
+      "TaskListResponse": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TaskRecord"
+            }
+          },
+          "page": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "pageSize": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "total": {
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "items",
+          "page",
+          "pageSize",
+          "total"
+        ],
+        "example": {
+          "items": [
+            {
+              "id": "9e22c508-1383-4609-9bbd-2e09b7a2d108",
+              "title": "Draft project brief",
+              "description": "Summarize goals and milestones for the release",
+              "status": "IN_PROGRESS",
+              "priority": "HIGH",
+              "dueDate": "2024-07-10T16:00:00.000Z",
+              "tags": [
+                "planning",
+                "product"
+              ],
+              "createdAt": "2024-06-01T12:00:00.000Z",
+              "updatedAt": "2024-06-03T09:30:00.000Z"
+            },
+            {
+              "id": "9e22c508-1383-4609-9bbd-2e09b7a2d108",
+              "title": "Draft project brief",
+              "description": "Summarize goals and milestones for the release",
+              "status": "IN_PROGRESS",
+              "priority": "HIGH",
+              "dueDate": "2024-07-10T16:00:00.000Z",
+              "tags": [
+                "planning",
+                "product"
+              ],
+              "createdAt": "2024-06-01T12:00:00.000Z",
+              "updatedAt": "2024-06-03T09:30:00.000Z"
+            }
+          ],
+          "page": 1,
+          "pageSize": 20,
+          "total": 2
+        }
       }
     }
   },
@@ -617,25 +808,75 @@
             "bearerAuth": []
           }
         ],
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            },
+            "description": "Page number (1-indexed)."
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20
+            },
+            "description": "Number of tasks per page."
+          }
+        ],
         "responses": {
           "200": {
             "description": "Task collection",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "items": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "additionalProperties": true
-                      }
+                  "$ref": "#/components/schemas/TaskListResponse"
+                },
+                "examples": {
+                  "default": {
+                    "value": {
+                      "items": [
+                        {
+                          "id": "9e22c508-1383-4609-9bbd-2e09b7a2d108",
+                          "title": "Draft project brief",
+                          "description": "Summarize goals and milestones for the release",
+                          "status": "IN_PROGRESS",
+                          "priority": "HIGH",
+                          "dueDate": "2024-07-10T16:00:00.000Z",
+                          "tags": [
+                            "planning",
+                            "product"
+                          ],
+                          "createdAt": "2024-06-01T12:00:00.000Z",
+                          "updatedAt": "2024-06-03T09:30:00.000Z"
+                        },
+                        {
+                          "id": "9e22c508-1383-4609-9bbd-2e09b7a2d108",
+                          "title": "Draft project brief",
+                          "description": "Summarize goals and milestones for the release",
+                          "status": "IN_PROGRESS",
+                          "priority": "HIGH",
+                          "dueDate": "2024-07-10T16:00:00.000Z",
+                          "tags": [
+                            "planning",
+                            "product"
+                          ],
+                          "createdAt": "2024-06-01T12:00:00.000Z",
+                          "updatedAt": "2024-06-03T09:30:00.000Z"
+                        }
+                      ],
+                      "page": 1,
+                      "pageSize": 20,
+                      "total": 2
                     }
-                  },
-                  "required": [
-                    "items"
-                  ]
+                  }
                 }
               }
             }
@@ -646,6 +887,13 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unauthorized": {
+                    "value": {
+                      "error": "Unauthorized"
+                    }
+                  }
                 }
               }
             }
@@ -667,8 +915,20 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "additionalProperties": true
+                "$ref": "#/components/schemas/TaskCreateInput"
+              },
+              "examples": {
+                "default": {
+                  "value": {
+                    "title": "Book product sync",
+                    "description": "Coordinate roadmap review with stakeholders",
+                    "priority": "HIGH",
+                    "tags": [
+                      "planning"
+                    ],
+                    "dueDate": "2024-07-05T15:00:00.000Z"
+                  }
+                }
               }
             }
           }
@@ -679,8 +939,25 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "additionalProperties": true
+                  "$ref": "#/components/schemas/TaskRecord"
+                },
+                "examples": {
+                  "default": {
+                    "value": {
+                      "id": "9e22c508-1383-4609-9bbd-2e09b7a2d108",
+                      "title": "Draft project brief",
+                      "description": "Summarize goals and milestones for the release",
+                      "status": "IN_PROGRESS",
+                      "priority": "HIGH",
+                      "dueDate": "2024-07-10T16:00:00.000Z",
+                      "tags": [
+                        "planning",
+                        "product"
+                      ],
+                      "createdAt": "2024-06-01T12:00:00.000Z",
+                      "updatedAt": "2024-06-03T09:30:00.000Z"
+                    }
+                  }
                 }
               }
             }
@@ -691,6 +968,21 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "invalid": {
+                    "value": {
+                      "error": "Invalid payload",
+                      "details": {
+                        "fieldErrors": {
+                          "email": [
+                            "Invalid email address"
+                          ]
+                        },
+                        "formErrors": []
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -701,6 +993,13 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unauthorized": {
+                    "value": {
+                      "error": "Unauthorized"
+                    }
+                  }
                 }
               }
             }


### PR DESCRIPTION
## Summary
- wire GET /api/taskforge/v1/tasks to the Prisma task repository with pagination metadata and shared DTOs
- enable POST /api/taskforge/v1/tasks for creating user-scoped tasks with validation and logging hooks
- refresh Zod schemas, HTTP smoke files, OpenAPI docs, and README guidance for authenticated usage

## Testing
- pnpm -C apps/api test
