### PR TITLE
feat(web): add task React Query hooks and demo

### DIFF
--- a/apps/web/app/(protected)/tasks/hooks-demo/page.tsx
+++ b/apps/web/app/(protected)/tasks/hooks-demo/page.tsx
@@ -1,0 +1,17 @@
+import { Suspense } from 'react';
+
+import { TasksHooksDemo } from '@/components/tasks/hooks-demo';
+
+export const metadata = {
+  title: 'Task Hooks Demo',
+};
+
+export default function TasksHooksDemoPage() {
+  return (
+    <div className="container mx-auto max-w-4xl space-y-6 py-10">
+      <Suspense fallback={<p className="text-sm text-muted-foreground">Preparing task data…</p>}>
+        <TasksHooksDemo />
+      </Suspense>
+    </div>
+  );
+}

--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -1,16 +1,40 @@
 'use client';
 
-import type { PropsWithChildren } from 'react';
+import { useState, type PropsWithChildren } from 'react';
 import { SessionProvider } from 'next-auth/react';
 import { domAnimation, LazyMotion } from 'framer-motion';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import { AuthProvider } from '@/lib/use-auth';
 
 export function Providers({ children }: PropsWithChildren) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 30_000,
+            refetchOnWindowFocus: true,
+            retry: (failureCount, error) => {
+              if ((error as Error | undefined)?.name === 'TaskClientError') {
+                return false;
+              }
+              return failureCount < 2;
+            },
+          },
+          mutations: {
+            retry: 0,
+          },
+        },
+      }),
+  );
+
   return (
     <SessionProvider>
       <AuthProvider>
-        <LazyMotion features={domAnimation}>{children}</LazyMotion>
+        <QueryClientProvider client={queryClient}>
+          <LazyMotion features={domAnimation}>{children}</LazyMotion>
+        </QueryClientProvider>
       </AuthProvider>
     </SessionProvider>
   );

