### PR TITLE
Add end-to-end coverage for task CRUD flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ taskforge/
 
 > `make up` builds and starts the Dockerized API/Web services, while the pnpm dev commands are ideal for iterative development outside containers.
 
+## Testing
+
+- **API integration tests** – `pnpm -C apps/api test`
+  - Spins up a disposable Postgres instance, applies Prisma migrations, then runs the Jest/Supertest suite that exercises auth plus the task CRUD/filter flows (tags, cross-user guards, pagination, validation).
+  - The same command runs in CI via `make test` / `make ci`, so keep it green before opening pull requests.
+
 ## Authentication Reference
 > For deeper architectural decisions see [ADR 0001 – Auth strategy](docs/adr/0001-auth-strategy-nextauth-%2B-backend-jwt.md) and the [PRD auth section](docs/PRD.md#authentication).
 

--- a/apps/api/tests/tasks.e2e.test.ts
+++ b/apps/api/tests/tasks.e2e.test.ts
@@ -3,8 +3,8 @@ import type { SuperTest, Test } from 'supertest';
 import type { TaskRepository } from '../src/repositories/task-repository';
 
 import { createTestAgent } from './utils/test-app';
-import { registerTestUser } from './utils/auth';
-import { createUser, defaultPassword } from './utils/factories';
+import { extractSessionCookie, registerTestUser } from './utils/auth';
+import { createTask, createUser, defaultPassword } from './utils/factories';
 
 const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
@@ -19,269 +19,463 @@ describe('Tasks API', () => {
   });
 
   async function register() {
-    const registered = await registerTestUser(agent, { email: 'tasks-user@example.com', password: defaultPassword });
+    const registered = await registerTestUser(agent, {
+      email: 'tasks-user@example.com',
+      password: defaultPassword,
+    });
+
     return {
       accessToken: registered.tokens.accessToken,
+      sessionCookie: extractSessionCookie(registered.cookies),
       userId: registered.user.id,
     };
   }
 
-  it('returns paginated tasks for the authenticated user', async () => {
-    const { accessToken, userId } = await register();
+  function withAuth(request: Test, auth: { accessToken: string; sessionCookie?: string }) {
+    let authed = request.set('Authorization', `Bearer ${auth.accessToken}`);
+    if (auth.sessionCookie) {
+      authed = authed.set('Cookie', auth.sessionCookie);
+    }
+    return authed;
+  }
 
-    await taskRepository.createTask(userId, { title: 'First' });
-    await sleep(2);
-    await taskRepository.createTask(userId, { title: 'Second' });
-    await sleep(2);
-    await taskRepository.createTask(userId, { title: 'Third' });
+  describe('list', () => {
+    it('returns paginated tasks for the authenticated user with metadata', async () => {
+      const auth = await register();
 
-    const other = await createUser({ email: 'other-user@example.com' });
-    await taskRepository.createTask(other.user.id, { title: 'Should not appear' });
+      const first = await createTask({
+        userId: auth.userId,
+        title: 'Calibrate roadmap',
+        description: 'Sync on upcoming milestones',
+        status: 'TODO',
+        priority: 'LOW',
+        dueDate: '2024-01-05T09:00:00.000Z',
+        tags: ['roadmap', 'planning'],
+      });
+      await sleep(5);
+      const second = await createTask({
+        userId: auth.userId,
+        title: 'Publish release notes',
+        description: 'Docs for the Q1 launch',
+        status: 'IN_PROGRESS',
+        priority: 'HIGH',
+        dueDate: '2024-01-15T17:00:00.000Z',
+        tags: ['docs', 'release'],
+      });
+      await sleep(5);
+      const third = await createTask({
+        userId: auth.userId,
+        title: 'Run retrospective',
+        description: 'Team retro for the last sprint',
+        status: 'DONE',
+        priority: 'MEDIUM',
+        dueDate: '2024-01-20T20:00:00.000Z',
+        tags: ['retro', 'team'],
+      });
 
-    const response = await agent
-      .get('/api/taskforge/v1/tasks?page=1&pageSize=2')
-      .set('Authorization', `Bearer ${accessToken}`)
-      .expect(200);
+      const outsider = await createUser({ email: 'outsider@example.com' });
+      await createTask({
+        userId: outsider.user.id,
+        title: 'Should stay hidden',
+        status: 'TODO',
+        dueDate: '2024-01-07T12:00:00.000Z',
+        tags: ['private'],
+      });
 
-    expect(response.body).toEqual(
-      expect.objectContaining({
+      const response = await withAuth(
+        agent.get('/api/taskforge/v1/tasks?page=1&pageSize=2'),
+        auth,
+      ).expect(200);
+
+      expect(response.body).toEqual({
         page: 1,
         pageSize: 2,
         total: 3,
         items: [
-          expect.objectContaining({ title: 'Third' }),
-          expect.objectContaining({ title: 'Second' }),
-        ],
-      }),
-    );
-  });
-
-  it('supports filtering by status, priority, tag, search, and due date range', async () => {
-    const { accessToken, userId } = await register();
-
-    const earlyDue = new Date('2024-01-01T10:00:00.000Z');
-    const targetDue = new Date('2024-01-10T10:00:00.000Z');
-
-    await taskRepository.createTask(userId, {
-      title: 'Plan kickoff',
-      description: 'Kickoff with stakeholders',
-      status: 'TODO',
-      priority: 'LOW',
-      dueDate: earlyDue.toISOString(),
-      tags: ['planning'],
-    });
-
-    await taskRepository.createTask(userId, {
-      title: 'Publish release notes',
-      description: 'Write docs for the Q1 release',
-      status: 'IN_PROGRESS',
-      priority: 'HIGH',
-      dueDate: targetDue.toISOString(),
-      tags: ['docs', 'release'],
-    });
-
-    await taskRepository.createTask(userId, {
-      title: 'File expenses',
-      description: 'Submit reimbursements',
-      status: 'DONE',
-      priority: 'MEDIUM',
-      tags: ['finance'],
-    });
-
-    const response = await agent
-      .get(
-        '/api/taskforge/v1/tasks?page=1&pageSize=10&status=IN_PROGRESS&priority=HIGH&tag=docs&q=release&dueFrom=2024-01-05T00:00:00.000Z&dueTo=2024-01-15T23:59:59.999Z',
-      )
-      .set('Authorization', `Bearer ${accessToken}`)
-      .expect(200);
-
-    expect(response.body).toEqual(
-      expect.objectContaining({
-        total: 1,
-        items: [
-          expect.objectContaining({
+          {
+            id: third.task.id,
+            title: 'Run retrospective',
+            description: 'Team retro for the last sprint',
+            status: 'DONE',
+            priority: 'MEDIUM',
+            dueDate: '2024-01-20T20:00:00.000Z',
+            tags: ['retro', 'team'],
+            createdAt: expect.any(String),
+            updatedAt: expect.any(String),
+          },
+          {
+            id: second.task.id,
             title: 'Publish release notes',
-            tags: ['docs', 'release'],
+            description: 'Docs for the Q1 launch',
             status: 'IN_PROGRESS',
             priority: 'HIGH',
+            dueDate: '2024-01-15T17:00:00.000Z',
+            tags: ['docs', 'release'],
+            createdAt: expect.any(String),
+            updatedAt: expect.any(String),
+          },
+        ],
+      });
+
+      expect(new Date(response.body.items[0].createdAt).toISOString()).toBe(
+        response.body.items[0].createdAt,
+      );
+      expect(new Date(response.body.items[0].updatedAt).getTime()).toBeGreaterThan(0);
+      expect(new Date(response.body.items[1].createdAt).toISOString()).toBe(
+        response.body.items[1].createdAt,
+      );
+      expect(new Date(response.body.items[1].updatedAt).getTime()).toBeGreaterThan(0);
+      expect(
+        response.body.items.find((item: { title: string }) => item.title === 'Should stay hidden'),
+      ).toBeUndefined();
+
+      const secondPage = await withAuth(
+        agent.get('/api/taskforge/v1/tasks?page=2&pageSize=2'),
+        auth,
+      ).expect(200);
+
+      expect(secondPage.body).toEqual({
+        page: 2,
+        pageSize: 2,
+        total: 3,
+        items: [
+          expect.objectContaining({
+            id: first.task.id,
+            title: 'Calibrate roadmap',
+            dueDate: '2024-01-05T09:00:00.000Z',
+            tags: ['planning', 'roadmap'],
           }),
         ],
-      }),
-    );
-  });
-
-  it('creates a task with defaults and returns the record', async () => {
-    const { accessToken } = await register();
-
-    const createResponse = await agent
-      .post('/api/taskforge/v1/tasks')
-      .set('Authorization', `Bearer ${accessToken}`)
-      .send({ title: 'Write docs', tags: ['docs', 'work'] })
-      .expect(201);
-
-    expect(createResponse.body).toEqual(
-      expect.objectContaining({
-        id: expect.any(String),
-        title: 'Write docs',
-        status: 'TODO',
-        priority: 'MEDIUM',
-        tags: ['docs', 'work'],
-        createdAt: expect.any(String),
-        updatedAt: expect.any(String),
-      }),
-    );
-  });
-
-  it('updates a task and returns the fresh record', async () => {
-    const { accessToken, userId } = await register();
-    const created = await taskRepository.createTask(userId, {
-      title: 'Draft proposal',
-      status: 'TODO',
-      tags: ['initial'],
+      });
     });
 
-    await sleep(10);
+    it('requires authentication to list tasks', async () => {
+      const response = await agent.get('/api/taskforge/v1/tasks').expect(401);
+      expect(response.body).toEqual({ error: 'Unauthorized' });
+    });
 
-    const response = await agent
-      .patch(`/api/taskforge/v1/tasks/${created.id}`)
-      .set('Authorization', `Bearer ${accessToken}`)
-      .send({ status: 'IN_PROGRESS', tags: ['planning', 'proposal'] })
-      .expect(200);
+    it('supports filtering by status, priority, tag, search, and due date range', async () => {
+      const auth = await register();
 
-    expect(response.body).toEqual(
-      expect.objectContaining({
-        id: created.id,
+      await createTask({
+        userId: auth.userId,
+        title: 'Plan kickoff',
+        description: 'Kickoff with stakeholders',
+        status: 'TODO',
+        priority: 'LOW',
+        dueDate: '2024-01-01T10:00:00.000Z',
+        tags: ['planning'],
+      });
+
+      const target = await createTask({
+        userId: auth.userId,
+        title: 'Publish release notes',
+        description: 'Write docs for the Q1 release',
         status: 'IN_PROGRESS',
-        title: 'Draft proposal',
-        tags: ['planning', 'proposal'],
+        priority: 'HIGH',
+        dueDate: '2024-01-10T10:00:00.000Z',
+        tags: ['docs', 'release'],
+      });
+
+      await createTask({
+        userId: auth.userId,
+        title: 'File expenses',
+        description: 'Submit reimbursements',
+        status: 'DONE',
+        priority: 'MEDIUM',
+        tags: ['finance'],
+      });
+
+      const response = await withAuth(
+        agent.get(
+          '/api/taskforge/v1/tasks?page=1&pageSize=10&status=IN_PROGRESS&priority=HIGH&tag=docs&q=release&dueFrom=2024-01-05T00:00:00.000Z&dueTo=2024-01-15T23:59:59.999Z',
+        ),
+        auth,
+      ).expect(200);
+
+      expect(response.body).toEqual({
+        page: 1,
+        pageSize: 10,
+        total: 1,
+        items: [
+          {
+            id: target.task.id,
+            title: 'Publish release notes',
+            description: 'Write docs for the Q1 release',
+            status: 'IN_PROGRESS',
+            priority: 'HIGH',
+            dueDate: '2024-01-10T10:00:00.000Z',
+            tags: ['docs', 'release'],
+            createdAt: expect.any(String),
+            updatedAt: expect.any(String),
+          },
+        ],
+      });
+
+      expect(
+        response.body.items.every(
+          (item: { status: string; priority: string; tags: string[]; title: string }) =>
+            item.status === 'IN_PROGRESS' &&
+            item.priority === 'HIGH' &&
+            item.tags.includes('docs') &&
+            item.title.toLowerCase().includes('release'),
+        ),
+      ).toBe(true);
+    });
+
+    it('rejects invalid due date ranges', async () => {
+      const auth = await register();
+
+      const response = await withAuth(
+        agent.get(
+          '/api/taskforge/v1/tasks?dueFrom=2025-01-10T00:00:00.000Z&dueTo=2025-01-01T00:00:00.000Z',
+        ),
+        auth,
+      ).expect(400);
+
+      expect(response.body).toEqual(expect.objectContaining({ error: 'Invalid payload' }));
+    });
+
+    it('validates pagination parameters', async () => {
+      const auth = await register();
+
+      const response = await withAuth(
+        agent.get('/api/taskforge/v1/tasks?page=0&pageSize=-1'),
+        auth,
+      ).expect(400);
+
+      expect(response.body).toEqual(expect.objectContaining({ error: 'Invalid payload' }));
+    });
+  });
+
+  describe('create', () => {
+    it('creates a task with defaults and returns the persisted record', async () => {
+      const auth = await register();
+
+      const createResponse = await withAuth(
+        agent.post('/api/taskforge/v1/tasks').send({
+          title: 'Write API docs',
+          description: 'Outline request/response examples',
+          priority: 'HIGH',
+          tags: [' docs  ', 'api', 'work'],
+          dueDate: '2024-03-01T09:30:00.000Z',
+        }),
+        auth,
+      ).expect(201);
+
+      expect(createResponse.body).toEqual({
+        id: expect.any(String),
+        title: 'Write API docs',
+        description: 'Outline request/response examples',
+        status: 'TODO',
+        priority: 'HIGH',
+        dueDate: '2024-03-01T09:30:00.000Z',
+        tags: ['api', 'docs', 'work'],
+        createdAt: expect.any(String),
         updatedAt: expect.any(String),
-      }),
-    );
+      });
 
-    expect(new Date(response.body.updatedAt).getTime()).toBeGreaterThan(
-      new Date(created.updatedAt).getTime(),
-    );
+      expect(new Date(createResponse.body.createdAt).toISOString()).toBe(
+        createResponse.body.createdAt,
+      );
+      expect(new Date(createResponse.body.updatedAt).getTime()).toBeGreaterThan(0);
+
+      const stored = await taskRepository.listTasks(auth.userId, { pageSize: 10 });
+      expect(stored.total).toBe(1);
+      expect(stored.items[0]).toMatchObject({
+        id: createResponse.body.id,
+        title: 'Write API docs',
+        priority: 'HIGH',
+        dueDate: '2024-03-01T09:30:00.000Z',
+        tags: ['api', 'docs', 'work'],
+      });
+    });
+
+    it('rejects invalid payloads with the standard error envelope', async () => {
+      const auth = await register();
+
+      const response = await withAuth(
+        agent.post('/api/taskforge/v1/tasks').send({ title: '  ' }),
+        auth,
+      ).expect(400);
+
+      expect(response.body).toEqual(
+        expect.objectContaining({
+          error: 'Invalid payload',
+          details: expect.any(Object),
+        }),
+      );
+    });
+
+    it('requires authentication to create tasks', async () => {
+      const response = await agent
+        .post('/api/taskforge/v1/tasks')
+        .send({ title: 'Unauthenticated task' })
+        .expect(401);
+
+      expect(response.body).toEqual({ error: 'Unauthorized' });
+    });
   });
 
-  it('returns 400 when updating with an invalid task id', async () => {
-    const { accessToken } = await register();
+  describe('update', () => {
+    it('updates a task and returns the fresh record with propagated tags', async () => {
+      const auth = await register();
+      const created = await createTask({
+        userId: auth.userId,
+        title: 'Draft proposal',
+        description: 'Initial outline',
+        status: 'TODO',
+        priority: 'LOW',
+        dueDate: '2024-04-01T12:00:00.000Z',
+        tags: ['initial'],
+      });
 
-    const response = await agent
-      .patch('/api/taskforge/v1/tasks/not-a-uuid')
-      .set('Authorization', `Bearer ${accessToken}`)
-      .send({ title: 'Renamed' })
-      .expect(400);
+      await sleep(10);
 
-    expect(response.body).toEqual({ error: 'Invalid identifier' });
+      const response = await withAuth(
+        agent.patch(`/api/taskforge/v1/tasks/${created.task.id}`).send({
+          title: 'Draft proposal v2',
+          description: 'Expanded with metrics',
+          status: 'IN_PROGRESS',
+          priority: 'HIGH',
+          dueDate: '2024-04-05T15:00:00.000Z',
+          tags: ['planning', 'proposal'],
+        }),
+        auth,
+      ).expect(200);
+
+      expect(response.body).toEqual({
+        id: created.task.id,
+        title: 'Draft proposal v2',
+        description: 'Expanded with metrics',
+        status: 'IN_PROGRESS',
+        priority: 'HIGH',
+        dueDate: '2024-04-05T15:00:00.000Z',
+        tags: ['planning', 'proposal'],
+        createdAt: created.task.createdAt,
+        updatedAt: expect.any(String),
+      });
+
+      expect(new Date(response.body.updatedAt).getTime()).toBeGreaterThan(
+        new Date(created.task.updatedAt).getTime(),
+      );
+
+      const refreshed = await taskRepository.listTasks(auth.userId);
+      expect(refreshed.total).toBe(1);
+      expect(refreshed.items[0]).toMatchObject({
+        id: created.task.id,
+        title: 'Draft proposal v2',
+        description: 'Expanded with metrics',
+        status: 'IN_PROGRESS',
+        priority: 'HIGH',
+        dueDate: '2024-04-05T15:00:00.000Z',
+        tags: ['planning', 'proposal'],
+      });
+      expect(refreshed.items[0].tags).not.toContain('initial');
+    });
+
+    it('returns 400 when updating with an invalid task id', async () => {
+      const auth = await register();
+
+      const response = await withAuth(
+        agent.patch('/api/taskforge/v1/tasks/not-a-uuid').send({ title: 'Renamed' }),
+        auth,
+      ).expect(400);
+
+      expect(response.body).toEqual({ error: 'Invalid identifier' });
+    });
+
+    it('returns validation errors for malformed updates', async () => {
+      const auth = await register();
+      const created = await createTask({ userId: auth.userId, title: 'Fix lint' });
+
+      const response = await withAuth(
+        agent.patch(`/api/taskforge/v1/tasks/${created.task.id}`).send({ dueDate: 'not-a-date' }),
+        auth,
+      ).expect(400);
+
+      expect(response.body).toEqual(
+        expect.objectContaining({ error: 'Invalid payload', details: expect.any(Object) }),
+      );
+    });
+
+    it('requires authentication to update tasks', async () => {
+      const created = await createTask({ title: 'Hidden task' });
+
+      const response = await agent
+        .patch(`/api/taskforge/v1/tasks/${created.task.id}`)
+        .send({ title: 'Blocked' })
+        .expect(401);
+
+      expect(response.body).toEqual({ error: 'Unauthorized' });
+    });
+
+    it("returns 404 when attempting to update another user's task", async () => {
+      const auth = await register();
+      const someoneElse = await createUser({ email: 'someone-else@example.com' });
+      const foreignTask = await createTask({ userId: someoneElse.user.id, title: 'Secret task' });
+
+      const response = await withAuth(
+        agent.patch(`/api/taskforge/v1/tasks/${foreignTask.task.id}`).send({ title: 'Hacked' }),
+        auth,
+      ).expect(404);
+
+      expect(response.body).toEqual({ error: 'Not found' });
+    });
   });
 
-  it("returns 404 when attempting to update another user's task", async () => {
-    const { accessToken } = await register();
-    const someoneElse = await createUser({ email: 'someone-else@example.com' });
-    const foreignTask = await taskRepository.createTask(someoneElse.user.id, { title: 'Secret task' });
+  describe('delete', () => {
+    it('deletes a task and returns a confirmation payload', async () => {
+      const auth = await register();
+      const created = await createTask({
+        userId: auth.userId,
+        title: 'Archive me',
+        tags: ['cleanup'],
+      });
 
-    await agent
-      .patch(`/api/taskforge/v1/tasks/${foreignTask.id}`)
-      .set('Authorization', `Bearer ${accessToken}`)
-      .send({ title: 'Hacked' })
-      .expect(404);
-  });
+      const response = await withAuth(
+        agent.delete(`/api/taskforge/v1/tasks/${created.task.id}`),
+        auth,
+      ).expect(200);
 
-  it('returns validation errors for malformed updates', async () => {
-    const { accessToken, userId } = await register();
-    const created = await taskRepository.createTask(userId, { title: 'Fix lint' });
+      expect(response.body).toEqual({ id: created.task.id, status: 'deleted' });
 
-    const response = await agent
-      .patch(`/api/taskforge/v1/tasks/${created.id}`)
-      .set('Authorization', `Bearer ${accessToken}`)
-      .send({ dueDate: 'not-a-date' })
-      .expect(400);
+      const remaining = await taskRepository.listTasks(auth.userId);
+      expect(remaining.total).toBe(0);
+    });
 
-    expect(response.body).toEqual(
-      expect.objectContaining({
-        error: 'Invalid payload',
-        details: expect.any(Object),
-      }),
-    );
-  });
+    it('returns 400 when deleting with an invalid task id', async () => {
+      const auth = await register();
 
-  it('deletes a task and returns a confirmation payload', async () => {
-    const { accessToken, userId } = await register();
-    const created = await taskRepository.createTask(userId, { title: 'Archive me' });
+      const response = await withAuth(
+        agent.delete('/api/taskforge/v1/tasks/not-a-uuid'),
+        auth,
+      ).expect(400);
 
-    const response = await agent
-      .delete(`/api/taskforge/v1/tasks/${created.id}`)
-      .set('Authorization', `Bearer ${accessToken}`)
-      .expect(200);
+      expect(response.body).toEqual({ error: 'Invalid identifier' });
+    });
 
-    expect(response.body).toEqual({ id: created.id, status: 'deleted' });
+    it('requires authentication to delete tasks', async () => {
+      const created = await createTask({ title: 'Do not remove' });
 
-    const remaining = await taskRepository.listTasks(userId);
-    expect(remaining.total).toBe(0);
-  });
+      const response = await agent
+        .delete(`/api/taskforge/v1/tasks/${created.task.id}`)
+        .expect(401);
 
-  it('returns 400 when deleting with an invalid task id', async () => {
-    const { accessToken } = await register();
+      expect(response.body).toEqual({ error: 'Unauthorized' });
+    });
 
-    const response = await agent
-      .delete('/api/taskforge/v1/tasks/not-a-uuid')
-      .set('Authorization', `Bearer ${accessToken}`)
-      .expect(400);
+    it("returns 404 when attempting to delete another user's task", async () => {
+      const auth = await register();
+      const someoneElse = await createUser({ email: 'delete-other@example.com' });
+      const foreignTask = await createTask({ userId: someoneElse.user.id, title: 'Keep out' });
 
-    expect(response.body).toEqual({ error: 'Invalid identifier' });
-  });
+      const response = await withAuth(
+        agent.delete(`/api/taskforge/v1/tasks/${foreignTask.task.id}`),
+        auth,
+      ).expect(404);
 
-  it("returns 404 when attempting to delete another user's task", async () => {
-    const { accessToken } = await register();
-    const someoneElse = await createUser({ email: 'delete-other@example.com' });
-    const foreignTask = await taskRepository.createTask(someoneElse.user.id, { title: 'Keep out' });
-
-    await agent
-      .delete(`/api/taskforge/v1/tasks/${foreignTask.id}`)
-      .set('Authorization', `Bearer ${accessToken}`)
-      .expect(404);
-  });
-
-  it('rejects invalid payloads with the standard error envelope', async () => {
-    const { accessToken } = await register();
-
-    const response = await agent
-      .post('/api/taskforge/v1/tasks')
-      .set('Authorization', `Bearer ${accessToken}`)
-      .send({ title: '  ' })
-      .expect(400);
-
-    expect(response.body).toEqual(
-      expect.objectContaining({
-        error: 'Invalid payload',
-        details: expect.any(Object),
-      }),
-    );
-  });
-
-  it('validates pagination parameters', async () => {
-    const { accessToken } = await register();
-
-    const response = await agent
-      .get('/api/taskforge/v1/tasks?page=0&pageSize=-1')
-      .set('Authorization', `Bearer ${accessToken}`)
-      .expect(400);
-
-    expect(response.body).toEqual(
-      expect.objectContaining({ error: 'Invalid payload' }),
-    );
-  });
-
-  it('rejects invalid due date ranges', async () => {
-    const { accessToken } = await register();
-
-    const response = await agent
-      .get(
-        '/api/taskforge/v1/tasks?dueFrom=2025-01-10T00:00:00.000Z&dueTo=2025-01-01T00:00:00.000Z',
-      )
-      .set('Authorization', `Bearer ${accessToken}`)
-      .expect(400);
-
-    expect(response.body).toEqual(expect.objectContaining({ error: 'Invalid payload' }));
+      expect(response.body).toEqual({ error: 'Not found' });
+    });
   });
 });

--- a/apps/api/tests/tasks.http
+++ b/apps/api/tests/tasks.http
@@ -21,9 +21,11 @@ Authorization: Bearer {{accessToken}}
 Cookie: tf_session={{accessToken}}
 
 {
-  "title": "Write docs",
-  "tags": ["work","docs"],
-  "dueDate": "2025-10-08T10:00:00.000Z"
+  "title": "Write API docs",
+  "description": "Outline request/response examples",
+  "priority": "HIGH",
+  "tags": ["api", "docs", "work"],
+  "dueDate": "2024-03-01T09:30:00.000Z"
 }
 
 ###
@@ -33,9 +35,12 @@ Authorization: Bearer {{accessToken}}
 Cookie: tf_session={{accessToken}}
 
 {
+  "title": "Draft proposal v2",
+  "description": "Expanded with metrics",
   "status": "IN_PROGRESS",
-  "tags": ["planning", "docs"],
-  "dueDate": "2025-11-01T17:00:00.000Z"
+  "priority": "HIGH",
+  "tags": ["planning", "proposal"],
+  "dueDate": "2024-04-05T15:00:00.000Z"
 }
 
 ###


### PR DESCRIPTION
## Summary
- add comprehensive Jest/Supertest coverage for the tasks CRUD and filtering scenarios, including authorization and validation edges
- refresh the HTTP examples to mirror the new task fixtures
- document the API integration test command in the root README

## Testing
- pnpm -C apps/api test

