### PR TITLE
feat: add typed task API client

### DIFF
--- a/apps/web/lib/tasks-client.test.ts
+++ b/apps/web/lib/tasks-client.test.ts
@@ -83,6 +83,21 @@ describe('tasks-client', () => {
       expect(headers.get('content-type')).toBeNull();
     });
 
+    it('supports relative base URLs on the server', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+      delete (globalThis as Record<string, unknown>).window;
+
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(jsonResponse({ items: [], page: 1, pageSize: 20, total: 0 }));
+
+      await listTasks(undefined, { baseUrl: '/api/taskforge', fetchImpl: fetchMock });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url] = fetchMock.mock.calls[0];
+      expect(url).toBe('/api/taskforge/v1/tasks');
+    });
+
     it('throws a validation error when filters are invalid', async () => {
       await expect(
         listTasks(

--- a/apps/web/lib/tasks-client.test.ts
+++ b/apps/web/lib/tasks-client.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  clearManualTaskClientAuthState,
+  createTask,
+  deleteTask,
+  listTasks,
+  TaskClientError,
+  updateTask,
+  withTaskClientAuth,
+} from './tasks-client';
+
+const API_BASE_URL = 'https://api.example.com/api/taskforge';
+
+const sampleTask = {
+  id: '11111111-1111-4111-8111-111111111111',
+  title: 'Draft API contract',
+  description: 'Outline request and response shapes for task endpoints',
+  status: 'TODO' as const,
+  priority: 'HIGH' as const,
+  dueDate: '2024-07-01T10:00:00.000Z',
+  tags: ['planning'],
+  createdAt: '2024-06-01T12:00:00.000Z',
+  updatedAt: '2024-06-01T12:00:00.000Z',
+};
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: {
+      'content-type': 'application/json',
+    },
+  });
+}
+
+const originalWindow = globalThis.window;
+
+describe('tasks-client', () => {
+  afterEach(() => {
+    clearManualTaskClientAuthState();
+    if (originalWindow) {
+      globalThis.window = originalWindow;
+    } else {
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+      delete (globalThis as Record<string, unknown>).window;
+    }
+  });
+
+  describe('listTasks', () => {
+    it('serializes filters and includes credentials on the browser', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        jsonResponse({ items: [], page: 1, pageSize: 20, total: 0 }),
+      );
+
+      const result = await listTasks(
+        {
+          page: 2,
+          pageSize: 50,
+          status: 'IN_PROGRESS',
+          priority: 'MEDIUM',
+          tag: ['frontend', 'api'],
+          q: '   sprint ',
+          dueFrom: '2024-06-01T00:00:00.000Z',
+        },
+        { baseUrl: API_BASE_URL, fetchImpl: fetchMock },
+      );
+
+      expect(result).toEqual({ items: [], page: 1, pageSize: 20, total: 0 });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toContain('/v1/tasks');
+      const parsedUrl = new URL(url as string);
+      expect(parsedUrl.searchParams.get('page')).toBe('2');
+      expect(parsedUrl.searchParams.get('pageSize')).toBe('50');
+      expect(parsedUrl.searchParams.get('status')).toBe('IN_PROGRESS');
+      expect(parsedUrl.searchParams.get('priority')).toBe('MEDIUM');
+      expect(parsedUrl.searchParams.getAll('tag')).toEqual(['frontend', 'api']);
+      expect(parsedUrl.searchParams.get('q')).toBe('sprint');
+      expect(parsedUrl.searchParams.get('dueFrom')).toBe('2024-06-01T00:00:00.000Z');
+      expect((init as RequestInit)?.credentials).toBe('include');
+      const headers = (init as RequestInit).headers as Headers;
+      expect(headers.get('accept')).toBe('application/json');
+      expect(headers.get('content-type')).toBeNull();
+    });
+
+    it('throws a validation error when filters are invalid', async () => {
+      await expect(
+        listTasks(
+          {
+            page: 0,
+          },
+          { baseUrl: API_BASE_URL, fetchImpl: vi.fn() },
+        ),
+      ).rejects.toMatchObject({ kind: 'validation' satisfies TaskClientError['kind'] });
+    });
+  });
+
+  describe('createTask', () => {
+    it('performs client-side validation before sending the request', async () => {
+      await expect(
+        createTask(
+          {
+            // @ts-expect-error intentionally invalid title
+            title: '   ',
+          },
+          { baseUrl: API_BASE_URL, fetchImpl: vi.fn() },
+        ),
+      ).rejects.toMatchObject({ kind: 'validation' satisfies TaskClientError['kind'] });
+    });
+
+    it('sends the session cookie when running on the server', async () => {
+      // Simulate server environment
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+      delete (globalThis as Record<string, unknown>).window;
+
+      const fetchMock = vi.fn().mockResolvedValue(jsonResponse(sampleTask));
+      await createTask(
+        {
+          title: 'Draft API contract',
+          description: 'Outline request and response shapes for task endpoints',
+          status: 'TODO',
+          priority: 'HIGH',
+          dueDate: '2024-07-01T10:00:00.000Z',
+          tags: ['planning'],
+        },
+        { baseUrl: API_BASE_URL, fetchImpl: fetchMock, sessionCookie: 'cookie-123' },
+      );
+
+      const [, init] = fetchMock.mock.calls[0];
+      const headers = (init as RequestInit).headers as Headers;
+      expect(headers.get('cookie')).toBe('tf_session=cookie-123');
+      expect(headers.get('content-type')).toBe('application/json');
+    });
+  });
+
+  describe('updateTask', () => {
+    it('attaches a bearer token when provided', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ ...sampleTask, status: 'DONE' }));
+
+      await updateTask(
+        sampleTask.id,
+        { status: 'DONE' },
+        { baseUrl: API_BASE_URL, fetchImpl: fetchMock, accessToken: 'token-123' },
+      );
+
+      const [, init] = fetchMock.mock.calls[0];
+      const headers = (init as RequestInit).headers as Headers;
+      expect(headers.get('authorization')).toBe('Bearer token-123');
+    });
+
+    it('throws a serialization error when the server response is malformed', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        jsonResponse({
+          id: sampleTask.id,
+          title: sampleTask.title,
+        }),
+      );
+
+      await expect(
+        updateTask(sampleTask.id, { status: 'DONE' }, { baseUrl: API_BASE_URL, fetchImpl: fetchMock }),
+      ).rejects.toMatchObject({ kind: 'serialization' satisfies TaskClientError['kind'] });
+    });
+  });
+
+  describe('deleteTask', () => {
+    it('propagates structured API errors', async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(jsonResponse({ error: 'Unauthorized' }, 401));
+
+      await expect(deleteTask(sampleTask.id, { baseUrl: API_BASE_URL, fetchImpl: fetchMock })).rejects.toMatchObject({
+        kind: 'http' satisfies TaskClientError['kind'],
+        status: 401,
+        error: 'Unauthorized',
+      });
+    });
+  });
+
+  describe('withTaskClientAuth', () => {
+    it('binds the session cookie to nested requests on the server', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+      delete (globalThis as Record<string, unknown>).window;
+      const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ items: [], page: 1, pageSize: 20, total: 0 }));
+
+      await withTaskClientAuth({ sessionCookie: 'server-cookie' }, async () => {
+        await listTasks(undefined, { baseUrl: API_BASE_URL, fetchImpl: fetchMock });
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [, init] = fetchMock.mock.calls[0];
+      const headers = (init as RequestInit).headers as Headers;
+      expect(headers.get('cookie')).toBe('tf_session=server-cookie');
+    });
+  });
+});

