### PR TITLE
Add kanban board read model and /tasks/board endpoint

### DIFF
--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -134,6 +134,130 @@ const taskRecord: OpenAPIV3.SchemaObject = {
   },
 };
 
+const taskBoardItem: OpenAPIV3.SchemaObject = {
+  type: 'object',
+  properties: {
+    id: { type: 'string', format: 'uuid' },
+    title: { type: 'string' },
+    status: { type: 'string', enum: ['TODO', 'IN_PROGRESS', 'DONE'] },
+    priority: { type: 'string', enum: ['LOW', 'MEDIUM', 'HIGH'] },
+    dueDate: { type: 'string', format: 'date-time', nullable: true },
+    tags: { type: 'array', items: { type: 'string' } },
+    updatedAt: { type: 'string', format: 'date-time' },
+  },
+  required: ['id', 'title', 'status', 'priority', 'tags', 'updatedAt'],
+  example: {
+    id: '9e22c508-1383-4609-9bbd-2e09b7a2d108',
+    title: 'Draft project brief',
+    status: 'IN_PROGRESS',
+    priority: 'HIGH',
+    dueDate: '2024-07-10T16:00:00.000Z',
+    tags: ['planning', 'product'],
+    updatedAt: '2024-06-03T09:30:00.000Z',
+  },
+};
+
+const tagSummary: OpenAPIV3.SchemaObject = {
+  type: 'object',
+  properties: {
+    label: { type: 'string' },
+    count: { type: 'integer', minimum: 0 },
+  },
+  required: ['label', 'count'],
+  example: {
+    label: 'planning',
+    count: 3,
+  },
+};
+
+const boardColumn: OpenAPIV3.SchemaObject = {
+  type: 'object',
+  properties: {
+    status: { type: 'string', enum: ['TODO', 'IN_PROGRESS', 'DONE'] },
+    title: { type: 'string' },
+    order: { type: 'integer', minimum: 1 },
+    tasks: {
+      type: 'array',
+      items: { $ref: '#/components/schemas/TaskBoardItem' },
+    },
+    total: { type: 'integer', minimum: 0 },
+    overdueCount: { type: 'integer', minimum: 0 },
+    tags: {
+      type: 'array',
+      items: { $ref: '#/components/schemas/TagSummary' },
+    },
+  },
+  required: ['status', 'title', 'order', 'tasks', 'total', 'overdueCount', 'tags'],
+  example: {
+    status: 'IN_PROGRESS',
+    title: 'In Progress',
+    order: 2,
+    tasks: [taskBoardItem.example],
+    total: 1,
+    overdueCount: 0,
+    tags: [tagSummary.example],
+  },
+};
+
+const boardSummary: OpenAPIV3.SchemaObject = {
+  type: 'object',
+  properties: {
+    totalsByStatus: {
+      type: 'object',
+      properties: {
+        TODO: { type: 'integer', minimum: 0 },
+        IN_PROGRESS: { type: 'integer', minimum: 0 },
+        DONE: { type: 'integer', minimum: 0 },
+      },
+      required: ['TODO', 'IN_PROGRESS', 'DONE'],
+    },
+    overdueByStatus: {
+      type: 'object',
+      properties: {
+        TODO: { type: 'integer', minimum: 0 },
+        IN_PROGRESS: { type: 'integer', minimum: 0 },
+        DONE: { type: 'integer', minimum: 0 },
+      },
+      required: ['TODO', 'IN_PROGRESS', 'DONE'],
+    },
+    totalTasks: { type: 'integer', minimum: 0 },
+    totalOverdue: { type: 'integer', minimum: 0 },
+  },
+  required: ['totalsByStatus', 'overdueByStatus', 'totalTasks', 'totalOverdue'],
+  example: {
+    totalsByStatus: {
+      TODO: 3,
+      IN_PROGRESS: 2,
+      DONE: 5,
+    },
+    overdueByStatus: {
+      TODO: 1,
+      IN_PROGRESS: 0,
+      DONE: 0,
+    },
+    totalTasks: 10,
+    totalOverdue: 1,
+  },
+};
+
+const boardResponse: OpenAPIV3.SchemaObject = {
+  type: 'object',
+  properties: {
+    columns: {
+      type: 'array',
+      items: { $ref: '#/components/schemas/BoardColumn' },
+    },
+    summary: { $ref: '#/components/schemas/BoardSummary' },
+    generatedAt: { type: 'string', format: 'date-time' },
+  },
+  required: ['columns', 'summary', 'generatedAt'],
+  example: {
+    columns: [boardColumn.example],
+    summary: boardSummary.example,
+    generatedAt: '2024-06-03T09:30:00.000Z',
+  },
+};
+
 const taskCreateInput: OpenAPIV3.SchemaObject = {
   type: 'object',
   properties: {
@@ -319,6 +443,11 @@ export const openApiDocument: OpenAPIV3.Document = {
       },
       ErrorResponse: errorResponse,
       TaskRecord: taskRecord,
+      TaskBoardItem: taskBoardItem,
+      TagSummary: tagSummary,
+      BoardColumn: boardColumn,
+      BoardSummary: boardSummary,
+      BoardResponse: boardResponse,
       TaskCreateInput: taskCreateInput,
       TaskUpdateInput: taskUpdateInput,
       TaskListResponse: taskListResponse,
@@ -700,6 +829,39 @@ export const openApiDocument: OpenAPIV3.Document = {
         },
       },
     },