--- a/apps/web/components/tasks/hooks-demo.tsx
+++ b/apps/web/components/tasks/hooks-demo.tsx
@@ -1,0 +1,198 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import type { TaskStatus } from '@taskforge/shared';
+
+import { Button } from '@/components/ui/button';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import {
+  useCreateTask,
+  useDeleteTask,
+  useTasksQuery,
+  useUpdateTask,
+} from '@/lib/tasks-hooks';
+
+const STATUS_LABELS: Record<TaskStatus, string> = {
+  TODO: 'To Do',
+  IN_PROGRESS: 'In Progress',
+  DONE: 'Done',
+};
+
+const statusFilters: Array<{ value?: TaskStatus; label: string }> = [
+  { value: undefined, label: 'All' },
+  { value: 'TODO', label: STATUS_LABELS.TODO },
+  { value: 'IN_PROGRESS', label: STATUS_LABELS.IN_PROGRESS },
+  { value: 'DONE', label: STATUS_LABELS.DONE },
+];
+
+function formatDate(value?: string): string {
+  if (!value) {
+    return 'No due date';
+  }
+
+  try {
+    return new Intl.DateTimeFormat('en-US', {
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    }).format(new Date(value));
+  } catch {
+    return value;
+  }
+}
+
+export function TasksHooksDemo() {
+  const [selectedStatus, setSelectedStatus] = useState<TaskStatus | undefined>();
+  const [searchTerm, setSearchTerm] = useState('');
+
+  const filters = useMemo(
+    () => ({
+      status: selectedStatus,
+      q: searchTerm.trim() || undefined,
+    }),
+    [selectedStatus, searchTerm],
+  );
+
+  const tasksQuery = useTasksQuery(filters);
+  const createTask = useCreateTask();
+  const updateTask = useUpdateTask();
+  const deleteTask = useDeleteTask();
+
+  const hasMutationError = createTask.error ?? updateTask.error ?? deleteTask.error;
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Task Hooks Demo</CardTitle>
+          <CardDescription>
+            Interact with the React Query hooks to verify caching, filters, and optimistic updates.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex flex-wrap gap-2">
+            {statusFilters.map((option) => {
+              const isActive = option.value === selectedStatus;
+              return (
+                <Button
+                  key={option.label}
+                  variant={isActive ? 'default' : 'secondary'}
+                  onClick={() => setSelectedStatus(option.value)}
+                >
+                  {option.label}
+                </Button>
+              );
+            })}
+          </div>
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+            <Input
+              value={searchTerm}
+              onChange={(event) => setSearchTerm(event.target.value)}
+              placeholder="Search by title or description"
+              className="sm:max-w-sm"
+            />
+            <div className="flex gap-2">
+              <Button variant="outline" onClick={() => tasksQuery.refetch()} disabled={tasksQuery.isFetching}>
+                Refresh
+              </Button>
+              <Button
+                onClick={() =>
+                  createTask.mutate({
+                    title: `Demo task ${new Date().toLocaleTimeString()}`,
+                    description: 'Created from the hooks showcase.',
+                    status: 'TODO',
+                    priority: 'MEDIUM',
+                  })
+                }
+                disabled={createTask.isPending}
+              >
+                Add demo task
+              </Button>
+            </div>
+          </div>
+          {tasksQuery.error ? (
+            <Alert variant="destructive">
+              <AlertTitle>Unable to load tasks</AlertTitle>
+              <AlertDescription>{tasksQuery.error.message}</AlertDescription>
+            </Alert>
+          ) : null}
+          {hasMutationError ? (
+            <Alert variant="destructive">
+              <AlertTitle>Task mutation failed</AlertTitle>
+              <AlertDescription>{hasMutationError.message}</AlertDescription>
+            </Alert>
+          ) : null}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Results</CardTitle>
+          <CardDescription>
+            Showing {tasksQuery.tasks.length} of {tasksQuery.data?.total ?? 0} tasks. Use the controls above to filter.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {tasksQuery.isLoading ? (
+            <p className="text-sm text-muted-foreground">Loading tasks…</p>
+          ) : null}
+
+          {!tasksQuery.isLoading && tasksQuery.tasks.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No tasks match the current filters.</p>
+          ) : null}
+
+          <ul className="space-y-3">
+            {tasksQuery.tasks.map((task) => (
+              <li key={task.id} className="rounded-xl border border-border/60 bg-card/60 p-4">
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                  <div>
+                    <p className="text-base font-semibold">
+                      {task.title}{' '}
+                      {task._optimistic ? <span className="text-xs uppercase text-amber-400">(pending)</span> : null}
+                    </p>
+                    {task.description ? (
+                      <p className="text-sm text-muted-foreground">{task.description}</p>
+                    ) : null}
+                    <p className="text-xs text-muted-foreground">
+                      Status: {STATUS_LABELS[task.status]} · Due: {formatDate(task.dueDate)}
+                    </p>
+                  </div>
+                  <div className="flex gap-2">
+                    <Button
+                      variant="secondary"
+                      disabled={updateTask.isPending}
+                      onClick={() =>
+                        updateTask.mutate({
+                          id: task.id,
+                          input: { status: task.status === 'DONE' ? 'TODO' : 'DONE' },
+                        })
+                      }
+                    >
+                      {task.status === 'DONE' ? 'Reopen' : 'Complete'}
+                    </Button>
+                    <Button
+                      variant="outline"
+                      disabled={deleteTask.isPending}
+                      onClick={() => deleteTask.mutate({ id: task.id })}
+                    >
+                      Delete
+                    </Button>
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/lib/tasks-hooks.ts
+++ b/apps/web/lib/tasks-hooks.ts
@@ -1,0 +1,739 @@
+'use client';
+
+import { useMemo } from 'react';
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type QueryKey,
+  type UseMutationOptions,
+  type UseMutationResult,
+  type UseQueryOptions,
+  type UseQueryResult,
+} from '@tanstack/react-query';
+import type { ZodIssue } from 'zod';
+
+import {
+  createTask,
+  deleteTask,
+  listTasks,
+  updateTask,
+  TaskClientError,
+} from './tasks-client';
+import type {
+  CreateTaskInput,
+  TaskClientErrorKind,
+  TaskListQuery,
+  TaskListResponse,
+  TaskRecordDTO,
+  UpdateTaskInput,
+} from './tasks-client';
+import { useAuth } from './use-auth';
+
+export type TaskListItem = TaskRecordDTO & { _optimistic?: boolean };
+
+export interface TaskListData extends Omit<TaskListResponse, 'items'> {
+  items: TaskListItem[];
+}
+
+type TaskQueryFnData = TaskListData;
+
+type TaskQueryKey = ReturnType<typeof taskQueryKeys.list>;
+
+type TaskQueryOptions = Omit<
+  UseQueryOptions<TaskQueryFnData, TaskClientError, TaskQueryFnData, TaskQueryKey>,
+  'queryKey' | 'queryFn'
+>;
+
+type TaskListQueryResult = UseQueryResult<TaskQueryFnData, TaskClientError>;
+
+interface TaskMutationContext {
+  touchedQueries: Array<[QueryKey, TaskListData | undefined]>;
+  optimisticTaskId?: string;
+}
+
+export interface TaskOperationError {
+  message: string;
+  kind: TaskClientErrorKind | 'unknown';
+  status?: number;
+  error?: string;
+  details?: unknown;
+  issues?: ZodIssue[];
+  raw: unknown;
+}
+
+export interface UseTasksQueryResult {
+  data: TaskListData | undefined;
+  tasks: TaskListItem[];
+  isLoading: boolean;
+  isFetching: boolean;
+  isError: boolean;
+  isSuccess: boolean;
+  status: TaskListQueryResult['status'];
+  fetchStatus: TaskListQueryResult['fetchStatus'];
+  refetch: TaskListQueryResult['refetch'];
+  queryKey: TaskQueryKey;
+  error: TaskOperationError | null;
+  rawError: unknown;
+}
+
+export interface UseTaskMutationResult<TData, TVariables>
+  extends Pick<
+      UseMutationResult<TData, TaskClientError, TVariables, TaskMutationContext>,
+      | 'mutate'
+      | 'mutateAsync'
+      | 'reset'
+      | 'status'
+      | 'isPending'
+      | 'isSuccess'
+      | 'isError'
+      | 'data'
+      | 'variables'
+    > {
+  error: TaskOperationError | null;
+  rawError: unknown;
+}
+
+interface NormalizedTaskListFilters {
+  page?: number;
+  pageSize?: number;
+  status?: TaskListQuery['status'];
+  priority?: TaskListQuery['priority'];
+  tag?: string[];
+  q?: string;
+  dueFrom?: string;
+  dueTo?: string;
+}
+
+const TASK_QUERY_SCOPE = 'tasks';
+
+const FALLBACK_USER_KEY = 'anonymous';
+
+const taskQueryKeys = {
+  all: (userKey: string) => [TASK_QUERY_SCOPE, userKey] as const,
+  list: (userKey: string, filters: NormalizedTaskListFilters | undefined) =>
+    [...taskQueryKeys.all(userKey), 'list', filters ?? {}] as const,
+};
+
+function stableSerialize(value: unknown): string {
+  if (value === undefined) {
+    return 'undefined';
+  }
+
+  return JSON.stringify(value, (_, nested) => {
+    if (Array.isArray(nested)) {
+      return nested;
+    }
+
+    if (nested && typeof nested === 'object') {
+      return Object.keys(nested as Record<string, unknown>)
+        .sort()
+        .reduce<Record<string, unknown>>((acc, key) => {
+          acc[key] = (nested as Record<string, unknown>)[key];
+          return acc;
+        }, {});
+    }
+
+    return nested;
+  });
+}
+
+function deserializeFilters(serialized: string): TaskListQuery | undefined {
+  if (!serialized || serialized === 'undefined' || serialized === 'null') {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(serialized) as TaskListQuery;
+  } catch {
+    return undefined;
+  }
+}
+
+function normalizeTaskListFilters(filters?: TaskListQuery): NormalizedTaskListFilters | undefined {
+  if (!filters) {
+    return undefined;
+  }
+
+  const normalized: NormalizedTaskListFilters = {};
+
+  if (filters.page !== undefined) {
+    normalized.page = filters.page;
+  }
+
+  if (filters.pageSize !== undefined) {
+    normalized.pageSize = filters.pageSize;
+  }
+
+  if (filters.status) {
+    normalized.status = filters.status;
+  }
+
+  if (filters.priority) {
+    normalized.priority = filters.priority;
+  }
+
+  if (filters.tag) {
+    const tags = Array.isArray(filters.tag) ? filters.tag : [filters.tag];
+    normalized.tag = Array.from(new Set(tags.map((tag) => tag.trim()))).sort();
+  }
+
+  if (filters.q?.trim()) {
+    normalized.q = filters.q.trim();
+  }
+
+  if (filters.dueFrom) {
+    normalized.dueFrom = filters.dueFrom;
+  }
+
+  if (filters.dueTo) {
+    normalized.dueTo = filters.dueTo;
+  }
+
+  return normalized;
+}
+
+function extractFiltersFromKey(queryKey: QueryKey): NormalizedTaskListFilters | undefined {
+  if (!Array.isArray(queryKey) || queryKey.length < 4) {
+    return undefined;
+  }
+
+  const maybeFilters = queryKey[3];
+  if (maybeFilters && typeof maybeFilters === 'object') {
+    const entries = Object.entries(maybeFilters as Record<string, unknown>).filter(([, value]) => value !== undefined);
+    if (entries.length === 0) {
+      return undefined;
+    }
+
+    return maybeFilters as NormalizedTaskListFilters;
+  }
+
+  return undefined;
+}
+
+function createTaskClientErrorMessage(error: TaskClientError): string {
+  switch (error.kind) {
+    case 'validation':
+      return 'Some fields were invalid. Please review the highlighted values and try again.';
+    case 'network':
+      return 'We could not reach the task service. Check your connection and try again.';
+    case 'serialization':
+      return 'The task service responded in an unexpected format. Please retry in a moment.';
+    case 'http': {
+      if (error.status === 401) {
+        return 'You need to sign in before managing tasks.';
+      }
+
+      if (error.status === 403) {
+        return 'You do not have permission to modify this task.';
+      }
+
+      if (error.status === 404) {
+        return 'The requested task could not be found.';
+      }
+
+      if ((error.status ?? 0) >= 500) {
+        return 'The task service is temporarily unavailable. Please try again shortly.';
+      }
+
+      return error.error ?? 'The task request could not be completed. Please try again.';
+    }
+    default:
+      return 'Something went wrong while communicating with the task service. Please try again.';
+  }
+}
+
+function toTaskOperationError(error: unknown): TaskOperationError | null {
+  if (!error) {
+    return null;
+  }
+
+  if (error instanceof TaskClientError) {
+    return {
+      message: createTaskClientErrorMessage(error),
+      kind: error.kind,
+      status: error.status,
+      error: error.error,
+      details: error.details,
+      issues: error.issues,
+      raw: error,
+    };
+  }
+
+  if (error instanceof Error) {
+    return {
+      message: error.message || 'An unexpected error occurred while working with tasks.',
+      kind: 'unknown',
+      raw: error,
+    };
+  }
+
+  return {
+    message: 'An unknown error occurred while working with tasks.',
+    kind: 'unknown',
+    raw: error,
+  };
+}
+
+function cloneTaskList(data: TaskListData): TaskListData {
+  return {
+    ...data,
+    items: data.items.map((item) => ({ ...item })),
+  };
+}
+
+function addTaskToList(list: TaskListData, task: TaskListItem): TaskListData {
+  if (list.page !== 1) {
+    return list;
+  }
+
+  const filtered = list.items.filter((item) => item.id !== task.id);
+  const nextItems = [task, ...filtered];
+
+  if (nextItems.length > list.pageSize) {
+    nextItems.length = list.pageSize;
+  }
+
+  const hasExisting = list.items.some((item) => item.id === task.id);
+  return {
+    ...list,
+    items: nextItems,
+    total: hasExisting ? list.total : list.total + 1,
+  };
+}
+
+function replaceTaskInList(list: TaskListData, previousId: string | undefined, task: TaskListItem): TaskListData {
+  const next = cloneTaskList(list);
+  const placeholderIndex = previousId ? next.items.findIndex((item) => item.id === previousId) : -1;
+  const actualIndex = next.items.findIndex((item) => item.id === task.id);
+
+  if (placeholderIndex !== -1) {
+    next.items[placeholderIndex] = task;
+    return next;
+  }
+
+  if (actualIndex !== -1) {
+    next.items[actualIndex] = task;
+    return next;
+  }
+
+  if (next.page !== 1) {
+    return next;
+  }
+
+  next.items.unshift(task);
+
+  if (next.items.length > next.pageSize) {
+    next.items.length = next.pageSize;
+  }
+
+  return {
+    ...next,
+    total: next.total + 1,
+  };
+}
+
+function updateTaskInList(list: TaskListData, taskId: string, patch: Partial<TaskListItem>): TaskListData {
+  const index = list.items.findIndex((item) => item.id === taskId);
+  if (index === -1) {
+    return list;
+  }
+
+  const next = cloneTaskList(list);
+  next.items[index] = { ...next.items[index], ...patch };
+  return next;
+}
+
+function removeTaskFromList(list: TaskListData, taskId: string): TaskListData {
+  const index = list.items.findIndex((item) => item.id === taskId);
+  if (index === -1) {
+    return list;
+  }
+
+  const nextItems = list.items.filter((item) => item.id !== taskId);
+  return {
+    ...list,
+    items: nextItems,
+    total: Math.max(0, list.total - 1),
+  };
+}
+
+function taskMatchesFilters(task: TaskListItem, filters?: NormalizedTaskListFilters): boolean {
+  if (!filters) {
+    return true;
+  }
+
+  if (filters.status && task.status !== filters.status) {
+    return false;
+  }
+
+  if (filters.priority && task.priority !== filters.priority) {
+    return false;
+  }
+
+  if (filters.tag && filters.tag.some((tag) => !task.tags.includes(tag))) {
+    return false;
+  }
+
+  if (filters.q) {
+    const haystack = `${task.title} ${task.description ?? ''}`.toLowerCase();
+    if (!haystack.includes(filters.q.toLowerCase())) {
+      return false;
+    }
+  }
+
+  if (filters.dueFrom) {
+    if (!task.dueDate) {
+      return false;
+    }
+    if (Date.parse(task.dueDate) < Date.parse(filters.dueFrom)) {
+      return false;
+    }
+  }
+
+  if (filters.dueTo) {
+    if (!task.dueDate) {
+      return false;
+    }
+    if (Date.parse(task.dueDate) > Date.parse(filters.dueTo)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function scopedQueryKey(userId?: string | null): string {
+  return userId ?? FALLBACK_USER_KEY;
+}
+
+function deserializeNormalizedFilters(serialized: string): NormalizedTaskListFilters | undefined {
+  if (!serialized || serialized === 'undefined' || serialized === 'null') {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(serialized) as NormalizedTaskListFilters;
+  } catch {
+    return undefined;
+  }
+}
+
+export function useTasksQuery(filters?: TaskListQuery, options?: TaskQueryOptions): UseTasksQueryResult {
+  const { user } = useAuth();
+  const filtersSignature = useMemo(() => stableSerialize(filters), [filters]);
+  const normalizedHash = useMemo(() => {
+    const parsedFilters = deserializeFilters(filtersSignature);
+    const normalized = normalizeTaskListFilters(parsedFilters);
+    return stableSerialize(normalized);
+  }, [filtersSignature]);
+
+  const userScope = scopedQueryKey(user?.id);
+  const queryKey = useMemo(
+    () => taskQueryKeys.list(userScope, deserializeNormalizedFilters(normalizedHash)),
+    [userScope, normalizedHash],
+  );
+
+  const query = useQuery({
+    queryKey,
+    queryFn: async () => {
+      const payload = await listTasks(filters);
+      return {
+        ...payload,
+        items: payload.items.map((item) => ({ ...item })),
+      } satisfies TaskListData;
+    },
+    staleTime: 30_000,
+    gcTime: 5 * 60_000,
+    ...options,
+  });
+
+  const friendlyError = toTaskOperationError(query.error);
+
+  return {
+    data: query.data,
+    tasks: query.data?.items ?? [],
+    isLoading: query.isLoading,
+    isFetching: query.isFetching,
+    isError: query.isError,
+    isSuccess: query.isSuccess,
+    status: query.status,
+    fetchStatus: query.fetchStatus,
+    refetch: query.refetch,
+    queryKey,
+    error: friendlyError,
+    rawError: query.error,
+  };
+}
+
+function buildOptimisticTask(input: CreateTaskInput): TaskListItem {
+  const now = new Date().toISOString();
+  const randomId =
+    typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+      ? crypto.randomUUID()
+      : Math.random().toString(36).slice(2);
+  return {
+    id: `optimistic-${randomId}`,
+    title: input.title,
+    description: input.description,
+    status: input.status ?? 'TODO',
+    priority: input.priority ?? 'MEDIUM',
+    dueDate: input.dueDate,
+    tags: input.tags ?? [],
+    createdAt: now,
+    updatedAt: now,
+    _optimistic: true,
+  };
+}
+
+function collectMatchingQueries(
+  queryClient: ReturnType<typeof useQueryClient>,
+  userScope: string,
+  predicate: (payload: TaskListData, filters: NormalizedTaskListFilters | undefined) => TaskListData,
+): Array<[QueryKey, TaskListData | undefined]> {
+  const candidates = queryClient.getQueriesData<TaskListData>({ queryKey: taskQueryKeys.all(userScope) });
+  const touched: Array<[QueryKey, TaskListData | undefined]> = [];
+
+  for (const [key, data] of candidates) {
+    if (!data) {
+      continue;
+    }
+
+    const filters = extractFiltersFromKey(key);
+    const next = predicate(data, filters);
+
+    if (next !== data) {
+      touched.push([key, data]);
+      queryClient.setQueryData(key, next);
+    }
+  }
+
+  return touched;
+}
+
+export function useCreateTask(
+  options?: UseMutationOptions<TaskRecordDTO, TaskClientError, CreateTaskInput, TaskMutationContext>,
+): UseTaskMutationResult<TaskRecordDTO, CreateTaskInput> {
+  const { user } = useAuth();
+  const queryClient = useQueryClient();
+  const userScope = scopedQueryKey(user?.id);
+
+  const mutation = useMutation({
+    mutationFn: (input) => createTask(input),
+    onMutate: async (input) => {
+      await queryClient.cancelQueries({ queryKey: taskQueryKeys.all(userScope) });
+
+      const optimisticTask = buildOptimisticTask(input);
+
+      const touchedQueries = collectMatchingQueries(queryClient, userScope, (payload, filters) => {
+        if (!taskMatchesFilters(optimisticTask, filters)) {
+          return payload;
+        }
+
+        return addTaskToList(payload, optimisticTask);
+      });
+
+      return { touchedQueries, optimisticTaskId: optimisticTask.id } satisfies TaskMutationContext;
+    },
+    onError: (error, _variables, context) => {
+      if (!context) {
+        return;
+      }
+
+      for (const [key, snapshot] of context.touchedQueries) {
+        queryClient.setQueryData(key, snapshot);
+      }
+
+      options?.onError?.(error, _variables, context);
+    },
+    onSuccess: (result, variables, context) => {
+      const taskItem: TaskListItem = { ...result };
+
+      collectMatchingQueries(queryClient, userScope, (payload, filters) => {
+        if (!taskMatchesFilters(taskItem, filters)) {
+          if (context?.optimisticTaskId) {
+            return removeTaskFromList(payload, context.optimisticTaskId);
+          }
+          return payload;
+        }
+
+        return replaceTaskInList(payload, context?.optimisticTaskId, taskItem);
+      });
+
+      options?.onSuccess?.(result, variables, context);
+    },
+    onSettled: (result, error, variables, context) => {
+      options?.onSettled?.(result, error, variables, context);
+      queryClient.invalidateQueries({ queryKey: taskQueryKeys.all(userScope) });
+    },
+    ...options,
+  });
+
+  const friendlyError = toTaskOperationError(mutation.error);
+
+  return {
+    mutate: mutation.mutate,
+    mutateAsync: mutation.mutateAsync,
+    reset: mutation.reset,
+    status: mutation.status,
+    isPending: mutation.isPending,
+    isSuccess: mutation.isSuccess,
+    isError: mutation.isError,
+    data: mutation.data,
+    variables: mutation.variables,
+    error: friendlyError,
+    rawError: mutation.error,
+  };
+}
+
+interface UpdateTaskVariables {
+  id: string;
+  input: UpdateTaskInput;
+}
+
+export function useUpdateTask(
+  options?: UseMutationOptions<TaskRecordDTO, TaskClientError, UpdateTaskVariables, TaskMutationContext>,
+): UseTaskMutationResult<TaskRecordDTO, UpdateTaskVariables> {
+  const { user } = useAuth();
+  const queryClient = useQueryClient();
+  const userScope = scopedQueryKey(user?.id);
+
+  const mutation = useMutation({
+    mutationFn: ({ id, input }) => updateTask(id, input),
+    onMutate: async ({ id, input }) => {
+      await queryClient.cancelQueries({ queryKey: taskQueryKeys.all(userScope) });
+
+      const touchedQueries = collectMatchingQueries(queryClient, userScope, (payload) => {
+        const existing = payload.items.find((item) => item.id === id);
+        if (!existing) {
+          return payload;
+        }
+
+        return updateTaskInList(payload, id, {
+          ...input,
+          updatedAt: new Date().toISOString(),
+          _optimistic: true,
+        });
+      });
+
+      return { touchedQueries, optimisticTaskId: id } satisfies TaskMutationContext;
+    },
+    onError: (error, variables, context) => {
+      if (context) {
+        for (const [key, snapshot] of context.touchedQueries) {
+          queryClient.setQueryData(key, snapshot);
+        }
+      }
+
+      options?.onError?.(error, variables, context);
+    },
+    onSuccess: (result, variables, context) => {
+      const taskItem: TaskListItem = { ...result };
+
+      collectMatchingQueries(queryClient, userScope, (payload, filters) => {
+        if (!taskMatchesFilters(taskItem, filters)) {
+          return removeTaskFromList(payload, variables.id);
+        }
+
+        return replaceTaskInList(payload, context?.optimisticTaskId ?? variables.id, taskItem);
+      });
+
+      options?.onSuccess?.(result, variables, context);
+    },
+    onSettled: (result, error, variables, context) => {
+      options?.onSettled?.(result, error, variables, context);
+      queryClient.invalidateQueries({ queryKey: taskQueryKeys.all(userScope) });
+    },
+    ...options,
+  });
+
+  const friendlyError = toTaskOperationError(mutation.error);
+
+  return {
+    mutate: mutation.mutate,
+    mutateAsync: mutation.mutateAsync,
+    reset: mutation.reset,
+    status: mutation.status,
+    isPending: mutation.isPending,
+    isSuccess: mutation.isSuccess,
+    isError: mutation.isError,
+    data: mutation.data,
+    variables: mutation.variables,
+    error: friendlyError,
+    rawError: mutation.error,
+  };
+}
+
+export function useDeleteTask(
+  options?: UseMutationOptions<
+    { id: string },
+    TaskClientError,
+    { id: string },
+    TaskMutationContext
+  >,
+): UseTaskMutationResult<{ id: string }, { id: string }> {
+  const { user } = useAuth();
+  const queryClient = useQueryClient();
+  const userScope = scopedQueryKey(user?.id);
+
+  const mutation = useMutation({
+    mutationFn: ({ id }) => deleteTask(id),
+    onMutate: async ({ id }) => {
+      await queryClient.cancelQueries({ queryKey: taskQueryKeys.all(userScope) });
+
+      const touchedQueries = collectMatchingQueries(queryClient, userScope, (payload) =>
+        removeTaskFromList(payload, id),
+      );
+
+      return { touchedQueries, optimisticTaskId: id } satisfies TaskMutationContext;
+    },
+    onError: (error, variables, context) => {
+      if (context) {
+        for (const [key, snapshot] of context.touchedQueries) {
+          queryClient.setQueryData(key, snapshot);
+        }
+      }
+
+      options?.onError?.(error, variables, context);
+    },
+    onSuccess: (result, variables, context) => {
+      options?.onSuccess?.(result, variables, context);
+    },
+    onSettled: (result, error, variables, context) => {
+      options?.onSettled?.(result, error, variables, context);
+      queryClient.invalidateQueries({ queryKey: taskQueryKeys.all(userScope) });
+    },
+    ...options,
+  });
+
+  const friendlyError = toTaskOperationError(mutation.error);
+
+  return {
+    mutate: mutation.mutate,
+    mutateAsync: mutation.mutateAsync,
+    reset: mutation.reset,
+    status: mutation.status,
+    isPending: mutation.isPending,
+    isSuccess: mutation.isSuccess,
+    isError: mutation.isError,
+    data: mutation.data,
+    variables: mutation.variables,
+    error: friendlyError,
+    rawError: mutation.error,
+  };
+}
+
+export const __testing = {
+  stableSerialize,
+  deserializeFilters,
+  normalizeTaskListFilters,
+  deserializeNormalizedFilters,
+  createTaskClientErrorMessage,
+  toTaskOperationError,
+  taskMatchesFilters,
+  addTaskToList,
+  replaceTaskInList,
+  updateTaskInList,
+  removeTaskFromList,
+  taskQueryKeys,
+};

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -24,6 +24,7 @@
     "clsx": "^2.1.0",
     "framer-motion": "^11.0.3",
     "lucide-react": "^0.344.0",
+    "@tanstack/react-query": "^5.51.3",
     "next": "^14.1.0",
     "next-auth": "^5.0.0-beta.17",
     "react": "^18.2.0",

--- a/docs/tasks/milestone3/09-frontend-task-query-hooks.md
+++ b/docs/tasks/milestone3/09-frontend-task-query-hooks.md
@@ -4,16 +4,44 @@
 - Wrap the typed API client with React Query (or SWR) hooks that manage caching, loading states, optimistic updates, and background refetches.
 - Provide mutations for create/update/delete so UI components can stay declarative.
 
-**Status:** New.  
+**Status:** Complete.
 **Concurrency:** Depends on `08-frontend-task-api-client`; can run in parallel with the UI tasks once the hooks are exported.
 
 ## Acceptance Criteria
-- [ ] `useTasksQuery` exposes `{ data, isLoading, error, refetch }` and respects filter parameters (status/tag/q).
-- [ ] Mutation hooks (`useCreateTask`, `useUpdateTask`, `useDeleteTask`) optimistically update the cache and roll back on failure.
-- [ ] Global error handling funnels toast-friendly messages to consumers.
-- [ ] Hooks documented in `docs/tasks/milestone3/sequence` (or README) so other teams know how to consume them.
-- [ ] Storybook or a small demo page shows the hooks in action for QA.
+- [x] `useTasksQuery` exposes `{ data, isLoading, error, refetch }` and respects filter parameters (status/tag/q).
+- [x] Mutation hooks (`useCreateTask`, `useUpdateTask`, `useDeleteTask`) optimistically update the cache and roll back on failure.
+- [x] Global error handling funnels toast-friendly messages to consumers.
+- [x] Hooks documented in `docs/tasks/milestone3/sequence` (or README) so other teams know how to consume them.
+- [x] Storybook or a small demo page shows the hooks in action for QA.
 
 ## Notes
 - Consider namespacing the query keys by user id to avoid cache collisions when switching accounts.
 - Keep suspense compatibility in mind for future server components.
+
+## Implementation
+
+- Added React Query-powered hooks in `apps/web/lib/tasks-hooks.ts` that wrap the typed API client. Hooks namespace query keys by user id, normalize filter parameters, and provide optimistic cache updates with rollback on errors.
+- Introduced a shared React Query client in `apps/web/app/providers.tsx` so any client component can opt into the hooks.
+- Exposed demo UI at `/tasks/hooks-demo` (see `apps/web/app/(protected)/tasks/hooks-demo/page.tsx`) that exercises listing, creating, updating, and deleting tasks using the new hooks.
+
+## Usage
+
+```tsx
+import {
+  useTasksQuery,
+  useCreateTask,
+  useUpdateTask,
+  useDeleteTask,
+} from '@/lib/tasks-hooks';
+
+const { tasks, isLoading, error, refetch } = useTasksQuery({ status: 'IN_PROGRESS' });
+const createTask = useCreateTask();
+
+createTask.mutate({
+  title: 'Wireframe task filters',
+  status: 'TODO',
+  priority: 'MEDIUM',
+});
+```
+
+Each hook surfaces a `friendly` error message (via the `error` property) that can be passed directly to toast/snackbar components while preserving the underlying error on `rawError` for logging.

--- a/docs/tasks/milestone3/sequence.md
+++ b/docs/tasks/milestone3/sequence.md
@@ -8,7 +8,7 @@
 6. 06-api-task-test-fixtures.md – Build Jest/Supertest harness + factories for tasks.
 7. 07-api-task-crud-tests.md – Write CRUD/filter tests leveraging the harness.
 8. 08-frontend-task-api-client.md – Ship typed HTTP client for task endpoints.
-9. 09-frontend-task-query-hooks.md – Wrap the client with React Query/SWR hooks + mutations.
+9. 09-frontend-task-query-hooks.md – Wrap the client with React Query hooks + mutations (`apps/web/lib/tasks-hooks.ts`, demo at `/tasks/hooks-demo`).
 10. 10-frontend-task-list-ui.md – Render the authenticated task list using the new hooks.
 11. 11-frontend-task-filters-empty-states.md – Add filter controls + empty-state UX tied to hook params.
 12. 12-frontend-task-create-dialog.md – Build the create-task dialog powered by the create mutation.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.0.2
         version: 1.2.3(@types/react@18.3.26)(react@18.3.1)
+      '@tanstack/react-query':
+        specifier: ^5.51.3
+        version: 5.90.7(react@18.3.1)
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.1
@@ -1860,6 +1863,19 @@ packages:
     dependencies:
       '@swc/counter': 0.1.3
       tslib: 2.8.1
+    dev: false
+
+  /@tanstack/query-core@5.90.7:
+    resolution: {integrity: sha512-6PN65csiuTNfBMXqQUxQhCNdtm1rV+9kC9YwWAIKcaxAauq3Wu7p18j3gQY3YIBJU70jT/wzCCZ2uqto/vQgiQ==}
+    dev: false
+
+  /@tanstack/react-query@5.90.7(react@18.3.1):
+    resolution: {integrity: sha512-wAHc/cgKzW7LZNFloThyHnV/AX9gTg3w5yAv0gvQHPZoCnepwqCMtzbuPbb2UvfvO32XZ46e8bPOYbfZhzVnnQ==}
+    peerDependencies:
+      react: ^18 || ^19
+    dependencies:
+      '@tanstack/query-core': 5.90.7
+      react: 18.3.1
     dev: false
 
   /@testcontainers/postgresql@10.28.0:


### PR DESCRIPTION
## Summary
- add React Query-powered task hooks that wrap the typed API client with optimistic cache updates and friendly errors
- provide a shared QueryClient provider and a protected demo route showcasing list/create/update/delete flows
- update milestone docs with usage guidance and record the new dependency in the workspace

## Testing
- pnpm --filter @taskforge/web lint *(fails: missing @typescript-eslint/no-dynamic-delete and Next.js module assignment rules in existing code)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69145bbb752c8322a0a0eb9522b2fa5a)