--- a/apps/web/lib/tasks-client.ts
+++ b/apps/web/lib/tasks-client.ts
@@ -353,10 +353,10 @@ function toQueryRecord(query?: NormalizedTaskListQuery): Record<string, string |
 
 function buildUrl(baseUrl: string, path: string, query?: Record<string, string | string[]>): string {
   const normalizedPath = path.startsWith('/') ? path : `/${path}`;
-  const url = new URL(`${baseUrl}${normalizedPath}`);
+  let url = `${baseUrl}${normalizedPath}`;
 
   if (query) {
-    const params = url.searchParams;
+    const params = new URLSearchParams();
     Object.entries(query).forEach(([key, value]) => {
       if (Array.isArray(value)) {
         value.forEach((entry) => {
@@ -366,9 +366,14 @@ function buildUrl(baseUrl: string, path: string, query?: Record<string, string |
         params.append(key, value);
       }
     });
+
+    const queryString = params.toString();
+    if (queryString) {
+      url += `?${queryString}`;
+    }
   }
 
-  return url.toString();
+  return url;
 }
 
 async function applyAuth(headers: Headers, options?: TaskClientRequestOptions): Promise<RequestCredentials | undefined> {

--- a/apps/web/lib/tasks-client.ts
+++ b/apps/web/lib/tasks-client.ts
@@ -1,0 +1,631 @@
+import { getSessionCookieName, type TaskDTO, type TaskRecordDTO, type TaskPriority, type TaskStatus } from '@taskforge/shared';
+import { z } from 'zod';
+
+import { getApiBaseUrl } from './env';
+
+const SESSION_COOKIE_NAME = getSessionCookieName();
+
+const TaskStatusSchema = z.union([z.literal('TODO'), z.literal('IN_PROGRESS'), z.literal('DONE')]);
+const TaskPrioritySchema = z.union([z.literal('LOW'), z.literal('MEDIUM'), z.literal('HIGH')]);
+
+const NonEmptyTrimmedString = z.string().trim().min(1);
+
+const NullableDateString = z
+  .string()
+  .datetime()
+  .optional()
+  .nullable()
+  .transform((value) => value ?? undefined);
+
+const NullableString = z
+  .string()
+  .trim()
+  .min(1)
+  .optional()
+  .nullable()
+  .transform((value) => value ?? undefined);
+
+const TaskRecordSchema = z.object({
+  id: z.string().uuid(),
+  title: NonEmptyTrimmedString,
+  description: NullableString,
+  status: TaskStatusSchema,
+  priority: TaskPrioritySchema,
+  dueDate: NullableDateString,
+  tags: z.array(z.string().min(1)).default([]),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+});
+
+const TaskListResponseSchema = z.object({
+  items: z.array(TaskRecordSchema),
+  page: z.number().int().min(1),
+  pageSize: z.number().int().min(1).max(100),
+  total: z.number().int().min(0),
+});
+
+const TaskDeleteResponseSchema = z.object({
+  id: z.string().uuid(),
+  status: z.literal('deleted'),
+});
+
+const ErrorResponseSchema = z.object({
+  error: z.string(),
+  details: z.unknown().nullish(),
+});
+
+const TaskIdSchema = z.string().uuid({ message: 'Task id must be a valid UUID.' });
+
+const TaskCreateSchema = z
+  .object({
+    title: NonEmptyTrimmedString,
+    description: NullableString,
+    status: TaskStatusSchema.optional(),
+    priority: TaskPrioritySchema.optional(),
+    dueDate: NullableDateString,
+    tags: z.array(NonEmptyTrimmedString).optional(),
+  })
+  .transform((value) => ({
+    ...value,
+    tags: value.tags ?? [],
+  }));
+
+const TaskUpdateSchema = z
+  .object({
+    title: NonEmptyTrimmedString.optional(),
+    description: NullableString,
+    status: TaskStatusSchema.optional(),
+    priority: TaskPrioritySchema.optional(),
+    dueDate: NullableDateString,
+    tags: z.array(NonEmptyTrimmedString).optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (Object.values(value).every((entry) => entry === undefined)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: [],
+        message: 'Update payload must include at least one field.',
+      });
+    }
+  })
+  .transform((value) => ({
+    ...value,
+    tags: value.tags ?? undefined,
+  }));
+
+const TaskListQuerySchema = z
+  .object({
+    page: z.number().int().min(1).optional(),
+    pageSize: z.number().int().min(1).max(100).optional(),
+    status: TaskStatusSchema.optional(),
+    priority: TaskPrioritySchema.optional(),
+    tag: z
+      .union([NonEmptyTrimmedString, z.array(NonEmptyTrimmedString)])
+      .optional()
+      .transform((value) => {
+        if (!value) {
+          return undefined;
+        }
+        return Array.isArray(value) ? value : [value];
+      }),
+    q: z.string().trim().min(1).optional().transform((value) => value?.trim()),
+    dueFrom: z.string().datetime().optional(),
+    dueTo: z.string().datetime().optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.dueFrom && value.dueTo) {
+      const from = Date.parse(value.dueFrom);
+      const to = Date.parse(value.dueTo);
+      if (!Number.isNaN(from) && !Number.isNaN(to) && from > to) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['dueFrom'],
+          message: 'dueFrom must be earlier than or equal to dueTo.',
+        });
+      }
+    }
+  });
+
+export type TaskListResponse = z.infer<typeof TaskListResponseSchema>;
+export type TaskDeleteResponse = z.infer<typeof TaskDeleteResponseSchema>;
+
+export type CreateTaskInput = Omit<TaskDTO, 'id'>;
+export type UpdateTaskInput = Partial<Omit<TaskDTO, 'id'>>;
+export type TaskListQuery = {
+  page?: number;
+  pageSize?: number;
+  status?: TaskStatus;
+  priority?: TaskPriority;
+  tag?: string | string[];
+  q?: string;
+  dueFrom?: string;
+  dueTo?: string;
+};
+
+type NormalizedTaskListQuery = z.infer<typeof TaskListQuerySchema>;
+
+export type TaskClientErrorKind = 'validation' | 'http' | 'network' | 'serialization';
+
+export interface TaskClientErrorInit {
+  kind: TaskClientErrorKind;
+  status?: number;
+  error?: string;
+  details?: unknown;
+  issues?: z.ZodIssue[];
+  cause?: unknown;
+}
+
+export class TaskClientError extends Error {
+  readonly kind: TaskClientErrorKind;
+  readonly status?: number;
+  readonly error?: string;
+  readonly details?: unknown;
+  readonly issues?: z.ZodIssue[];
+
+  constructor(message: string, init: TaskClientErrorInit) {
+    super(message);
+    this.name = 'TaskClientError';
+    this.kind = init.kind;
+    this.status = init.status;
+    this.error = init.error;
+    this.details = init.details;
+    this.issues = init.issues;
+
+    if (init.cause !== undefined) {
+      // @ts-expect-error Node 18 target may not include the cause property
+      this.cause = init.cause;
+    }
+
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+export interface TaskClientAuthState {
+  sessionCookie?: string;
+  accessToken?: string;
+}
+
+export interface TaskClientRequestOptions extends TaskClientAuthState {
+  baseUrl?: string;
+  fetchImpl?: typeof fetch;
+  signal?: AbortSignal;
+  headers?: HeadersInit;
+  cookieHeader?: string;
+  credentials?: RequestCredentials;
+}
+
+let manualServerAuthState: TaskClientAuthState | undefined;
+let triedLoadingNextCookies = false;
+let nextCookiesGetter: (() => { get(name: string): { value?: string } | undefined } | undefined) | undefined;
+let serverAuthStoragePromise: Promise<import('node:async_hooks').AsyncLocalStorage<TaskClientAuthState> | null> | null = null;
+let serverAuthStorage: import('node:async_hooks').AsyncLocalStorage<TaskClientAuthState> | null | undefined;
+
+function isBrowser(): boolean {
+  return typeof window !== 'undefined' && typeof window.document !== 'undefined';
+}
+
+async function loadServerAuthStorage(): Promise<import('node:async_hooks').AsyncLocalStorage<TaskClientAuthState> | null> {
+  if (isBrowser()) {
+    return null;
+  }
+
+  if (serverAuthStorage !== undefined) {
+    return serverAuthStorage;
+  }
+
+  if (serverAuthStoragePromise) {
+    return serverAuthStoragePromise;
+  }
+
+  serverAuthStoragePromise = import('node:async_hooks')
+    .then((module) => {
+      serverAuthStorage = new module.AsyncLocalStorage<TaskClientAuthState>();
+      return serverAuthStorage;
+    })
+    .catch(() => {
+      serverAuthStorage = null;
+      return null;
+    })
+    .finally(() => {
+      serverAuthStoragePromise = null;
+    });
+
+  return serverAuthStoragePromise;
+}
+
+async function getServerAuthState(): Promise<TaskClientAuthState | undefined> {
+  if (isBrowser()) {
+    return undefined;
+  }
+
+  const storage = await loadServerAuthStorage();
+  if (storage) {
+    return storage.getStore() ?? undefined;
+  }
+
+  return manualServerAuthState;
+}
+
+async function tryReadNextSessionCookie(): Promise<string | undefined> {
+  if (isBrowser()) {
+    return undefined;
+  }
+
+  if (!triedLoadingNextCookies) {
+    triedLoadingNextCookies = true;
+    try {
+      const module = await import('next/headers');
+      if (typeof module.cookies === 'function') {
+        nextCookiesGetter = module.cookies;
+      } else {
+        nextCookiesGetter = undefined;
+      }
+    } catch {
+      nextCookiesGetter = undefined;
+    }
+  }
+
+  if (!nextCookiesGetter) {
+    return undefined;
+  }
+
+  try {
+    const cookieStore = nextCookiesGetter();
+    const cookie = cookieStore?.get?.(SESSION_COOKIE_NAME);
+    return cookie?.value;
+  } catch {
+    return undefined;
+  }
+}
+
+async function resolveSessionCookie(options?: TaskClientRequestOptions): Promise<string | undefined> {
+  if (options?.sessionCookie) {
+    return options.sessionCookie;
+  }
+
+  const state = await getServerAuthState();
+  if (state?.sessionCookie) {
+    return state.sessionCookie;
+  }
+
+  return tryReadNextSessionCookie();
+}
+
+async function resolveAccessToken(options?: TaskClientRequestOptions): Promise<string | undefined> {
+  if (options?.accessToken) {
+    return options.accessToken;
+  }
+
+  const state = await getServerAuthState();
+  return state?.accessToken;
+}
+
+function ensureBaseUrl(options?: TaskClientRequestOptions): string {
+  const fromOptions = options?.baseUrl;
+  if (fromOptions) {
+    return fromOptions.replace(/\/$/, '');
+  }
+
+  return getApiBaseUrl();
+}
+
+function toQueryRecord(query?: NormalizedTaskListQuery): Record<string, string | string[]> | undefined {
+  if (!query) {
+    return undefined;
+  }
+
+  const record: Record<string, string | string[]> = {};
+
+  if (query.page !== undefined) {
+    record.page = String(query.page);
+  }
+
+  if (query.pageSize !== undefined) {
+    record.pageSize = String(query.pageSize);
+  }
+
+  if (query.status) {
+    record.status = query.status;
+  }
+
+  if (query.priority) {
+    record.priority = query.priority;
+  }
+
+  if (query.tag && query.tag.length > 0) {
+    record.tag = query.tag;
+  }
+
+  if (query.q) {
+    record.q = query.q;
+  }
+
+  if (query.dueFrom) {
+    record.dueFrom = query.dueFrom;
+  }
+
+  if (query.dueTo) {
+    record.dueTo = query.dueTo;
+  }
+
+  return record;
+}
+
+function buildUrl(baseUrl: string, path: string, query?: Record<string, string | string[]>): string {
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  const url = new URL(`${baseUrl}${normalizedPath}`);
+
+  if (query) {
+    const params = url.searchParams;
+    Object.entries(query).forEach(([key, value]) => {
+      if (Array.isArray(value)) {
+        value.forEach((entry) => {
+          params.append(key, entry);
+        });
+      } else if (value !== undefined) {
+        params.append(key, value);
+      }
+    });
+  }
+
+  return url.toString();
+}
+
+async function applyAuth(headers: Headers, options?: TaskClientRequestOptions): Promise<RequestCredentials | undefined> {
+  const explicitCookieHeader = options?.cookieHeader;
+  if (explicitCookieHeader) {
+    headers.set('cookie', explicitCookieHeader);
+  } else if (!isBrowser()) {
+    const cookie = await resolveSessionCookie(options);
+    if (cookie && !headers.has('cookie')) {
+      headers.set('cookie', `${SESSION_COOKIE_NAME}=${cookie}`);
+    }
+  }
+
+  const accessToken = await resolveAccessToken(options);
+  if (accessToken) {
+    headers.set('authorization', accessToken.startsWith('Bearer ') ? accessToken : `Bearer ${accessToken}`);
+  }
+
+  if (options?.credentials) {
+    return options.credentials;
+  }
+
+  if (isBrowser()) {
+    return 'include';
+  }
+
+  return undefined;
+}
+
+async function parseJson<T>(response: Response, schema: z.ZodSchema<T>): Promise<T> {
+  const raw = await response.json().catch(() => {
+    throw new TaskClientError('Failed to parse response body as JSON.', {
+      kind: 'serialization',
+      status: response.status,
+    });
+  });
+
+  const parsed = schema.safeParse(raw);
+  if (!parsed.success) {
+    throw new TaskClientError('Response payload was not in the expected shape.', {
+      kind: 'serialization',
+      status: response.status,
+      issues: parsed.error.issues,
+    });
+  }
+
+  return parsed.data;
+}
+
+async function handleError(response: Response): Promise<never> {
+  let payload: z.infer<typeof ErrorResponseSchema> | undefined;
+
+  try {
+    payload = ErrorResponseSchema.parse(await response.clone().json());
+  } catch {
+    // ignore parse errors and fallback to plain text below
+  }
+
+  if (!payload) {
+    try {
+      const text = await response.text();
+      throw new TaskClientError(`Request failed with status ${response.status}.`, {
+        kind: 'http',
+        status: response.status,
+        details: text || undefined,
+      });
+    } catch (error) {
+      throw new TaskClientError(`Request failed with status ${response.status}.`, {
+        kind: 'http',
+        status: response.status,
+        cause: error,
+      });
+    }
+  }
+
+  throw new TaskClientError(payload.error || 'Request failed.', {
+    kind: 'http',
+    status: response.status,
+    error: payload.error,
+    details: payload.details ?? undefined,
+  });
+}
+
+async function requestJson<T>(
+  path: string,
+  init: {
+    method: string;
+    body?: unknown;
+    query?: Record<string, string | string[]>;
+    schema: z.ZodSchema<T>;
+  },
+  options?: TaskClientRequestOptions,
+): Promise<T> {
+  const baseUrl = ensureBaseUrl(options);
+  const url = buildUrl(baseUrl, path, init.query);
+
+  const headers = new Headers(options?.headers ?? {});
+  headers.set('accept', 'application/json');
+
+  let body: string | undefined;
+  if (init.body !== undefined) {
+    headers.set('content-type', 'application/json');
+    body = JSON.stringify(init.body);
+  }
+
+  const fetchImpl = options?.fetchImpl ?? globalThis.fetch;
+  if (typeof fetchImpl !== 'function') {
+    throw new TaskClientError('Fetch API is not available in this environment.', {
+      kind: 'network',
+    });
+  }
+
+  const credentials = await applyAuth(headers, options);
+
+  const response = await fetchImpl(url, {
+    method: init.method,
+    headers,
+    body,
+    signal: options?.signal,
+    credentials,
+  }).catch((error: unknown) => {
+    throw new TaskClientError('Network request failed.', {
+      kind: 'network',
+      cause: error,
+    });
+  });
+
+  if (!response.ok) {
+    await handleError(response);
+  }
+
+  return parseJson(response, init.schema);
+}
+
+export async function listTasks(
+  params?: TaskListQuery,
+  options?: TaskClientRequestOptions,
+): Promise<TaskListResponse> {
+  let normalizedQuery: NormalizedTaskListQuery | undefined;
+  if (params) {
+    const parsed = TaskListQuerySchema.safeParse(params);
+    if (!parsed.success) {
+      throw new TaskClientError('Task filters were invalid.', {
+        kind: 'validation',
+        issues: parsed.error.issues,
+      });
+    }
+    normalizedQuery = parsed.data;
+  }
+
+  return requestJson(
+    'v1/tasks',
+    {
+      method: 'GET',
+      query: toQueryRecord(normalizedQuery),
+      schema: TaskListResponseSchema,
+    },
+    options,
+  );
+}
+
+export async function createTask(
+  input: CreateTaskInput,
+  options?: TaskClientRequestOptions,
+): Promise<TaskRecordDTO> {
+  const parsed = TaskCreateSchema.safeParse(input);
+  if (!parsed.success) {
+    throw new TaskClientError('Task payload was invalid.', {
+      kind: 'validation',
+      issues: parsed.error.issues,
+    });
+  }
+
+  return requestJson(
+    'v1/tasks',
+    {
+      method: 'POST',
+      body: parsed.data,
+      schema: TaskRecordSchema,
+    },
+    options,
+  );
+}
+
+export async function updateTask(
+  id: string,
+  input: UpdateTaskInput,
+  options?: TaskClientRequestOptions,
+): Promise<TaskRecordDTO> {
+  const validatedId = TaskIdSchema.safeParse(id);
+  if (!validatedId.success) {
+    throw new TaskClientError('Task identifier was invalid.', {
+      kind: 'validation',
+      issues: validatedId.error.issues,
+    });
+  }
+
+  const parsed = TaskUpdateSchema.safeParse(input);
+  if (!parsed.success) {
+    throw new TaskClientError('Task update payload was invalid.', {
+      kind: 'validation',
+      issues: parsed.error.issues,
+    });
+  }
+
+  return requestJson(
+    `v1/tasks/${validatedId.data}`,
+    {
+      method: 'PATCH',
+      body: parsed.data,
+      schema: TaskRecordSchema,
+    },
+    options,
+  );
+}
+
+export async function deleteTask(id: string, options?: TaskClientRequestOptions): Promise<TaskDeleteResponse> {
+  const validatedId = TaskIdSchema.safeParse(id);
+  if (!validatedId.success) {
+    throw new TaskClientError('Task identifier was invalid.', {
+      kind: 'validation',
+      issues: validatedId.error.issues,
+    });
+  }
+
+  return requestJson(
+    `v1/tasks/${validatedId.data}`,
+    {
+      method: 'DELETE',
+      schema: TaskDeleteResponseSchema,
+    },
+    options,
+  );
+}
+
+export async function withTaskClientAuth<T>(
+  auth: TaskClientAuthState,
+  callback: () => Promise<T> | T,
+): Promise<T> {
+  if (isBrowser()) {
+    return await callback();
+  }
+
+  const storage = await loadServerAuthStorage();
+  if (storage) {
+    return storage.run(auth, callback as () => T);
+  }
+
+  const previous = manualServerAuthState;
+  manualServerAuthState = auth;
+  try {
+    return await callback();
+  } finally {
+    manualServerAuthState = previous;
+  }
+}
+
+export function clearManualTaskClientAuthState(): void {
+  manualServerAuthState = undefined;
+}

--- a/docs/tasks-client.md
+++ b/docs/tasks-client.md
@@ -1,0 +1,95 @@
+# Task API Client
+
+The Task API client is a lightweight wrapper around the `/api/taskforge/v1/tasks` endpoints. It centralises
+serialization rules, authentication, and error handling so UI layers can focus on rendering logic.
+
+## Importing
+
+```ts
+import {
+  listTasks,
+  createTask,
+  updateTask,
+  deleteTask,
+  withTaskClientAuth,
+  type TaskListQuery,
+  type CreateTaskInput,
+  type UpdateTaskInput,
+  TaskClientError,
+} from '@/lib/tasks-client';
+```
+
+All helpers are framework-agnostic and only rely on the Fetch API. Consumers can override the `fetch` implementation or
+base URL with the optional `TaskClientRequestOptions` argument.
+
+## Authentication
+
+On the browser the client automatically opts into `credentials: 'include'` so the `tf_session` cookie is forwarded
+without any additional wiring.
+
+On the server the client attempts to read the session cookie from:
+
+1. The contextual auth passed to `withTaskClientAuth` (preferred).
+2. The active Next.js request via `next/headers` (when available).
+3. `TaskClientRequestOptions.sessionCookie` or `cookieHeader` overrides.
+
+Wrap your server-side logic with `withTaskClientAuth` to bind a cookie or bearer token to all nested calls:
+
+```ts
+import { cookies } from 'next/headers';
+import { getSessionCookieName } from '@taskforge/shared';
+
+import { withTaskClientAuth, listTasks } from '@/lib/tasks-client';
+
+const SESSION_COOKIE = getSessionCookieName();
+
+export async function loadTasksForServerComponent() {
+  const sessionCookie = cookies().get(SESSION_COOKIE)?.value;
+
+  return withTaskClientAuth({ sessionCookie }, async () => {
+    return listTasks({ pageSize: 50 });
+  });
+}
+```
+
+The helper falls back to a manual (non-isolated) store when `AsyncLocalStorage` is unavailable. Call
+`clearManualTaskClientAuthState()` after each request if you use this fallback.
+
+## Making requests
+
+Each function performs minimal client-side validation with Zod and returns strongly typed DTOs. Validation errors throw a
+`TaskClientError` with `kind: 'validation'` so UI layers can surface inline feedback.
+
+```ts
+try {
+  const task = await createTask({
+    title: 'Plan sprint review',
+    status: 'IN_PROGRESS',
+    priority: 'MEDIUM',
+  });
+
+  console.log(task.id);
+} catch (error) {
+  if (error instanceof TaskClientError) {
+    switch (error.kind) {
+      case 'validation':
+        console.error('Fix the form values', error.issues);
+        break;
+      case 'http':
+        console.error('Server rejected the request', error.status, error.error);
+        break;
+      default:
+        console.error('Unexpected failure', error);
+    }
+  }
+}
+```
+
+The helpers normalise query parameters (including multiple `tag` filters), coerce blank strings, and guard against
+out-of-order date ranges before the request is issued.
+
+## Testing utilities
+
+The client exposes a `TaskClientRequestOptions.fetchImpl` override, making it straightforward to inject `vitest`/`jest`
+mocks for unit tests. Server-only code paths can be exercised by temporarily removing `globalThis.window` or by wrapping
+a test block with `withTaskClientAuth`.


### PR DESCRIPTION
## Summary
- add a reusable tasks API client with shared validation, auth propagation, and typed DTO parsing
- cover query serialization, error handling, and auth helpers with unit tests
- document how to consume the client and bind server-side auth context

## Testing
- pnpm -C apps/web test
