### PR TITLE
Raise API test harness timeout for container startup

### DIFF
--- a/apps/api/tests/setup.ts
+++ b/apps/api/tests/setup.ts
@@ -15,7 +15,7 @@ process.env.JWT_SECRET = process.env.JWT_SECRET ?? 'test-secret';
 process.env.JWT_REFRESH_SECRET = process.env.JWT_REFRESH_SECRET ?? 'test-refresh-secret';
 process.env.SESSION_BRIDGE_SECRET = process.env.SESSION_BRIDGE_SECRET ?? 'test-bridge-secret';
 
-jest.setTimeout(60_000);
+jest.setTimeout(120_000);
 
 declare global {
   // eslint-disable-next-line no-var


### PR DESCRIPTION
## Summary
- increase the Jest timeout in the API test harness to 120 seconds so container startup and migrations can finish reliably