+    '/api/taskforge/v1/tasks/board': {
+      get: {
+        tags: ['Tasks'],
+        summary: 'Retrieve the Kanban board read model',
+        description:
+          'Returns a board-friendly representation of tasks grouped by status lanes. Requires a valid JWT via `Authorization` header or the `tf_session` cookie.',
+        security: [{ bearerAuth: [] }, { sessionCookie: [] }],
+        responses: {
+          '200': {
+            description: 'Task board',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/BoardResponse' },
+                examples: {
+                  default: { value: boardResponse.example as Record<string, unknown> },
+                },
+              },
+            },
+          },
+          '401': {
+            description: 'Unauthorized',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/ErrorResponse' },
+                examples: {
+                  unauthorized: unauthorizedExample,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
     '/api/taskforge/v1/tasks/{id}': {
       patch: {
         tags: ['Tasks'],
@@ -916,4 +1078,3 @@ export const openApiDocument: OpenAPIV3.Document = {
   },
   security: [],
 };
-

--- a/apps/api/src/repositories/task-mapper.ts
+++ b/apps/api/src/repositories/task-mapper.ts
@@ -1,5 +1,5 @@
 import type { Prisma } from '@prisma/client';
-import type { TaskRecordDTO } from '@taskforge/shared';
+import type { TaskBoardItemDTO, TaskRecordDTO } from '@taskforge/shared';
 
 export const taskWithTagsInclude = {
   TaskTag: {
@@ -27,6 +27,22 @@ export function toTaskRecordDTO(task: TaskWithTags): TaskRecordDTO {
     dueDate: task.dueDate?.toISOString(),
     tags,
     createdAt: task.createdAt.toISOString(),
+    updatedAt: task.updatedAt.toISOString(),
+  };
+}
+
+export function toTaskBoardItemDTO(task: TaskWithTags): TaskBoardItemDTO {
+  const tags = task.TaskTag.map(({ tag }) => tag.label).sort((a: string, b: string) =>
+    a.localeCompare(b, undefined, { sensitivity: 'base' }),
+  );
+
+  return {
+    id: task.id,
+    title: task.title,
+    status: task.status,
+    priority: task.priority,
+    dueDate: task.dueDate?.toISOString(),
+    tags,
     updatedAt: task.updatedAt.toISOString(),
   };
 }

--- a/apps/api/src/repositories/task-repository.ts
+++ b/apps/api/src/repositories/task-repository.ts
@@ -7,10 +7,21 @@ import type {
 import type {
   TaskPriority as SharedTaskPriority,
   TaskStatus as SharedTaskStatus,
+  BoardReadModelDTO,
+  BoardColumnDTO,
+  BoardSummaryDTO,
   TaskRecordDTO,
+  TaskBoardItemDTO,
+  TagSummaryDTO,
 } from '@taskforge/shared';
 
-import { normalizeTagLabels, parseDueDate, taskWithTagsInclude, toTaskRecordDTO } from './task-mapper';
+import {
+  normalizeTagLabels,
+  parseDueDate,
+  taskWithTagsInclude,
+  toTaskBoardItemDTO,
+  toTaskRecordDTO,
+} from './task-mapper';
 
 export interface TaskCreateInput {
   title: string;
@@ -41,6 +52,7 @@ export interface TaskListResult {
 
 export interface TaskRepository {
   listTasks(userId: string, options?: TaskListOptions): Promise<TaskListResult>;
+  getTaskBoard(userId: string): Promise<BoardReadModelDTO>;
   createTask(userId: string, input: TaskCreateInput): Promise<TaskRecordDTO>;
   updateTask(
     userId: string,
@@ -115,6 +127,23 @@ export function createTaskRepository(prisma: PrismaClient): TaskRepository {
       return {
         items: tasks.map(toTaskRecordDTO),
         total,
+      };
+    },
+
+    async getTaskBoard(userId) {
+      const tasks = await prisma.task.findMany({
+        where: { userId },
+        include: taskWithTagsInclude,
+      });
+
+      const now = new Date();
+      const columns = buildBoardColumns(tasks.map(toTaskBoardItemDTO), now);
+      const summary = buildBoardSummary(columns);
+
+      return {
+        columns,
+        summary,
+        generatedAt: now.toISOString(),
       };
     },
 
@@ -233,4 +262,132 @@ async function replaceTaskTags(
       },
     });
   }
+}
+
+const statusOrder: Array<{
+  status: SharedTaskStatus;
+  title: string;
+  order: number;
+}> = [
+  { status: 'TODO', title: 'To Do', order: 1 },
+  { status: 'IN_PROGRESS', title: 'In Progress', order: 2 },
+  { status: 'DONE', title: 'Done', order: 3 },
+];
+
+const priorityRank: Record<SharedTaskPriority, number> = {
+  HIGH: 0,
+  MEDIUM: 1,
+  LOW: 2,
+};
+
+function buildBoardColumns(tasks: TaskBoardItemDTO[], now: Date): BoardColumnDTO[] {
+  const buckets = new Map<SharedTaskStatus, TaskBoardItemDTO[]>();
+  for (const { status } of statusOrder) {
+    buckets.set(status, []);
+  }
+
+  for (const task of tasks) {
+    const bucket = buckets.get(task.status);
+    if (bucket) {
+      bucket.push(task);
+    }
+  }
+
+  return statusOrder.map(({ status, title, order }) => {
+    const items = buckets.get(status) ?? [];
+    const sorted = [...items].sort((left, right) => compareBoardTasks(left, right));
+    const overdueCount = sorted.filter(task => isOverdue(task, now)).length;
+    const tags = summarizeTags(sorted);
+
+    return {
+      status,
+      title,
+      order,
+      tasks: sorted,
+      total: sorted.length,
+      overdueCount,
+      tags,
+    };
+  });
+}
+
+function compareBoardTasks(left: TaskBoardItemDTO, right: TaskBoardItemDTO): number {
+  const priorityDelta = priorityRank[left.priority] - priorityRank[right.priority];
+  if (priorityDelta !== 0) {
+    return priorityDelta;
+  }
+
+  const leftDue = left.dueDate ? Date.parse(left.dueDate) : Number.POSITIVE_INFINITY;
+  const rightDue = right.dueDate ? Date.parse(right.dueDate) : Number.POSITIVE_INFINITY;
+  if (leftDue !== rightDue) {
+    return leftDue - rightDue;
+  }
+
+  const updatedDelta = Date.parse(right.updatedAt) - Date.parse(left.updatedAt);
+  if (updatedDelta !== 0) {
+    return updatedDelta;
+  }
+
+  const titleDelta = left.title.localeCompare(right.title, undefined, { sensitivity: 'base' });
+  if (titleDelta !== 0) {
+    return titleDelta;
+  }
+
+  return left.id.localeCompare(right.id);
+}
+
+function summarizeTags(tasks: TaskBoardItemDTO[]): TagSummaryDTO[] {
+  const counts = new Map<string, number>();
+
+  for (const task of tasks) {
+    for (const label of task.tags) {
+      counts.set(label, (counts.get(label) ?? 0) + 1);
+    }
+  }
+
+  return [...counts.entries()]
+    .map(([label, count]) => ({ label, count }))
+    .sort((left, right) => left.label.localeCompare(right.label, undefined, { sensitivity: 'base' }));
+}
+
+function isOverdue(task: TaskBoardItemDTO, now: Date): boolean {
+  if (!task.dueDate) {
+    return false;
+  }
+  if (task.status === 'DONE') {
+    return false;
+  }
+  const due = Date.parse(task.dueDate);
+  if (Number.isNaN(due)) {
+    return false;
+  }
+  return due < now.getTime();
+}
+
+function buildBoardSummary(columns: BoardColumnDTO[]): BoardSummaryDTO {
+  const totalsByStatus = {
+    TODO: 0,
+    IN_PROGRESS: 0,
+    DONE: 0,
+  } satisfies Record<SharedTaskStatus, number>;
+  const overdueByStatus = {
+    TODO: 0,
+    IN_PROGRESS: 0,
+    DONE: 0,
+  } satisfies Record<SharedTaskStatus, number>;
+
+  for (const column of columns) {
+    totalsByStatus[column.status] = column.total;
+    overdueByStatus[column.status] = column.overdueCount;
+  }
+
+  const totalTasks = Object.values(totalsByStatus).reduce((sum, value) => sum + value, 0);
+  const totalOverdue = Object.values(overdueByStatus).reduce((sum, value) => sum + value, 0);
+
+  return {
+    totalsByStatus,
+    overdueByStatus,
+    totalTasks,
+    totalOverdue,
+  };
 }

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -105,6 +105,20 @@ export function createTaskRouter(taskRepository?: TaskRepository) {
     }
   });
 
+  router.get('/board', async (req, res, next) => {
+    try {
+      const user = res.locals.user;
+      if (!user) {
+        return res.status(401).json({ error: 'Unauthorized' });
+      }
+
+      const board = await repository.getTaskBoard(user.id);
+      res.json(board);
+    } catch (error) {
+      next(error);
+    }
+  });
+
   router.patch('/:id', async (req, res, next) => {
     const params = TaskIdParamSchema.safeParse(req.params);
     if (!params.success) {

--- a/apps/web/lib/tasks-client.ts
+++ b/apps/web/lib/tasks-client.ts
@@ -1,4 +1,11 @@
-import { getSessionCookieName, type TaskDTO, type TaskRecordDTO, type TaskPriority, type TaskStatus } from '@taskforge/shared';
+import {
+  getSessionCookieName,
+  type BoardReadModelDTO,
+  type TaskDTO,
+  type TaskRecordDTO,
+  type TaskPriority,
+  type TaskStatus,
+} from '@taskforge/shared';
 import { z } from 'zod';
 
 import { getApiBaseUrl } from './env';
@@ -35,6 +42,52 @@ const TaskRecordSchema = z.object({
   tags: z.array(z.string().min(1)).default([]),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),
+});
+
+const TaskBoardItemSchema = z.object({
+  id: z.string().uuid(),
+  title: NonEmptyTrimmedString,
+  status: TaskStatusSchema,
+  priority: TaskPrioritySchema,
+  dueDate: NullableDateString,
+  tags: z.array(z.string().min(1)).default([]),
+  updatedAt: z.string().datetime(),
+});
+
+const TagSummarySchema = z.object({
+  label: NonEmptyTrimmedString,
+  count: z.number().int().min(0),
+});
+
+const BoardColumnSchema = z.object({
+  status: TaskStatusSchema,
+  title: NonEmptyTrimmedString,
+  order: z.number().int().min(1),
+  tasks: z.array(TaskBoardItemSchema),
+  total: z.number().int().min(0),
+  overdueCount: z.number().int().min(0),
+  tags: z.array(TagSummarySchema),
+});
+
+const BoardSummarySchema = z.object({
+  totalsByStatus: z.object({
+    TODO: z.number().int().min(0),
+    IN_PROGRESS: z.number().int().min(0),
+    DONE: z.number().int().min(0),
+  }),
+  overdueByStatus: z.object({
+    TODO: z.number().int().min(0),
+    IN_PROGRESS: z.number().int().min(0),
+    DONE: z.number().int().min(0),
+  }),
+  totalTasks: z.number().int().min(0),
+  totalOverdue: z.number().int().min(0),
+});
+
+const BoardResponseSchema = z.object({
+  columns: z.array(BoardColumnSchema),
+  summary: BoardSummarySchema,
+  generatedAt: z.string().datetime(),
 });
 
 const TaskListResponseSchema = z.object({
@@ -128,6 +181,7 @@ const TaskListQuerySchema = z
 
 export type TaskListResponse = z.infer<typeof TaskListResponseSchema>;
 export type TaskDeleteResponse = z.infer<typeof TaskDeleteResponseSchema>;
+export type TaskBoardResponse = z.infer<typeof BoardResponseSchema>;
 
 export type CreateTaskInput = Omit<TaskDTO, 'id'>;
 export type UpdateTaskInput = Partial<Omit<TaskDTO, 'id'>>;
@@ -530,6 +584,17 @@ export async function listTasks(
       method: 'GET',
       query: toQueryRecord(normalizedQuery),
       schema: TaskListResponseSchema,
+    },
+    options,
+  );
+}
+
+export async function getTaskBoard(options?: TaskClientRequestOptions): Promise<BoardReadModelDTO> {
+  return requestJson(
+    'v1/tasks/board',
+    {
+      method: 'GET',
+      schema: BoardResponseSchema,
     },
     options,
   );

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -23,6 +23,44 @@ export interface TaskRecordDTO {
   updatedAt: string;
 }
 
+export interface TaskBoardItemDTO {
+  id: string;
+  title: string;
+  status: TaskStatus;
+  priority: TaskPriority;
+  dueDate?: string;
+  tags: string[];
+  updatedAt: string;
+}
+
+export interface TagSummaryDTO {
+  label: string;
+  count: number;
+}
+
+export interface BoardColumnDTO {
+  status: TaskStatus;
+  title: string;
+  order: number;
+  tasks: TaskBoardItemDTO[];
+  total: number;
+  overdueCount: number;
+  tags: TagSummaryDTO[];
+}
+
+export interface BoardSummaryDTO {
+  totalsByStatus: Record<TaskStatus, number>;
+  overdueByStatus: Record<TaskStatus, number>;
+  totalTasks: number;
+  totalOverdue: number;
+}
+
+export interface BoardReadModelDTO {
+  columns: BoardColumnDTO[];
+  summary: BoardSummaryDTO;
+  generatedAt: string;
+}
+
 export interface AuthUserDTO {
   id: string;
   email: string;


### PR DESCRIPTION
### Motivation
- Provide a dedicated, lean read model optimized for Kanban UI rendering that groups tasks into status lanes and preserves column ordering and per-column aggregates. 
- Surface tag summaries and overdue counts with the board payload so the frontend can render summary chips without extra queries.

### Description
- Added shared DTOs for the board read model in `packages/shared/src/index.ts` including `TaskBoardItemDTO`, `TagSummaryDTO`, `BoardColumnDTO`, `BoardSummaryDTO`, and `BoardReadModelDTO` to share the response contract between API and web client. 
- Implemented `toTaskBoardItemDTO` in `apps/api/src/repositories/task-mapper.ts` to produce a lean task item (no large `description` bodies). 
- Added `getTaskBoard` to the repository in `apps/api/src/repositories/task-repository.ts` which fetches tasks with related tags in a single `prisma.task.findMany({ include: taskWithTagsInclude })` call and builds board columns with deterministic ordering (`priority -> dueDate -> updatedAt -> title -> id`), per-lane tag summaries, and overdue counts via helper functions (`buildBoardColumns`, `compareBoardTasks`, `summarizeTags`, `isOverdue`, `buildBoardSummary`). 
- Exposed a new route `GET /api/taskforge/v1/tasks/board` in `apps/api/src/routes/tasks.ts` and documented the full response schema in the OpenAPI spec (`apps/api/src/openapi.ts`) with `TaskBoardItem`, `TagSummary`, `BoardColumn`, `BoardSummary`, and `BoardResponse`. 
- Added a client-side schema and helper `getTaskBoard` in `apps/web/lib/tasks-client.ts` so the Next.js app can fetch and validate the board read model using the shared types.

### Testing
- No automated tests were executed for this change.

