### PR TITLE
Add Kanban board endpoints and persistent ordering

### DIFF
--- a/apps/api/prisma/migrations/20241010123000_task_board_order/migration.sql
+++ b/apps/api/prisma/migrations/20241010123000_task_board_order/migration.sql
@@ -1,0 +1,15 @@
+ALTER TABLE "Task" ADD COLUMN "board_order" INTEGER NOT NULL DEFAULT 0;
+
+WITH ranked AS (
+  SELECT
+    "id",
+    ROW_NUMBER() OVER (
+      PARTITION BY "userId", "status"
+      ORDER BY "updatedAt" DESC, "id"
+    ) - 1 AS row_num
+  FROM "Task"
+)
+UPDATE "Task"
+SET "board_order" = ranked.row_num
+FROM ranked
+WHERE "Task"."id" = ranked."id";

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -68,6 +68,7 @@ model Task {
   status      TaskStatus   @default(TODO)
   priority    TaskPriority @default(MEDIUM)
   dueDate     DateTime?
+  boardOrder  Int          @default(0) @map("board_order")
   createdAt   DateTime     @default(now())
   updatedAt   DateTime     @updatedAt
   user        User         @relation(fields: [userId], references: [id], onDelete: Cascade)

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -8,6 +8,7 @@ import swaggerUi from 'swagger-ui-express';
 import { PrismaUserStore, UserStore } from './auth/user-store';
 import { openApiDocument } from './openapi';
 import { createAuthRouter } from './routes/auth';
+import { createBoardRouter } from './routes/board';
 import { getPrismaClient } from './prisma';
 import { router as tagRoutes } from './routes/tags';
 import { createTaskRouter } from './routes/tasks';
@@ -80,6 +81,7 @@ export function createApp(options: CreateAppOptions = {}) {
 
   app.use(authRouterFactory.authMiddleware);
   app.use('/api/taskforge/v1/tasks', createTaskRouter(taskRepository));
+  app.use('/api/taskforge/v1/board', createBoardRouter(taskRepository));
   app.use('/api/taskforge/v1/tags', tagRoutes);
   app.get('/api/taskforge/v1/me', (_req, res) => {
     const user = res.locals.user as

--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -249,12 +249,29 @@ const boardResponse: OpenAPIV3.SchemaObject = {
     },
     summary: { $ref: '#/components/schemas/BoardSummary' },
     generatedAt: { type: 'string', format: 'date-time' },
+    updatedAt: { type: 'string', format: 'date-time' },
   },
-  required: ['columns', 'summary', 'generatedAt'],
+  required: ['columns', 'summary', 'generatedAt', 'updatedAt'],
   example: {
     columns: [boardColumn.example],
     summary: boardSummary.example,
     generatedAt: '2024-06-03T09:30:00.000Z',
+    updatedAt: '2024-06-03T09:30:00.000Z',
+  },
+};
+
+const boardMoveInput: OpenAPIV3.SchemaObject = {
+  type: 'object',
+  properties: {
+    taskId: { type: 'string', format: 'uuid' },
+    targetStatus: { type: 'string', enum: ['TODO', 'IN_PROGRESS', 'DONE'] },
+    targetIndex: { type: 'integer', minimum: 0 },
+  },
+  required: ['taskId', 'targetStatus', 'targetIndex'],
+  example: {
+    taskId: '9e22c508-1383-4609-9bbd-2e09b7a2d108',
+    targetStatus: 'IN_PROGRESS',
+    targetIndex: 1,
   },
 };
 
@@ -448,6 +465,7 @@ export const openApiDocument: OpenAPIV3.Document = {
       BoardColumn: boardColumn,
       BoardSummary: boardSummary,
       BoardResponse: boardResponse,
+      BoardMoveInput: boardMoveInput,
       TaskCreateInput: taskCreateInput,
       TaskUpdateInput: taskUpdateInput,
       TaskListResponse: taskListResponse,
@@ -839,6 +857,12 @@ export const openApiDocument: OpenAPIV3.Document = {
         responses: {
           '200': {
             description: 'Task board',
+            headers: {
+              ETag: {
+                schema: { type: 'string' },
+                description: 'Entity tag for cache validation.',
+              },
+            },
             content: {
               'application/json': {
                 schema: { $ref: '#/components/schemas/BoardResponse' },
@@ -855,6 +879,117 @@ export const openApiDocument: OpenAPIV3.Document = {
                 schema: { $ref: '#/components/schemas/ErrorResponse' },
                 examples: {
                   unauthorized: unauthorizedExample,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/api/taskforge/v1/board': {
+      get: {
+        tags: ['Board'],
+        summary: 'Retrieve the Kanban board read model',
+        description:
+          'Returns a board-friendly representation of tasks grouped by status lanes. Requires a valid JWT via `Authorization` header or the `tf_session` cookie.',
+        security: [{ bearerAuth: [] }, { sessionCookie: [] }],
+        responses: {
+          '200': {
+            description: 'Task board',
+            headers: {
+              ETag: {
+                schema: { type: 'string' },
+                description: 'Entity tag for cache validation.',
+              },
+            },
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/BoardResponse' },
+                examples: {
+                  default: { value: boardResponse.example as Record<string, unknown> },
+                },
+              },
+            },
+          },
+          '401': {
+            description: 'Unauthorized',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/ErrorResponse' },
+                examples: {
+                  unauthorized: unauthorizedExample,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/api/taskforge/v1/board/move': {
+      patch: {
+        tags: ['Board'],
+        summary: 'Move a task within the Kanban board',
+        description:
+          'Moves a task to a new status lane and/or position for the authenticated user. Requires a valid JWT via `Authorization` header or the `tf_session` cookie.',
+        security: [{ bearerAuth: [] }, { sessionCookie: [] }],
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/BoardMoveInput' },
+              examples: {
+                default: { value: boardMoveInput.example as Record<string, unknown> },
+              },
+            },
+          },
+        },
+        responses: {
+          '200': {
+            description: 'Updated board',
+            headers: {
+              ETag: {
+                schema: { type: 'string' },
+                description: 'Entity tag for cache validation.',
+              },
+            },
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/BoardResponse' },
+                examples: {
+                  default: { value: boardResponse.example as Record<string, unknown> },
+                },
+              },
+            },
+          },
+          '400': {
+            description: 'Validation error',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/ErrorResponse' },
+                examples: {
+                  invalid: invalidPayloadExample,
+                },
+              },
+            },
+          },
+          '401': {
+            description: 'Unauthorized',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/ErrorResponse' },
+                examples: {
+                  unauthorized: unauthorizedExample,
+                },
+              },
+            },
+          },
+          '404': {
+            description: 'Task not found',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/ErrorResponse' },
+                examples: {
+                  notFound: notFoundExample,
                 },
               },
             },

--- a/apps/api/src/repositories/task-mapper.ts
+++ b/apps/api/src/repositories/task-mapper.ts
@@ -13,6 +13,8 @@ export type TaskWithTags = Prisma.TaskGetPayload<{
   include: typeof taskWithTagsInclude;
 }>;
 
+export type TaskBoardItemWithOrder = TaskBoardItemDTO & { boardOrder: number };
+
 export function toTaskRecordDTO(task: TaskWithTags): TaskRecordDTO {
   const tags = task.TaskTag.map(({ tag }) => tag.label).sort((a: string, b: string) =>
     a.localeCompare(b, undefined, { sensitivity: 'base' }),
@@ -31,7 +33,7 @@ export function toTaskRecordDTO(task: TaskWithTags): TaskRecordDTO {
   };
 }
 
-export function toTaskBoardItemDTO(task: TaskWithTags): TaskBoardItemDTO {
+export function toTaskBoardItemDTO(task: TaskWithTags): TaskBoardItemWithOrder {
   const tags = task.TaskTag.map(({ tag }) => tag.label).sort((a: string, b: string) =>
     a.localeCompare(b, undefined, { sensitivity: 'base' }),
   );
@@ -44,6 +46,7 @@ export function toTaskBoardItemDTO(task: TaskWithTags): TaskBoardItemDTO {
     dueDate: task.dueDate?.toISOString(),
     tags,
     updatedAt: task.updatedAt.toISOString(),
+    boardOrder: task.boardOrder,
   };
 }
 

--- a/apps/api/src/repositories/task-repository.ts
+++ b/apps/api/src/repositories/task-repository.ts
@@ -21,6 +21,7 @@ import {
   taskWithTagsInclude,
   toTaskBoardItemDTO,
   toTaskRecordDTO,
+  type TaskBoardItemWithOrder,
 } from './task-mapper';
 
 export interface TaskCreateInput {
@@ -53,6 +54,10 @@ export interface TaskListResult {
 export interface TaskRepository {
   listTasks(userId: string, options?: TaskListOptions): Promise<TaskListResult>;
   getTaskBoard(userId: string): Promise<BoardReadModelDTO>;
+  moveTaskOnBoard(
+    userId: string,
+    input: { taskId: string; targetStatus: SharedTaskStatus; targetIndex: number },
+  ): Promise<BoardReadModelDTO | null>;
   createTask(userId: string, input: TaskCreateInput): Promise<TaskRecordDTO>;
   updateTask(
     userId: string,
@@ -137,43 +142,108 @@ export function createTaskRepository(prisma: PrismaClient): TaskRepository {
       });
 
       const now = new Date();
-      const columns = buildBoardColumns(tasks.map(toTaskBoardItemDTO), now);
+      const boardItems = tasks.map(toTaskBoardItemDTO);
+      const columns = buildBoardColumns(boardItems, now);
       const summary = buildBoardSummary(columns);
+      const updatedAt = resolveBoardUpdatedAt(boardItems, now);
 
       return {
         columns,
         summary,
         generatedAt: now.toISOString(),
+        updatedAt,
       };
+    },
+
+    async moveTaskOnBoard(userId, input) {
+      const moved = await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
+        const task = await tx.task.findFirst({
+          where: { id: input.taskId, userId },
+        });
+
+        if (!task) {
+          return null;
+        }
+
+        const sourceStatus = task.status;
+        const targetStatus = input.targetStatus as PrismaTaskStatus;
+
+        const sourceTasks = await tx.task.findMany({
+          where: { userId, status: sourceStatus },
+          orderBy: { boardOrder: 'asc' },
+          select: { id: true },
+        });
+
+        const targetTasks =
+          sourceStatus === targetStatus
+            ? sourceTasks
+            : await tx.task.findMany({
+                where: { userId, status: targetStatus },
+                orderBy: { boardOrder: 'asc' },
+                select: { id: true },
+              });
+
+        const sourceIds = sourceTasks.map(item => item.id);
+        const targetIds = (sourceStatus === targetStatus ? sourceIds : targetTasks.map(item => item.id))
+          .filter(id => id !== task.id);
+
+        const filteredSourceIds =
+          sourceStatus === targetStatus ? targetIds : sourceIds.filter(id => id !== task.id);
+
+        const clampedIndex = clampIndex(input.targetIndex, targetIds.length);
+        targetIds.splice(clampedIndex, 0, task.id);
+
+        await updateBoardOrders(tx, targetIds, {
+          movedTaskId: task.id,
+          movedTaskStatus: targetStatus,
+        });
+
+        if (sourceStatus !== targetStatus) {
+          await updateBoardOrders(tx, filteredSourceIds);
+        }
+
+        return true;
+      });
+
+      if (!moved) {
+        return null;
+      }
+
+      return this.getTaskBoard(userId);
     },
 
     async createTask(userId, input) {
       const normalizedTags = normalizeTagLabels(input.tags);
-      const task = await prisma.task.create({
-        data: {
-          title: input.title,
-          description: input.description ?? null,
-          status: (input.status ?? 'TODO') as PrismaTaskStatus,
-          priority: (input.priority ?? 'MEDIUM') as PrismaTaskPriority,
-          dueDate: parseDueDate(input.dueDate),
-          user: { connect: { id: userId } },
-          TaskTag: normalizedTags.length
-            ? {
-                create: normalizedTags.map(label => ({
-                  tag: {
-                    connectOrCreate: {
-                      where: { label },
-                      create: { label },
+      return prisma.$transaction(async (tx: Prisma.TransactionClient) => {
+        const status = (input.status ?? 'TODO') as PrismaTaskStatus;
+        const boardOrder = await nextBoardOrder(tx, userId, status);
+        const task = await tx.task.create({
+          data: {
+            title: input.title,
+            description: input.description ?? null,
+            status,
+            priority: (input.priority ?? 'MEDIUM') as PrismaTaskPriority,
+            dueDate: parseDueDate(input.dueDate),
+            boardOrder,
+            user: { connect: { id: userId } },
+            TaskTag: normalizedTags.length
+              ? {
+                  create: normalizedTags.map(label => ({
+                    tag: {
+                      connectOrCreate: {
+                        where: { label },
+                        create: { label },
+                      },
                     },
-                  },
-                })),
-              }
-            : undefined,
-        },
-        include: taskWithTagsInclude,
-      });
+                  })),
+                }
+              : undefined,
+          },
+          include: taskWithTagsInclude,
+        });
 
-      return toTaskRecordDTO(task);
+        return toTaskRecordDTO(task);
+      });
     },
 
     async updateTask(userId, taskId, input) {
@@ -191,7 +261,11 @@ export function createTaskRepository(prisma: PrismaClient): TaskRepository {
           updateData.description = input.description;
         }
         if (input.status !== undefined) {
-          updateData.status = input.status as PrismaTaskStatus;
+          const nextStatus = input.status as PrismaTaskStatus;
+          updateData.status = nextStatus;
+          if (nextStatus !== existing.status) {
+            updateData.boardOrder = await nextBoardOrder(tx, userId, nextStatus);
+          }
         }
         if (input.priority !== undefined) {
           updateData.priority = input.priority as PrismaTaskPriority;
@@ -280,8 +354,8 @@ const priorityRank: Record<SharedTaskPriority, number> = {
   LOW: 2,
 };
 
-function buildBoardColumns(tasks: TaskBoardItemDTO[], now: Date): BoardColumnDTO[] {
-  const buckets = new Map<SharedTaskStatus, TaskBoardItemDTO[]>();
+function buildBoardColumns(tasks: TaskBoardItemWithOrder[], now: Date): BoardColumnDTO[] {
+  const buckets = new Map<SharedTaskStatus, TaskBoardItemWithOrder[]>();
   for (const { status } of statusOrder) {
     buckets.set(status, []);
   }
@@ -296,6 +370,7 @@ function buildBoardColumns(tasks: TaskBoardItemDTO[], now: Date): BoardColumnDTO
   return statusOrder.map(({ status, title, order }) => {
     const items = buckets.get(status) ?? [];
     const sorted = [...items].sort((left, right) => compareBoardTasks(left, right));
+    const visibleTasks = sorted.map(({ boardOrder: _boardOrder, ...task }) => task);
     const overdueCount = sorted.filter(task => isOverdue(task, now)).length;
     const tags = summarizeTags(sorted);
 
@@ -303,15 +378,20 @@ function buildBoardColumns(tasks: TaskBoardItemDTO[], now: Date): BoardColumnDTO
       status,
       title,
       order,
-      tasks: sorted,
-      total: sorted.length,
+      tasks: visibleTasks,
+      total: visibleTasks.length,
       overdueCount,
       tags,
     };
   });
 }
 
-function compareBoardTasks(left: TaskBoardItemDTO, right: TaskBoardItemDTO): number {
+function compareBoardTasks(left: TaskBoardItemWithOrder, right: TaskBoardItemWithOrder): number {
+  const orderDelta = left.boardOrder - right.boardOrder;
+  if (orderDelta !== 0) {
+    return orderDelta;
+  }
+
   const priorityDelta = priorityRank[left.priority] - priorityRank[right.priority];
   if (priorityDelta !== 0) {
     return priorityDelta;
@@ -390,4 +470,59 @@ function buildBoardSummary(columns: BoardColumnDTO[]): BoardSummaryDTO {
     totalTasks,
     totalOverdue,
   };
+}
+
+function resolveBoardUpdatedAt(tasks: TaskBoardItemWithOrder[], fallback: Date): string {
+  const maxUpdatedAt = tasks.reduce((latest, task) => {
+    const updated = Date.parse(task.updatedAt);
+    if (Number.isNaN(updated)) {
+      return latest;
+    }
+    return Math.max(latest, updated);
+  }, Number.NEGATIVE_INFINITY);
+
+  if (!Number.isFinite(maxUpdatedAt)) {
+    return fallback.toISOString();
+  }
+
+  return new Date(maxUpdatedAt).toISOString();
+}
+
+async function nextBoardOrder(
+  tx: Prisma.TransactionClient,
+  userId: string,
+  status: PrismaTaskStatus,
+): Promise<number> {
+  const result = await tx.task.aggregate({
+    where: { userId, status },
+    _max: { boardOrder: true },
+  });
+
+  return (result._max.boardOrder ?? -1) + 1;
+}
+
+function clampIndex(index: number, max: number): number {
+  if (Number.isNaN(index) || !Number.isFinite(index)) {
+    return 0;
+  }
+
+  return Math.min(Math.max(0, Math.floor(index)), max);
+}
+
+async function updateBoardOrders(
+  tx: Prisma.TransactionClient,
+  orderedIds: string[],
+  options?: { movedTaskId?: string; movedTaskStatus?: PrismaTaskStatus },
+): Promise<void> {
+  for (const [index, id] of orderedIds.entries()) {
+    const data: Prisma.TaskUpdateInput = { boardOrder: index };
+    if (options?.movedTaskId === id && options.movedTaskStatus) {
+      data.status = options.movedTaskStatus;
+    }
+
+    await tx.task.update({
+      where: { id },
+      data,
+    });
+  }
 }

--- a/apps/api/src/routes/board.ts
+++ b/apps/api/src/routes/board.ts
@@ -1,0 +1,70 @@
+import { Router } from 'express';
+
+import { getPrismaClient } from '../prisma';
+import { createTaskRepository, type TaskRepository } from '../repositories/task-repository';
+import { BoardMoveSchema } from '../schemas/board';
+
+function resolveIfNoneMatch(req: { headers: Record<string, string | string[] | undefined> }) {
+  const header = req.headers['if-none-match'];
+  if (Array.isArray(header)) {
+    return header.join(', ');
+  }
+  return header;
+}
+
+function setBoardCacheHeaders(res: { setHeader: (key: string, value: string) => void }, updatedAt: string) {
+  const etag = `W/"${updatedAt}"`;
+  res.setHeader('ETag', etag);
+  res.setHeader('Last-Modified', updatedAt);
+  return etag;
+}
+
+export function createBoardRouter(taskRepository?: TaskRepository) {
+  const repository = taskRepository ?? createTaskRepository(getPrismaClient());
+  const router = Router();
+
+  router.get('/', async (req, res, next) => {
+    try {
+      const user = res.locals.user;
+      if (!user) {
+        return res.status(401).json({ error: 'Unauthorized' });
+      }
+
+      const board = await repository.getTaskBoard(user.id);
+      const etag = setBoardCacheHeaders(res, board.updatedAt);
+      if (resolveIfNoneMatch(req) === etag) {
+        return res.status(304).end();
+      }
+
+      res.json(board);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.patch('/move', async (req, res, next) => {
+    const parsed = BoardMoveSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ error: 'Invalid payload', details: parsed.error.flatten() });
+    }
+
+    try {
+      const user = res.locals.user;
+      if (!user) {
+        return res.status(401).json({ error: 'Unauthorized' });
+      }
+
+      const board = await repository.moveTaskOnBoard(user.id, parsed.data);
+      if (!board) {
+        return res.status(404).json({ error: 'Not found' });
+      }
+
+      setBoardCacheHeaders(res, board.updatedAt);
+      res.json(board);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  return router;
+}

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -44,6 +44,21 @@ const TaskIdParamSchema = z.object({
     .uuid({ message: 'Invalid identifier' }),
 });
 
+function resolveIfNoneMatch(req: { headers: Record<string, string | string[] | undefined> }) {
+  const header = req.headers['if-none-match'];
+  if (Array.isArray(header)) {
+    return header.join(', ');
+  }
+  return header;
+}
+
+function setBoardCacheHeaders(res: { setHeader: (key: string, value: string) => void }, updatedAt: string) {
+  const etag = `W/"${updatedAt}"`;
+  res.setHeader('ETag', etag);
+  res.setHeader('Last-Modified', updatedAt);
+  return etag;
+}
+
 export function createTaskRouter(taskRepository?: TaskRepository) {
   const repository = taskRepository ?? createTaskRepository(getPrismaClient());
   const router = Router();
@@ -113,6 +128,10 @@ export function createTaskRouter(taskRepository?: TaskRepository) {
       }
 
       const board = await repository.getTaskBoard(user.id);
+      const etag = setBoardCacheHeaders(res, board.updatedAt);
+      if (resolveIfNoneMatch(req) === etag) {
+        return res.status(304).end();
+      }
       res.json(board);
     } catch (error) {
       next(error);

--- a/apps/api/src/schemas/board.ts
+++ b/apps/api/src/schemas/board.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const BoardMoveSchema = z.object({
+  taskId: z
+    .string({ required_error: 'Task id is required', invalid_type_error: 'Invalid identifier' })
+    .trim()
+    .uuid({ message: 'Invalid identifier' }),
+  targetStatus: z.enum(['TODO', 'IN_PROGRESS', 'DONE']),
+  targetIndex: z.number().int().min(0),
+});

--- a/apps/api/tests/tasks.http
+++ b/apps/api/tests/tasks.http
@@ -8,6 +8,25 @@ Authorization: Bearer {{accessToken}}
 Cookie: tf_session={{accessToken}}
 
 ###
+# Fetch the Kanban board read model
+GET http://localhost:4000/api/taskforge/v1/board
+Authorization: Bearer {{accessToken}}
+Cookie: tf_session={{accessToken}}
+
+###
+# Move a task to another status + index (replace {{taskId}})
+PATCH http://localhost:4000/api/taskforge/v1/board/move
+Content-Type: application/json
+Authorization: Bearer {{accessToken}}
+Cookie: tf_session={{accessToken}}
+
+{
+  "taskId": "{{taskId}}",
+  "targetStatus": "IN_PROGRESS",
+  "targetIndex": 0
+}
+
+###
 # Filtered search: high priority docs tasks due in Q1
 
 GET http://localhost:4000/api/taskforge/v1/tasks?q=release&status=IN_PROGRESS&priority=HIGH&tag=docs&tag=launch&dueFrom=2024-01-01T00:00:00.000Z&dueTo=2024-03-31T23:59:59.999Z

--- a/apps/web/lib/tasks-client.ts
+++ b/apps/web/lib/tasks-client.ts
@@ -88,6 +88,7 @@ const BoardResponseSchema = z.object({
   columns: z.array(BoardColumnSchema),
   summary: BoardSummarySchema,
   generatedAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
 });
 
 const TaskListResponseSchema = z.object({

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -59,6 +59,7 @@ export interface BoardReadModelDTO {
   columns: BoardColumnDTO[];
   summary: BoardSummaryDTO;
   generatedAt: string;
+  updatedAt: string;
 }
 
 export interface AuthUserDTO {


### PR DESCRIPTION
### Motivation
- Provide a read model and client-friendly endpoints for the Kanban board with caching metadata to allow efficient UI polling and client caching.
- Persist and manage per-user task ordering so drag/drop operations reliably update task positions and cannot corrupt indices under concurrent updates.
- Expose a single move API that validates payloads and enforces that only the owning user can mutate their board ordering.

### Description
- Database: added `board_order` integer column to `Task` (`board_order` default 0) and a migration SQL that backfills per-user/status ordering based on `updatedAt` (ranked by `updatedAt` desc, id). 
- Repository & mapper: included `boardOrder` in task mapping, added `nextBoardOrder`, `clampIndex`, `updateBoardOrders`, and `moveTaskOnBoard` transactional logic that reorders source/target lanes atomically and sets `boardOrder` when creating/updating tasks, and exposed `updatedAt` in the board read model. 
- Routes & schemas: added `GET /api/taskforge/v1/board` and `PATCH /api/taskforge/v1/board/move` via a new board router with Zod `BoardMoveSchema`, ETag/Last-Modified cache headers, 304 handling, and consistent error envelopes; also added caching support to existing `GET /tasks/board` response. 
- API surface & clients: updated shared DTOs to include `updatedAt` on `BoardReadModelDTO`, updated OpenAPI docs with `BoardResponse` and `BoardMoveInput` schemas and examples, added `.http` request examples, and updated the web client `BoardResponseSchema` accordingly. 

### Testing
- No automated tests were executed as part of this change (only HTTP examples and OpenAPI docs were added for manual/QA exercise).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69773ee7c7908322aae455d0c0bb244a)