### PR TITLE
Fix Kanban drag interactions (drag-handle, board error guard) and add board API tests

### DIFF
--- a/apps/api/tests/tasks.e2e.test.ts
+++ b/apps/api/tests/tasks.e2e.test.ts
@@ -1,26 +1,28 @@
-import type { SuperTest, Test } from 'supertest';
+import type { SuperTest, Test } from "supertest";
 
-import type { TaskRepository } from '../src/repositories/task-repository';
+import type { TaskRepository } from "../src/repositories/task-repository";
 
-import { createTestAgent } from './utils/test-app';
-import { extractSessionCookie, registerTestUser } from './utils/auth';
-import { createTask, createUser, defaultPassword } from './utils/factories';
+import { createTestAgent } from "./utils/test-app";
+import { extractSessionCookie, registerTestUser } from "./utils/auth";
+import { createTask, createUser, defaultPassword } from "./utils/factories";
 
-const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
-describe('Tasks API', () => {
+describe("Tasks API", () => {
   let agent: SuperTest<Test>;
   let taskRepository: TaskRepository;
 
   beforeEach(() => {
-    const context = createTestAgent({ sessionBridgeSecret: 'test-bridge-secret' });
+    const context = createTestAgent({
+      sessionBridgeSecret: "test-bridge-secret",
+    });
     agent = context.agent;
     taskRepository = context.taskRepository;
   });
 
   async function register() {
     const registered = await registerTestUser(agent, {
-      email: 'tasks-user@example.com',
+      email: "tasks-user@example.com",
       password: defaultPassword,
     });
 
@@ -31,59 +33,62 @@ describe('Tasks API', () => {
     };
   }
 
-  function withAuth(request: Test, auth: { accessToken: string; sessionCookie?: string }) {
-    let authed = request.set('Authorization', `Bearer ${auth.accessToken}`);
+  function withAuth(
+    request: Test,
+    auth: { accessToken: string; sessionCookie?: string },
+  ) {
+    let authed = request.set("Authorization", `Bearer ${auth.accessToken}`);
     if (auth.sessionCookie) {
-      authed = authed.set('Cookie', auth.sessionCookie);
+      authed = authed.set("Cookie", auth.sessionCookie);
     }
     return authed;
   }
 
-  describe('list', () => {
-    it('returns paginated tasks for the authenticated user with metadata', async () => {
+  describe("list", () => {
+    it("returns paginated tasks for the authenticated user with metadata", async () => {
       const auth = await register();
 
       const first = await createTask({
         userId: auth.userId,
-        title: 'Calibrate roadmap',
-        description: 'Sync on upcoming milestones',
-        status: 'TODO',
-        priority: 'LOW',
-        dueDate: '2024-01-05T09:00:00.000Z',
-        tags: ['roadmap', 'planning'],
+        title: "Calibrate roadmap",
+        description: "Sync on upcoming milestones",
+        status: "TODO",
+        priority: "LOW",
+        dueDate: "2024-01-05T09:00:00.000Z",
+        tags: ["roadmap", "planning"],
       });
       await sleep(5);
       const second = await createTask({
         userId: auth.userId,
-        title: 'Publish release notes',
-        description: 'Docs for the Q1 launch',
-        status: 'IN_PROGRESS',
-        priority: 'HIGH',
-        dueDate: '2024-01-15T17:00:00.000Z',
-        tags: ['docs', 'release'],
+        title: "Publish release notes",
+        description: "Docs for the Q1 launch",
+        status: "IN_PROGRESS",
+        priority: "HIGH",
+        dueDate: "2024-01-15T17:00:00.000Z",
+        tags: ["docs", "release"],
       });
       await sleep(5);
       const third = await createTask({
         userId: auth.userId,
-        title: 'Run retrospective',
-        description: 'Team retro for the last sprint',
-        status: 'DONE',
-        priority: 'MEDIUM',
-        dueDate: '2024-01-20T20:00:00.000Z',
-        tags: ['retro', 'team'],
+        title: "Run retrospective",
+        description: "Team retro for the last sprint",
+        status: "DONE",
+        priority: "MEDIUM",
+        dueDate: "2024-01-20T20:00:00.000Z",
+        tags: ["retro", "team"],
       });
 
-      const outsider = await createUser({ email: 'outsider@example.com' });
+      const outsider = await createUser({ email: "outsider@example.com" });
       await createTask({
         userId: outsider.user.id,
-        title: 'Should stay hidden',
-        status: 'TODO',
-        dueDate: '2024-01-07T12:00:00.000Z',
-        tags: ['private'],
+        title: "Should stay hidden",
+        status: "TODO",
+        dueDate: "2024-01-07T12:00:00.000Z",
+        tags: ["private"],
       });
 
       const response = await withAuth(
-        agent.get('/api/taskforge/v1/tasks?page=1&pageSize=2'),
+        agent.get("/api/taskforge/v1/tasks?page=1&pageSize=2"),
         auth,
       ).expect(200);
 
@@ -94,23 +99,23 @@ describe('Tasks API', () => {
         items: [
           {
             id: third.task.id,
-            title: 'Run retrospective',
-            description: 'Team retro for the last sprint',
-            status: 'DONE',
-            priority: 'MEDIUM',
-            dueDate: '2024-01-20T20:00:00.000Z',
-            tags: ['retro', 'team'],
+            title: "Run retrospective",
+            description: "Team retro for the last sprint",
+            status: "DONE",
+            priority: "MEDIUM",
+            dueDate: "2024-01-20T20:00:00.000Z",
+            tags: ["retro", "team"],
             createdAt: expect.any(String),
             updatedAt: expect.any(String),
           },
           {
             id: second.task.id,
-            title: 'Publish release notes',
-            description: 'Docs for the Q1 launch',
-            status: 'IN_PROGRESS',
-            priority: 'HIGH',
-            dueDate: '2024-01-15T17:00:00.000Z',
-            tags: ['docs', 'release'],
+            title: "Publish release notes",
+            description: "Docs for the Q1 launch",
+            status: "IN_PROGRESS",
+            priority: "HIGH",
+            dueDate: "2024-01-15T17:00:00.000Z",
+            tags: ["docs", "release"],
             createdAt: expect.any(String),
             updatedAt: expect.any(String),
           },
@@ -120,17 +125,23 @@ describe('Tasks API', () => {
       expect(new Date(response.body.items[0].createdAt).toISOString()).toBe(
         response.body.items[0].createdAt,
       );
-      expect(new Date(response.body.items[0].updatedAt).getTime()).toBeGreaterThan(0);
+      expect(
+        new Date(response.body.items[0].updatedAt).getTime(),
+      ).toBeGreaterThan(0);
       expect(new Date(response.body.items[1].createdAt).toISOString()).toBe(
         response.body.items[1].createdAt,
       );
-      expect(new Date(response.body.items[1].updatedAt).getTime()).toBeGreaterThan(0);
       expect(
-        response.body.items.find((item: { title: string }) => item.title === 'Should stay hidden'),
+        new Date(response.body.items[1].updatedAt).getTime(),
+      ).toBeGreaterThan(0);
+      expect(
+        response.body.items.find(
+          (item: { title: string }) => item.title === "Should stay hidden",
+        ),
       ).toBeUndefined();
 
       const secondPage = await withAuth(
-        agent.get('/api/taskforge/v1/tasks?page=2&pageSize=2'),
+        agent.get("/api/taskforge/v1/tasks?page=2&pageSize=2"),
         auth,
       ).expect(200);
 
@@ -141,54 +152,54 @@ describe('Tasks API', () => {
         items: [
           expect.objectContaining({
             id: first.task.id,
-            title: 'Calibrate roadmap',
-            dueDate: '2024-01-05T09:00:00.000Z',
-            tags: ['planning', 'roadmap'],
+            title: "Calibrate roadmap",
+            dueDate: "2024-01-05T09:00:00.000Z",
+            tags: ["planning", "roadmap"],
           }),
         ],
       });
     });
 
-    it('requires authentication to list tasks', async () => {
-      const response = await agent.get('/api/taskforge/v1/tasks').expect(401);
-      expect(response.body).toEqual({ error: 'Unauthorized' });
+    it("requires authentication to list tasks", async () => {
+      const response = await agent.get("/api/taskforge/v1/tasks").expect(401);
+      expect(response.body).toEqual({ error: "Unauthorized" });
     });
 
-    it('supports filtering by status, priority, tag, search, and due date range', async () => {
+    it("supports filtering by status, priority, tag, search, and due date range", async () => {
       const auth = await register();
 
       await createTask({
         userId: auth.userId,
-        title: 'Plan kickoff',
-        description: 'Kickoff with stakeholders',
-        status: 'TODO',
-        priority: 'LOW',
-        dueDate: '2024-01-01T10:00:00.000Z',
-        tags: ['planning'],
+        title: "Plan kickoff",
+        description: "Kickoff with stakeholders",
+        status: "TODO",
+        priority: "LOW",
+        dueDate: "2024-01-01T10:00:00.000Z",
+        tags: ["planning"],
       });
 
       const target = await createTask({
         userId: auth.userId,
-        title: 'Publish release notes',
-        description: 'Write docs for the Q1 release',
-        status: 'IN_PROGRESS',
-        priority: 'HIGH',
-        dueDate: '2024-01-10T10:00:00.000Z',
-        tags: ['docs', 'release'],
+        title: "Publish release notes",
+        description: "Write docs for the Q1 release",
+        status: "IN_PROGRESS",
+        priority: "HIGH",
+        dueDate: "2024-01-10T10:00:00.000Z",
+        tags: ["docs", "release"],
       });
 
       await createTask({
         userId: auth.userId,
-        title: 'File expenses',
-        description: 'Submit reimbursements',
-        status: 'DONE',
-        priority: 'MEDIUM',
-        tags: ['finance'],
+        title: "File expenses",
+        description: "Submit reimbursements",
+        status: "DONE",
+        priority: "MEDIUM",
+        tags: ["finance"],
       });
 
       const response = await withAuth(
         agent.get(
-          '/api/taskforge/v1/tasks?page=1&pageSize=10&status=IN_PROGRESS&priority=HIGH&tag=docs&q=release&dueFrom=2024-01-05T00:00:00.000Z&dueTo=2024-01-15T23:59:59.999Z',
+          "/api/taskforge/v1/tasks?page=1&pageSize=10&status=IN_PROGRESS&priority=HIGH&tag=docs&q=release&dueFrom=2024-01-05T00:00:00.000Z&dueTo=2024-01-15T23:59:59.999Z",
         ),
         auth,
       ).expect(200);
@@ -200,12 +211,12 @@ describe('Tasks API', () => {
         items: [
           {
             id: target.task.id,
-            title: 'Publish release notes',
-            description: 'Write docs for the Q1 release',
-            status: 'IN_PROGRESS',
-            priority: 'HIGH',
-            dueDate: '2024-01-10T10:00:00.000Z',
-            tags: ['docs', 'release'],
+            title: "Publish release notes",
+            description: "Write docs for the Q1 release",
+            status: "IN_PROGRESS",
+            priority: "HIGH",
+            dueDate: "2024-01-10T10:00:00.000Z",
+            tags: ["docs", "release"],
             createdAt: expect.any(String),
             updatedAt: expect.any(String),
           },
@@ -214,63 +225,72 @@ describe('Tasks API', () => {
 
       expect(
         response.body.items.every(
-          (item: { status: string; priority: string; tags: string[]; title: string }) =>
-            item.status === 'IN_PROGRESS' &&
-            item.priority === 'HIGH' &&
-            item.tags.includes('docs') &&
-            item.title.toLowerCase().includes('release'),
+          (item: {
+            status: string;
+            priority: string;
+            tags: string[];
+            title: string;
+          }) =>
+            item.status === "IN_PROGRESS" &&
+            item.priority === "HIGH" &&
+            item.tags.includes("docs") &&
+            item.title.toLowerCase().includes("release"),
         ),
       ).toBe(true);
     });
 
-    it('rejects invalid due date ranges', async () => {
+    it("rejects invalid due date ranges", async () => {
       const auth = await register();
 
       const response = await withAuth(
         agent.get(
-          '/api/taskforge/v1/tasks?dueFrom=2025-01-10T00:00:00.000Z&dueTo=2025-01-01T00:00:00.000Z',
+          "/api/taskforge/v1/tasks?dueFrom=2025-01-10T00:00:00.000Z&dueTo=2025-01-01T00:00:00.000Z",
         ),
         auth,
       ).expect(400);
 
-      expect(response.body).toEqual(expect.objectContaining({ error: 'Invalid payload' }));
+      expect(response.body).toEqual(
+        expect.objectContaining({ error: "Invalid payload" }),
+      );
     });
 
-    it('validates pagination parameters', async () => {
+    it("validates pagination parameters", async () => {
       const auth = await register();
 
       const response = await withAuth(
-        agent.get('/api/taskforge/v1/tasks?page=0&pageSize=-1'),
+        agent.get("/api/taskforge/v1/tasks?page=0&pageSize=-1"),
         auth,
       ).expect(400);
 
-      expect(response.body).toEqual(expect.objectContaining({ error: 'Invalid payload' }));
+      expect(response.body).toEqual(
+        expect.objectContaining({ error: "Invalid payload" }),
+      );
     });
   });
 
-  describe('create', () => {
-    it('creates a task with defaults and returns the persisted record', async () => {
+  describe("create", () => {
+    it("creates a task with defaults and returns the persisted record", async () => {
       const auth = await register();
 
       const createResponse = await withAuth(
-        agent.post('/api/taskforge/v1/tasks').send({
-          title: 'Write API docs',
-          description: 'Outline request/response examples',
-          priority: 'HIGH',
-          tags: [' docs  ', 'api', 'work'],
-          dueDate: '2024-03-01T09:30:00.000Z',
+        agent.post("/api/taskforge/v1/tasks").send({
+          title: "Write API docs",
+          description: "Outline request/response examples",
+          priority: "HIGH",
+          tags: [" docs  ", "api", "work"],
+          dueDate: "2024-03-01T09:30:00.000Z",
         }),
         auth,
       ).expect(201);
 
       expect(createResponse.body).toEqual({
         id: expect.any(String),
-        title: 'Write API docs',
-        description: 'Outline request/response examples',
-        status: 'TODO',
-        priority: 'HIGH',
-        dueDate: '2024-03-01T09:30:00.000Z',
-        tags: ['api', 'docs', 'work'],
+        title: "Write API docs",
+        description: "Outline request/response examples",
+        status: "TODO",
+        priority: "HIGH",
+        dueDate: "2024-03-01T09:30:00.000Z",
+        tags: ["api", "docs", "work"],
         createdAt: expect.any(String),
         updatedAt: expect.any(String),
       });
@@ -278,80 +298,282 @@ describe('Tasks API', () => {
       expect(new Date(createResponse.body.createdAt).toISOString()).toBe(
         createResponse.body.createdAt,
       );
-      expect(new Date(createResponse.body.updatedAt).getTime()).toBeGreaterThan(0);
+      expect(new Date(createResponse.body.updatedAt).getTime()).toBeGreaterThan(
+        0,
+      );
 
-      const stored = await taskRepository.listTasks(auth.userId, { pageSize: 10 });
+      const stored = await taskRepository.listTasks(auth.userId, {
+        pageSize: 10,
+      });
       expect(stored.total).toBe(1);
       expect(stored.items[0]).toMatchObject({
         id: createResponse.body.id,
-        title: 'Write API docs',
-        priority: 'HIGH',
-        dueDate: '2024-03-01T09:30:00.000Z',
-        tags: ['api', 'docs', 'work'],
+        title: "Write API docs",
+        priority: "HIGH",
+        dueDate: "2024-03-01T09:30:00.000Z",
+        tags: ["api", "docs", "work"],
       });
     });
 
-    it('rejects invalid payloads with the standard error envelope', async () => {
+    it("rejects invalid payloads with the standard error envelope", async () => {
       const auth = await register();
 
       const response = await withAuth(
-        agent.post('/api/taskforge/v1/tasks').send({ title: '  ' }),
+        agent.post("/api/taskforge/v1/tasks").send({ title: "  " }),
         auth,
       ).expect(400);
 
       expect(response.body).toEqual(
         expect.objectContaining({
-          error: 'Invalid payload',
+          error: "Invalid payload",
           details: expect.any(Object),
         }),
       );
     });
 
-    it('requires authentication to create tasks', async () => {
+    it("requires authentication to create tasks", async () => {
       const response = await agent
-        .post('/api/taskforge/v1/tasks')
-        .send({ title: 'Unauthenticated task' })
+        .post("/api/taskforge/v1/tasks")
+        .send({ title: "Unauthenticated task" })
         .expect(401);
 
-      expect(response.body).toEqual({ error: 'Unauthorized' });
+      expect(response.body).toEqual({ error: "Unauthorized" });
     });
   });
 
-  describe('update', () => {
-    it('updates a task and returns the fresh record with propagated tags', async () => {
+  describe("board", () => {
+    it("returns grouped board data, lane ordering, and summary for the authenticated user", async () => {
+      const auth = await register();
+
+      const todoA = await createTask({
+        userId: auth.userId,
+        title: "Todo A",
+        status: "TODO",
+        tags: ["ops"],
+      });
+      const todoB = await createTask({
+        userId: auth.userId,
+        title: "Todo B",
+        status: "TODO",
+        tags: ["ops", "frontend"],
+      });
+      const inProgress = await createTask({
+        userId: auth.userId,
+        title: "In Progress A",
+        status: "IN_PROGRESS",
+        tags: ["backend"],
+      });
+      const done = await createTask({
+        userId: auth.userId,
+        title: "Done A",
+        status: "DONE",
+        tags: ["frontend"],
+      });
+
+      const outsider = await createUser({
+        email: "board-outsider@example.com",
+      });
+      await createTask({
+        userId: outsider.user.id,
+        title: "Private task",
+        status: "TODO",
+        tags: ["private"],
+      });
+
+      const response = await withAuth(
+        agent.get("/api/taskforge/v1/tasks/board"),
+        auth,
+      ).expect(200);
+
+      expect(
+        response.body.columns.map(
+          (column: { status: string }) => column.status,
+        ),
+      ).toEqual(["TODO", "IN_PROGRESS", "DONE"]);
+      expect(
+        response.body.columns[0].tasks.map((task: { id: string }) => task.id),
+      ).toEqual([todoA.task.id, todoB.task.id]);
+      expect(
+        response.body.columns[1].tasks.map((task: { id: string }) => task.id),
+      ).toEqual([inProgress.task.id]);
+      expect(
+        response.body.columns[2].tasks.map((task: { id: string }) => task.id),
+      ).toEqual([done.task.id]);
+      expect(response.body.summary).toEqual(
+        expect.objectContaining({
+          totalTasks: 4,
+          totalsByStatus: { TODO: 2, IN_PROGRESS: 1, DONE: 1 },
+        }),
+      );
+    });
+
+    it("requires authentication to fetch the board", async () => {
+      const response = await agent
+        .get("/api/taskforge/v1/tasks/board")
+        .expect(401);
+      expect(response.body).toEqual({ error: "Unauthorized" });
+    });
+
+    it("supports same-lane reorder and cross-lane move through board move endpoint", async () => {
+      const auth = await register();
+      const todoA = await createTask({
+        userId: auth.userId,
+        title: "Todo A",
+        status: "TODO",
+      });
+      const todoB = await createTask({
+        userId: auth.userId,
+        title: "Todo B",
+        status: "TODO",
+      });
+      const todoC = await createTask({
+        userId: auth.userId,
+        title: "Todo C",
+        status: "TODO",
+      });
+      const inProgress = await createTask({
+        userId: auth.userId,
+        title: "Doing A",
+        status: "IN_PROGRESS",
+      });
+
+      const reordered = await withAuth(
+        agent.patch("/api/taskforge/v1/tasks/board/move").send({
+          taskId: todoC.task.id,
+          targetStatus: "TODO",
+          targetIndex: 0,
+        }),
+        auth,
+      ).expect(200);
+
+      expect(
+        reordered.body.columns
+          .find((column: { status: string }) => column.status === "TODO")
+          .tasks.map((task: { id: string }) => task.id),
+      ).toEqual([todoC.task.id, todoA.task.id, todoB.task.id]);
+
+      const moved = await withAuth(
+        agent.patch("/api/taskforge/v1/tasks/board/move").send({
+          taskId: todoA.task.id,
+          targetStatus: "IN_PROGRESS",
+          targetIndex: 1,
+        }),
+        auth,
+      ).expect(200);
+
+      expect(
+        moved.body.columns
+          .find((column: { status: string }) => column.status === "TODO")
+          .tasks.map((task: { id: string }) => task.id),
+      ).toEqual([todoC.task.id, todoB.task.id]);
+      expect(
+        moved.body.columns
+          .find((column: { status: string }) => column.status === "IN_PROGRESS")
+          .tasks.map((task: { id: string; status: string }) => ({
+            id: task.id,
+            status: task.status,
+          })),
+      ).toEqual([
+        { id: inProgress.task.id, status: "IN_PROGRESS" },
+        { id: todoA.task.id, status: "IN_PROGRESS" },
+      ]);
+    });
+
+    it("validates targetIndex and returns not found for unknown tasks", async () => {
+      const auth = await register();
+      const todo = await createTask({
+        userId: auth.userId,
+        title: "Todo A",
+        status: "TODO",
+      });
+
+      const invalid = await withAuth(
+        agent.patch("/api/taskforge/v1/tasks/board/move").send({
+          taskId: todo.task.id,
+          targetStatus: "TODO",
+          targetIndex: 99,
+        }),
+        auth,
+      ).expect(400);
+
+      expect(invalid.body).toEqual(
+        expect.objectContaining({
+          error: "Invalid payload",
+          details: expect.objectContaining({
+            targetIndex: expect.stringContaining("targetIndex must be between"),
+          }),
+        }),
+      );
+
+      const notFound = await withAuth(
+        agent.patch("/api/taskforge/v1/tasks/board/move").send({
+          taskId: "f30fc08a-f14c-403f-ac46-bccabf17eca6",
+          targetStatus: "TODO",
+          targetIndex: 0,
+        }),
+        auth,
+      ).expect(404);
+
+      expect(notFound.body).toEqual({ error: "Not found" });
+    });
+
+    it("isolates board moves by user ownership", async () => {
+      const auth = await register();
+      const other = await createUser({ email: "board-isolation@example.com" });
+      const foreign = await createTask({
+        userId: other.user.id,
+        title: "Foreign task",
+        status: "TODO",
+      });
+
+      const response = await withAuth(
+        agent.patch("/api/taskforge/v1/tasks/board/move").send({
+          taskId: foreign.task.id,
+          targetStatus: "DONE",
+          targetIndex: 0,
+        }),
+        auth,
+      ).expect(404);
+
+      expect(response.body).toEqual({ error: "Not found" });
+    });
+  });
+
+  describe("update", () => {
+    it("updates a task and returns the fresh record with propagated tags", async () => {
       const auth = await register();
       const created = await createTask({
         userId: auth.userId,
-        title: 'Draft proposal',
-        description: 'Initial outline',
-        status: 'TODO',
-        priority: 'LOW',
-        dueDate: '2024-04-01T12:00:00.000Z',
-        tags: ['initial'],
+        title: "Draft proposal",
+        description: "Initial outline",
+        status: "TODO",
+        priority: "LOW",
+        dueDate: "2024-04-01T12:00:00.000Z",
+        tags: ["initial"],
       });
 
       await sleep(10);
 
       const response = await withAuth(
         agent.patch(`/api/taskforge/v1/tasks/${created.task.id}`).send({
-          title: 'Draft proposal v2',
-          description: 'Expanded with metrics',
-          status: 'IN_PROGRESS',
-          priority: 'HIGH',
-          dueDate: '2024-04-05T15:00:00.000Z',
-          tags: ['planning', 'proposal'],
+          title: "Draft proposal v2",
+          description: "Expanded with metrics",
+          status: "IN_PROGRESS",
+          priority: "HIGH",
+          dueDate: "2024-04-05T15:00:00.000Z",
+          tags: ["planning", "proposal"],
         }),
         auth,
       ).expect(200);
 
       expect(response.body).toEqual({
         id: created.task.id,
-        title: 'Draft proposal v2',
-        description: 'Expanded with metrics',
-        status: 'IN_PROGRESS',
-        priority: 'HIGH',
-        dueDate: '2024-04-05T15:00:00.000Z',
-        tags: ['planning', 'proposal'],
+        title: "Draft proposal v2",
+        description: "Expanded with metrics",
+        status: "IN_PROGRESS",
+        priority: "HIGH",
+        dueDate: "2024-04-05T15:00:00.000Z",
+        tags: ["planning", "proposal"],
         createdAt: created.task.createdAt,
         updatedAt: expect.any(String),
       });
@@ -364,73 +586,90 @@ describe('Tasks API', () => {
       expect(refreshed.total).toBe(1);
       expect(refreshed.items[0]).toMatchObject({
         id: created.task.id,
-        title: 'Draft proposal v2',
-        description: 'Expanded with metrics',
-        status: 'IN_PROGRESS',
-        priority: 'HIGH',
-        dueDate: '2024-04-05T15:00:00.000Z',
-        tags: ['planning', 'proposal'],
+        title: "Draft proposal v2",
+        description: "Expanded with metrics",
+        status: "IN_PROGRESS",
+        priority: "HIGH",
+        dueDate: "2024-04-05T15:00:00.000Z",
+        tags: ["planning", "proposal"],
       });
-      expect(refreshed.items[0].tags).not.toContain('initial');
+      expect(refreshed.items[0].tags).not.toContain("initial");
     });
 
-    it('returns 400 when updating with an invalid task id', async () => {
+    it("returns 400 when updating with an invalid task id", async () => {
       const auth = await register();
 
       const response = await withAuth(
-        agent.patch('/api/taskforge/v1/tasks/not-a-uuid').send({ title: 'Renamed' }),
+        agent
+          .patch("/api/taskforge/v1/tasks/not-a-uuid")
+          .send({ title: "Renamed" }),
         auth,
       ).expect(400);
 
-      expect(response.body).toEqual({ error: 'Invalid identifier' });
+      expect(response.body).toEqual({ error: "Invalid identifier" });
     });
 
-    it('returns validation errors for malformed updates', async () => {
+    it("returns validation errors for malformed updates", async () => {
       const auth = await register();
-      const created = await createTask({ userId: auth.userId, title: 'Fix lint' });
+      const created = await createTask({
+        userId: auth.userId,
+        title: "Fix lint",
+      });
 
       const response = await withAuth(
-        agent.patch(`/api/taskforge/v1/tasks/${created.task.id}`).send({ dueDate: 'not-a-date' }),
+        agent
+          .patch(`/api/taskforge/v1/tasks/${created.task.id}`)
+          .send({ dueDate: "not-a-date" }),
         auth,
       ).expect(400);
 
       expect(response.body).toEqual(
-        expect.objectContaining({ error: 'Invalid payload', details: expect.any(Object) }),
+        expect.objectContaining({
+          error: "Invalid payload",
+          details: expect.any(Object),
+        }),
       );
     });
 
-    it('requires authentication to update tasks', async () => {
-      const created = await createTask({ title: 'Hidden task' });
+    it("requires authentication to update tasks", async () => {
+      const created = await createTask({ title: "Hidden task" });
 
       const response = await agent
         .patch(`/api/taskforge/v1/tasks/${created.task.id}`)
-        .send({ title: 'Blocked' })
+        .send({ title: "Blocked" })
         .expect(401);
 
-      expect(response.body).toEqual({ error: 'Unauthorized' });
+      expect(response.body).toEqual({ error: "Unauthorized" });
     });
 
     it("returns 404 when attempting to update another user's task", async () => {
       const auth = await register();
-      const someoneElse = await createUser({ email: 'someone-else@example.com' });
-      const foreignTask = await createTask({ userId: someoneElse.user.id, title: 'Secret task' });
+      const someoneElse = await createUser({
+        email: "someone-else@example.com",
+      });
+      const foreignTask = await createTask({
+        userId: someoneElse.user.id,
+        title: "Secret task",
+      });
 
       const response = await withAuth(
-        agent.patch(`/api/taskforge/v1/tasks/${foreignTask.task.id}`).send({ title: 'Hacked' }),
+        agent
+          .patch(`/api/taskforge/v1/tasks/${foreignTask.task.id}`)
+          .send({ title: "Hacked" }),
         auth,
       ).expect(404);
 
-      expect(response.body).toEqual({ error: 'Not found' });
+      expect(response.body).toEqual({ error: "Not found" });
     });
   });
 
-  describe('delete', () => {
-    it('deletes a task and returns a confirmation payload', async () => {
+  describe("delete", () => {
+    it("deletes a task and returns a confirmation payload", async () => {
       const auth = await register();
       const created = await createTask({
         userId: auth.userId,
-        title: 'Archive me',
-        tags: ['cleanup'],
+        title: "Archive me",
+        tags: ["cleanup"],
       });
 
       const response = await withAuth(
@@ -438,44 +677,49 @@ describe('Tasks API', () => {
         auth,
       ).expect(200);
 
-      expect(response.body).toEqual({ id: created.task.id, status: 'deleted' });
+      expect(response.body).toEqual({ id: created.task.id, status: "deleted" });
 
       const remaining = await taskRepository.listTasks(auth.userId);
       expect(remaining.total).toBe(0);
     });
 
-    it('returns 400 when deleting with an invalid task id', async () => {
+    it("returns 400 when deleting with an invalid task id", async () => {
       const auth = await register();
 
       const response = await withAuth(
-        agent.delete('/api/taskforge/v1/tasks/not-a-uuid'),
+        agent.delete("/api/taskforge/v1/tasks/not-a-uuid"),
         auth,
       ).expect(400);
 
-      expect(response.body).toEqual({ error: 'Invalid identifier' });
+      expect(response.body).toEqual({ error: "Invalid identifier" });
     });
 
-    it('requires authentication to delete tasks', async () => {
-      const created = await createTask({ title: 'Do not remove' });
+    it("requires authentication to delete tasks", async () => {
+      const created = await createTask({ title: "Do not remove" });
 
       const response = await agent
         .delete(`/api/taskforge/v1/tasks/${created.task.id}`)
         .expect(401);
 
-      expect(response.body).toEqual({ error: 'Unauthorized' });
+      expect(response.body).toEqual({ error: "Unauthorized" });
     });
 
     it("returns 404 when attempting to delete another user's task", async () => {
       const auth = await register();
-      const someoneElse = await createUser({ email: 'delete-other@example.com' });
-      const foreignTask = await createTask({ userId: someoneElse.user.id, title: 'Keep out' });
+      const someoneElse = await createUser({
+        email: "delete-other@example.com",
+      });
+      const foreignTask = await createTask({
+        userId: someoneElse.user.id,
+        title: "Keep out",
+      });
 
       const response = await withAuth(
         agent.delete(`/api/taskforge/v1/tasks/${foreignTask.task.id}`),
         auth,
       ).expect(404);
 
-      expect(response.body).toEqual({ error: 'Not found' });
+      expect(response.body).toEqual({ error: "Not found" });
     });
   });
 });

--- a/apps/web/app/(protected)/dashboard/dashboard-content.tsx
+++ b/apps/web/app/(protected)/dashboard/dashboard-content.tsx
@@ -1,13 +1,14 @@
-'use client';
+"use client";
 
-import { useEffect, useMemo, useRef, useState } from 'react';
-import { motion } from 'framer-motion';
+import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
+import { motion } from "framer-motion";
 import {
   ArrowUpDown,
   Check,
   CheckCircle2,
   ClipboardList,
   Filter,
+  GripVertical,
   ListTodo,
   Loader2,
   PenSquare,
@@ -15,7 +16,7 @@ import {
   RefreshCcw,
   Sparkles,
   Timer,
-} from 'lucide-react';
+} from "lucide-react";
 import {
   closestCenter,
   DndContext,
@@ -28,21 +29,27 @@ import {
   type DragEndEvent,
   type DragOverEvent,
   type DragStartEvent,
-} from '@dnd-kit/core';
+} from "@dnd-kit/core";
 import {
   arrayMove,
   SortableContext,
   sortableKeyboardCoordinates,
   useSortable,
   verticalListSortingStrategy,
-} from '@dnd-kit/sortable';
-import { CSS } from '@dnd-kit/utilities';
-import type { TaskPriority, TaskStatus } from '@taskforge/shared';
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import type { TaskPriority, TaskStatus } from "@taskforge/shared";
 
-import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
-import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -50,14 +57,19 @@ import {
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
-import { Skeleton } from '@/components/ui/skeleton';
-import { ToastAction } from '@/components/ui/toast';
-import { useToast } from '@/components/ui/use-toast';
-import { useMoveTaskOnBoard, useTaskBoardQuery, useTasksQuery, type TaskListItem } from '@/lib/tasks-hooks';
-import { cn } from '@/lib/utils';
+} from "@/components/ui/dropdown-menu";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ToastAction } from "@/components/ui/toast";
+import { useToast } from "@/components/ui/use-toast";
+import {
+  useMoveTaskOnBoard,
+  useTaskBoardQuery,
+  useTasksQuery,
+  type TaskListItem,
+} from "@/lib/tasks-hooks";
+import { cn } from "@/lib/utils";
 
-import type { DashboardUser } from './types';
+import type { DashboardUser } from "./types";
 import {
   areArraysEqual,
   cloneColumnOrder,
@@ -68,39 +80,39 @@ import {
   getStatusFromColumnId,
   type ColumnOrderState,
   statusOrder,
-} from './board-order-utils';
+} from "./board-order-utils";
 
 const statusMeta: Record<TaskStatus, { title: string; description: string }> = {
   TODO: {
-    title: 'To do',
-    description: 'Ideas and tasks that still need attention.',
+    title: "To do",
+    description: "Ideas and tasks that still need attention.",
   },
   IN_PROGRESS: {
-    title: 'In progress',
-    description: 'Focused work currently moving forward.',
+    title: "In progress",
+    description: "Focused work currently moving forward.",
   },
   DONE: {
-    title: 'Done',
-    description: 'Shipped work ready to celebrate.',
+    title: "Done",
+    description: "Shipped work ready to celebrate.",
   },
 };
 
 const statusEmptyCopy: Record<TaskStatus, string> = {
-  TODO: 'No tasks to pick up yet.',
-  IN_PROGRESS: 'Nothing in progress yet.',
-  DONE: 'Nothing completed yet.',
+  TODO: "No tasks to pick up yet.",
+  IN_PROGRESS: "Nothing in progress yet.",
+  DONE: "Nothing completed yet.",
 };
 
 const statusLabels: Record<TaskStatus, string> = {
-  TODO: 'To Do',
-  IN_PROGRESS: 'In Progress',
-  DONE: 'Done',
+  TODO: "To Do",
+  IN_PROGRESS: "In Progress",
+  DONE: "Done",
 };
 
 const priorityLabels: Record<TaskPriority, string> = {
-  HIGH: 'High',
-  MEDIUM: 'Medium',
-  LOW: 'Low',
+  HIGH: "High",
+  MEDIUM: "Medium",
+  LOW: "Low",
 };
 
 const priorityWeights: Record<TaskPriority, number> = {
@@ -110,55 +122,56 @@ const priorityWeights: Record<TaskPriority, number> = {
 };
 
 const statusBadgeTone: Record<TaskStatus, string> = {
-  TODO: 'border-amber-300/70 bg-amber-400/10 text-amber-700 dark:border-amber-200/40 dark:text-amber-100',
-  IN_PROGRESS: 'border-sky-300/70 bg-sky-400/10 text-sky-700 dark:border-sky-200/40 dark:text-sky-100',
-  DONE: 'border-emerald-300/70 bg-emerald-400/10 text-emerald-700 dark:border-emerald-200/40 dark:text-emerald-100',
+  TODO: "border-amber-300/70 bg-amber-400/10 text-amber-700 dark:border-amber-200/40 dark:text-amber-100",
+  IN_PROGRESS:
+    "border-sky-300/70 bg-sky-400/10 text-sky-700 dark:border-sky-200/40 dark:text-sky-100",
+  DONE: "border-emerald-300/70 bg-emerald-400/10 text-emerald-700 dark:border-emerald-200/40 dark:text-emerald-100",
 };
 
 const priorityBadgeTone: Record<TaskPriority, string> = {
-  HIGH: 'border-destructive/50 bg-destructive/10 text-destructive',
-  MEDIUM: 'border-primary/40 bg-primary/10 text-primary',
-  LOW: 'border-muted-foreground/30 bg-muted/80 text-muted-foreground',
+  HIGH: "border-destructive/50 bg-destructive/10 text-destructive",
+  MEDIUM: "border-primary/40 bg-primary/10 text-primary",
+  LOW: "border-muted-foreground/30 bg-muted/80 text-muted-foreground",
 };
 
-const statusFilters: Array<{ value: 'ALL' | TaskStatus; label: string }> = [
-  { value: 'ALL', label: 'All' },
-  { value: 'TODO', label: 'To Do' },
-  { value: 'IN_PROGRESS', label: 'In Progress' },
-  { value: 'DONE', label: 'Done' },
+const statusFilters: Array<{ value: "ALL" | TaskStatus; label: string }> = [
+  { value: "ALL", label: "All" },
+  { value: "TODO", label: "To Do" },
+  { value: "IN_PROGRESS", label: "In Progress" },
+  { value: "DONE", label: "Done" },
 ];
 
 const sortOptions = [
-  { value: 'manual', label: 'Board order' },
-  { value: 'recent', label: 'Recently updated' },
-  { value: 'dueDate', label: 'Due date' },
-  { value: 'priority', label: 'Priority' },
+  { value: "manual", label: "Board order" },
+  { value: "recent", label: "Recently updated" },
+  { value: "dueDate", label: "Due date" },
+  { value: "priority", label: "Priority" },
 ] as const;
 
-type SortOption = (typeof sortOptions)[number]['value'];
+type SortOption = (typeof sortOptions)[number]["value"];
 
 function getInitials(user: DashboardUser) {
   return (
     user.name
-      ?.split(' ')
+      ?.split(" ")
       .map((segment) => segment.charAt(0).toUpperCase())
-      .join('') ?? (user.email ? user.email.charAt(0).toUpperCase() : 'TF')
+      .join("") ?? (user.email ? user.email.charAt(0).toUpperCase() : "TF")
   );
 }
 
 function formatDueDate(value: string | null | undefined) {
   if (!value) {
-    return 'No due date';
+    return "No due date";
   }
 
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) {
-    return 'No due date';
+    return "No due date";
   }
 
-  return new Intl.DateTimeFormat('en-US', {
-    month: 'short',
-    day: 'numeric',
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
   }).format(date);
 }
 
@@ -175,12 +188,14 @@ function sortTasks(tasks: TaskListItem[], sortBy: SortOption): TaskListItem[] {
   const copy = [...tasks];
 
   switch (sortBy) {
-    case 'manual':
+    case "manual":
       return copy;
-    case 'priority':
-      copy.sort((a, b) => priorityWeights[a.priority] - priorityWeights[b.priority]);
+    case "priority":
+      copy.sort(
+        (a, b) => priorityWeights[a.priority] - priorityWeights[b.priority],
+      );
       break;
-    case 'dueDate':
+    case "dueDate":
       copy.sort((a, b) => {
         const aTime = parseDate(a.dueDate);
         const bTime = parseDate(b.dueDate);
@@ -200,7 +215,7 @@ function sortTasks(tasks: TaskListItem[], sortBy: SortOption): TaskListItem[] {
         return aTime - bTime;
       });
       break;
-    case 'recent':
+    case "recent":
     default:
       copy.sort((a, b) => {
         const aTime = parseDate(a.updatedAt ?? a.createdAt);
@@ -217,24 +232,35 @@ function TaskCard({
   task,
   dragging,
   editable = true,
+  dragHandle,
 }: {
   task: TaskListItem;
   dragging?: boolean;
   editable?: boolean;
+  dragHandle?: ReactNode;
 }) {
   return (
     <Card
       className={cn(
-        'border-border/60 bg-background/60 shadow-sm transition-colors',
-        dragging ? 'shadow-md ring-2 ring-primary/40' : 'hover:border-border',
+        "border-border/60 bg-background/60 shadow-sm transition-colors",
+        dragging ? "shadow-md ring-2 ring-primary/40" : "hover:border-border",
       )}
     >
       <CardContent className="space-y-3 p-4">
         <div className="flex flex-wrap items-center gap-2">
-          <Badge variant="outline" className={cn('uppercase tracking-wide', statusBadgeTone[task.status])}>
+          <Badge
+            variant="outline"
+            className={cn(
+              "uppercase tracking-wide",
+              statusBadgeTone[task.status],
+            )}
+          >
             {statusLabels[task.status]}
           </Badge>
-          <Badge variant="outline" className={cn('capitalize', priorityBadgeTone[task.priority])}>
+          <Badge
+            variant="outline"
+            className={cn("capitalize", priorityBadgeTone[task.priority])}
+          >
             {priorityLabels[task.priority]}
           </Badge>
           {task._optimistic ? (
@@ -246,20 +272,34 @@ function TaskCard({
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div className="space-y-2">
             <p className="text-sm font-medium text-foreground">{task.title}</p>
-            {task.description ? <p className="text-xs text-muted-foreground">{task.description}</p> : null}
-            <p className="text-xs text-muted-foreground">Due {formatDueDate(task.dueDate)}</p>
+            {task.description ? (
+              <p className="text-xs text-muted-foreground">
+                {task.description}
+              </p>
+            ) : null}
+            <p className="text-xs text-muted-foreground">
+              Due {formatDueDate(task.dueDate)}
+            </p>
           </div>
           <div className="flex flex-col items-start gap-2 sm:items-end">
+            {dragHandle}
             <Button
               type="button"
               size="sm"
               variant="ghost"
               className="gap-2 px-2 text-xs"
               disabled={!editable}
-              {...(editable ? { 'data-task-dialog': 'edit', 'data-task-id': task.id } : {})}
-              aria-label={editable ? `Edit task ${task.title}` : `Task ${task.title} cannot be edited from this view`}
+              {...(editable
+                ? { "data-task-dialog": "edit", "data-task-id": task.id }
+                : {})}
+              aria-label={
+                editable
+                  ? `Edit task ${task.title}`
+                  : `Task ${task.title} cannot be edited from this view`
+              }
             >
-              <PenSquare className="h-3.5 w-3.5" /> {editable ? 'Edit' : 'View only'}
+              <PenSquare className="h-3.5 w-3.5" />{" "}
+              {editable ? "Edit" : "View only"}
             </Button>
           </div>
         </div>
@@ -281,7 +321,15 @@ function SortableTaskCard({
 }) {
   const isOptimistic = Boolean(task._optimistic);
   const dragDisabled = isOptimistic || !draggable;
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    setActivatorNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({
     id: task.id,
     data: { status: columnStatus },
     disabled: dragDisabled,
@@ -296,12 +344,33 @@ function SortableTaskCard({
     <article
       ref={setNodeRef}
       style={style}
-      {...attributes}
-      {...listeners}
       aria-disabled={dragDisabled}
-      className={cn(dragDisabled ? 'cursor-not-allowed opacity-90' : 'cursor-grab active:cursor-grabbing')}
+      className={cn(dragDisabled ? "opacity-90" : "")}
     >
-      <TaskCard task={task} dragging={isDragging} editable={editable} />
+      <TaskCard
+        task={task}
+        dragging={isDragging}
+        editable={editable}
+        dragHandle={
+          <Button
+            ref={setActivatorNodeRef}
+            type="button"
+            size="icon"
+            variant="ghost"
+            className="h-8 w-8 cursor-grab text-muted-foreground active:cursor-grabbing"
+            aria-label={
+              dragDisabled
+                ? `Task ${task.title} cannot be dragged right now`
+                : `Drag task ${task.title}`
+            }
+            disabled={dragDisabled}
+            {...attributes}
+            {...listeners}
+          >
+            <GripVertical className="h-4 w-4" />
+          </Button>
+        }
+      />
     </article>
   );
 }
@@ -337,13 +406,15 @@ function BoardColumn({
       animate={{ opacity: 1, y: 0 }}
       transition={{ delay: 0.1 * index, duration: 0.4 }}
       className={cn(
-        'flex flex-col gap-4 rounded-xl border border-border/70 bg-card/50 p-5 shadow-sm backdrop-blur',
-        dragActive ? 'ring-1 ring-border/60' : '',
+        "flex flex-col gap-4 rounded-xl border border-border/70 bg-card/50 p-5 shadow-sm backdrop-blur",
+        dragActive ? "ring-1 ring-border/60" : "",
       )}
     >
       <div>
         <div className="flex items-center justify-between gap-2">
-          <h3 className="text-lg font-semibold text-foreground/90">{meta.title}</h3>
+          <h3 className="text-lg font-semibold text-foreground/90">
+            {meta.title}
+          </h3>
           <Badge variant="muted" className="uppercase tracking-wide">
             {tasks.length}
           </Badge>
@@ -355,8 +426,8 @@ function BoardColumn({
         role="region"
         aria-label={`${meta.title} drop zone`}
         className={cn(
-          'space-y-3 rounded-lg border border-dashed border-border/40 bg-background/40 p-3 transition-colors',
-          isOver ? 'border-primary/60 bg-primary/5 ring-2 ring-primary/30' : '',
+          "space-y-3 rounded-lg border border-dashed border-border/40 bg-background/40 p-3 transition-colors",
+          isOver ? "border-primary/60 bg-primary/5 ring-2 ring-primary/30" : "",
         )}
       >
         {tasks.length === 0 ? (
@@ -364,7 +435,10 @@ function BoardColumn({
             {statusEmptyCopy[status]}
           </div>
         ) : null}
-        <SortableContext items={tasks.map((task) => task.id)} strategy={verticalListSortingStrategy}>
+        <SortableContext
+          items={tasks.map((task) => task.id)}
+          strategy={verticalListSortingStrategy}
+        >
           {tasks.map((task) => (
             <SortableTaskCard
               key={task.id}
@@ -385,13 +459,19 @@ function BoardColumn({
   );
 }
 export function DashboardContent({ user }: { user: DashboardUser }) {
-  const [statusFilter, setStatusFilter] = useState<'ALL' | TaskStatus>('ALL');
-  const [sortBy, setSortBy] = useState<SortOption>('manual');
-  const [columnOrder, setColumnOrder] = useState<ColumnOrderState>(() => cloneColumnOrder(emptyColumnOrder));
+  const [statusFilter, setStatusFilter] = useState<"ALL" | TaskStatus>("ALL");
+  const [sortBy, setSortBy] = useState<SortOption>("manual");
+  const [columnOrder, setColumnOrder] = useState<ColumnOrderState>(() =>
+    cloneColumnOrder(emptyColumnOrder),
+  );
   const [activeId, setActiveId] = useState<string | null>(null);
   const columnOrderRef = useRef(columnOrder);
   const dragSnapshotRef = useRef<ColumnOrderState | null>(null);
-  const lastMoveRef = useRef<{ taskId: string; targetStatus: TaskStatus; targetIndex: number } | null>(null);
+  const lastMoveRef = useRef<{
+    taskId: string;
+    targetStatus: TaskStatus;
+    targetIndex: number;
+  } | null>(null);
 
   const tasksQuery = useTasksQuery({ pageSize: 50 });
   const boardQuery = useTaskBoardQuery();
@@ -415,6 +495,7 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
   }, [boardQuery.data]);
 
   const isBoardReady = Boolean(boardOrder);
+  const canDragTasks = isBoardReady && !boardQuery.error && !moveTask.isPending;
 
   useEffect(() => {
     if (!boardOrder || activeId) {
@@ -448,7 +529,9 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
     };
 
     if (boardQuery.data) {
-      const detailedTaskMap = new Map(tasksQuery.tasks.map((task) => [task.id, task]));
+      const detailedTaskMap = new Map(
+        tasksQuery.tasks.map((task) => [task.id, task]),
+      );
       const seen = new Set<string>();
 
       for (const column of boardQuery.data.columns) {
@@ -504,7 +587,9 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
 
       for (const status of statusOrder) {
         const visibleIds = tasksByStatus[status].map((task) => task.id);
-        const baseOrder = boardOrder?.[status] ?? prev[status].filter((id) => visibleIds.includes(id));
+        const baseOrder =
+          boardOrder?.[status] ??
+          prev[status].filter((id) => visibleIds.includes(id));
         const additions = visibleIds.filter((id) => !baseOrder.includes(id));
         const nextOrder = [...baseOrder, ...additions];
 
@@ -526,7 +611,7 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
     };
 
     for (const status of statusOrder) {
-      if (sortBy !== 'manual') {
+      if (sortBy !== "manual") {
         ordered[status] = sortTasks(tasksByStatus[status], sortBy);
         continue;
       }
@@ -534,7 +619,9 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
       const order = columnOrder[status];
       const tasks = tasksByStatus[status];
       const taskMap = new Map(tasks.map((task) => [task.id, task]));
-      const orderedTasks = order.map((id) => taskMap.get(id)).filter(Boolean) as TaskListItem[];
+      const orderedTasks = order
+        .map((id) => taskMap.get(id))
+        .filter(Boolean) as TaskListItem[];
       const missing = tasks.filter((task) => !order.includes(task.id));
       ordered[status] = [...orderedTasks, ...missing];
     }
@@ -542,69 +629,90 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
     return ordered;
   }, [columnOrder, sortBy, tasksByStatus]);
 
-  const visibleColumns = useMemo(
-    () => {
-      const targetStatuses = statusFilter === 'ALL' ? statusOrder : [statusFilter];
+  const visibleColumns = useMemo(() => {
+    const targetStatuses =
+      statusFilter === "ALL" ? statusOrder : [statusFilter];
 
-      return targetStatuses.map((status) => ({
-        status,
-        meta: statusMeta[status],
-        tasks: orderedTasksByStatus[status],
-      }));
-    },
-    [orderedTasksByStatus, statusFilter],
-  );
+    return targetStatuses.map((status) => ({
+      status,
+      meta: statusMeta[status],
+      tasks: orderedTasksByStatus[status],
+    }));
+  }, [orderedTasksByStatus, statusFilter]);
 
   const visibleTaskCount = useMemo(
-    () => visibleColumns.reduce((total, column) => total + column.tasks.length, 0),
+    () =>
+      visibleColumns.reduce((total, column) => total + column.tasks.length, 0),
     [visibleColumns],
   );
 
-  const totalTasks = boardQuery.data?.summary.totalTasks ?? tasksQuery.data?.total ?? tasksQuery.tasks.length;
+  const totalTasks =
+    boardQuery.data?.summary.totalTasks ??
+    tasksQuery.data?.total ??
+    tasksQuery.tasks.length;
   const completedTasks = useMemo(
-    () => boardQuery.data?.summary.totalsByStatus.DONE ?? tasksByStatus.DONE.length,
+    () =>
+      boardQuery.data?.summary.totalsByStatus.DONE ?? tasksByStatus.DONE.length,
     [boardQuery.data, tasksByStatus.DONE.length],
   );
   const activeTasks = useMemo(
-    () => boardQuery.data?.summary.totalsByStatus.IN_PROGRESS ?? tasksByStatus.IN_PROGRESS.length,
+    () =>
+      boardQuery.data?.summary.totalsByStatus.IN_PROGRESS ??
+      tasksByStatus.IN_PROGRESS.length,
     [boardQuery.data, tasksByStatus.IN_PROGRESS.length],
   );
   const todoTasks = useMemo(
-    () => boardQuery.data?.summary.totalsByStatus.TODO ?? tasksByStatus.TODO.length,
+    () =>
+      boardQuery.data?.summary.totalsByStatus.TODO ?? tasksByStatus.TODO.length,
     [boardQuery.data, tasksByStatus.TODO.length],
   );
 
-  const firstName = user.name?.split(' ')[0] ?? 'there';
+  const firstName = user.name?.split(" ")[0] ?? "there";
 
-  const isEmpty = !tasksQuery.isLoading && !tasksQuery.isError && totalTasks === 0;
+  const isEmpty =
+    !tasksQuery.isLoading && !tasksQuery.isError && totalTasks === 0;
   const dragActive = Boolean(activeId);
 
-  const taskMap = useMemo(() => new Map(tasksQuery.tasks.map((task) => [task.id, task])), [tasksQuery.tasks]);
-  const editableTaskIds = useMemo(() => new Set(tasksQuery.tasks.map((task) => task.id)), [tasksQuery.tasks]);
-  const draggableTaskIds = useMemo(() => {
-    const ids = new Set(tasksQuery.tasks.map((task) => task.id));
+  const renderedTaskMap = useMemo(() => {
+    const map = new Map<string, TaskListItem>();
 
-    if (boardQuery.data) {
-      for (const column of boardQuery.data.columns) {
-        for (const task of column.tasks) {
-          ids.add(task.id);
-        }
+    for (const status of statusOrder) {
+      for (const task of orderedTasksByStatus[status]) {
+        map.set(task.id, task);
       }
     }
 
+    return map;
+  }, [orderedTasksByStatus]);
+  const editableTaskIds = useMemo(
+    () => new Set(tasksQuery.tasks.map((task) => task.id)),
+    [tasksQuery.tasks],
+  );
+  const draggableTaskIds = useMemo(() => {
+    const ids = new Set<string>();
+    if (!canDragTasks) {
+      return ids;
+    }
+    for (const taskId of renderedTaskMap.keys()) {
+      ids.add(taskId);
+    }
     return ids;
-  }, [boardQuery.data, tasksQuery.tasks]);
-  const activeTask = activeId ? taskMap.get(activeId) ?? null : null;
+  }, [canDragTasks, renderedTaskMap]);
+  const activeTask = activeId ? (renderedTaskMap.get(activeId) ?? null) : null;
 
   const buildPositionAnnouncement = (taskId: string, status: TaskStatus) => {
     const tasks = columnOrderRef.current[status];
     const position = tasks.indexOf(taskId);
-    return position === -1 ? '' : `Position ${position + 1} of ${tasks.length}.`;
+    return position === -1
+      ? ""
+      : `Position ${position + 1} of ${tasks.length}.`;
   };
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
-    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
   );
 
   const findStatusForTask = (id: string) => {
@@ -616,19 +724,19 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
   };
 
   const handleDragStart = (event: DragStartEvent) => {
-    if (moveTask.isPending || !isBoardReady) {
+    if (!canDragTasks) {
       return;
     }
 
     const currentId = event.active.id as string;
     setActiveId(currentId);
-    setSortBy('manual');
+    setSortBy("manual");
     dragSnapshotRef.current = cloneColumnOrder(columnOrderRef.current);
   };
 
   const handleDragOver = (event: DragOverEvent) => {
     const { active, over } = event;
-    if (!over || moveTask.isPending || !isBoardReady) {
+    if (!over || !canDragTasks) {
       return;
     }
 
@@ -645,9 +753,15 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
       setColumnOrder((prev) => {
         const items = prev[overStatus];
         const activeIndex = items.indexOf(activeId);
-        const overIndex = overId.startsWith(columnIdPrefix) ? items.length - 1 : items.indexOf(overId);
+        const overIndex = overId.startsWith(columnIdPrefix)
+          ? items.length - 1
+          : items.indexOf(overId);
 
-        if (activeIndex === -1 || overIndex === -1 || activeIndex === overIndex) {
+        if (
+          activeIndex === -1 ||
+          overIndex === -1 ||
+          activeIndex === overIndex
+        ) {
           return prev;
         }
 
@@ -662,7 +776,9 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
     setColumnOrder((prev) => {
       const activeItems = prev[activeStatus].filter((id) => id !== activeId);
       const overItems = [...prev[overStatus]];
-      const overIndex = overId.startsWith(columnIdPrefix) ? overItems.length : overItems.indexOf(overId);
+      const overIndex = overId.startsWith(columnIdPrefix)
+        ? overItems.length
+        : overItems.indexOf(overId);
       const nextIndex = overIndex >= 0 ? overIndex : overItems.length;
       overItems.splice(nextIndex, 0, activeId);
 
@@ -681,7 +797,7 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
     const activeTaskId = active.id as string;
     setActiveId(null);
 
-    if (moveTask.isPending || !isBoardReady) {
+    if (!canDragTasks) {
       dragSnapshotRef.current = null;
       return;
     }
@@ -708,16 +824,22 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
     }
 
     const initialSnapshot = dragSnapshotRef.current;
-    const initialStatus = initialSnapshot ? findTaskStatusInOrder(initialSnapshot, activeTaskId) : null;
+    const initialStatus = initialSnapshot
+      ? findTaskStatusInOrder(initialSnapshot, activeTaskId)
+      : null;
     const sourceStatus = initialStatus ?? activeStatus;
     const destinationStatus = overStatus;
-    const initialIndex = sourceStatus ? initialSnapshot?.[sourceStatus].indexOf(activeTaskId) ?? -1 : -1;
+    const initialIndex = sourceStatus
+      ? (initialSnapshot?.[sourceStatus].indexOf(activeTaskId) ?? -1)
+      : -1;
 
     const nextOrder = columnOrderRef.current;
     const targetIndex = nextOrder[destinationStatus].indexOf(activeTaskId);
 
     const hasMoved =
-      targetIndex !== -1 && (sourceStatus !== destinationStatus || (sourceStatus === destinationStatus && initialIndex !== targetIndex));
+      targetIndex !== -1 &&
+      (sourceStatus !== destinationStatus ||
+        (sourceStatus === destinationStatus && initialIndex !== targetIndex));
 
     let clearSnapshotAfterDragEnd = true;
 
@@ -729,7 +851,9 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
       };
       lastMoveRef.current = movePayload;
 
-      const rollbackSnapshot = dragSnapshotRef.current ? cloneColumnOrder(dragSnapshotRef.current) : null;
+      const rollbackSnapshot = dragSnapshotRef.current
+        ? cloneColumnOrder(dragSnapshotRef.current)
+        : null;
       clearSnapshotAfterDragEnd = false;
 
       moveTask.mutate(movePayload, {
@@ -742,9 +866,9 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
           }
 
           toast({
-            variant: 'destructive',
-            title: 'Unable to move task',
-            description: 'We could not save that move. Please try again.',
+            variant: "destructive",
+            title: "Unable to move task",
+            description: "We could not save that move. Please try again.",
             action: (
               <ToastAction
                 altText="Retry move"
@@ -782,7 +906,8 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
     setActiveId(null);
   };
 
-  const refetchBoardAndTasks = () => Promise.all([tasksQuery.refetch(), boardQuery.refetch()]);
+  const refetchBoardAndTasks = () =>
+    Promise.all([tasksQuery.refetch(), boardQuery.refetch()]);
 
   return (
     <div className="space-y-10">
@@ -796,13 +921,15 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
           <span className="inline-flex items-center gap-2 rounded-full border border-primary/30 px-3 py-1 text-xs uppercase tracking-[0.2em] text-primary">
             <Sparkles className="h-3 w-3" /> Dashboard
           </span>
-          <h2 className="text-4xl font-semibold leading-tight">Welcome back, {firstName}!</h2>
+          <h2 className="text-4xl font-semibold leading-tight">
+            Welcome back, {firstName}!
+          </h2>
           <p className="text-lg text-muted-foreground">
             {tasksQuery.isLoading
-              ? 'We are syncing your workspace tasks—hang tight for a moment.'
+              ? "We are syncing your workspace tasks—hang tight for a moment."
               : totalTasks > 0
                 ? `Here is a quick snapshot of your work: ${activeTasks} in progress, ${todoTasks} queued up, and ${completedTasks} already done.`
-                : 'Create your first task to capture the work that matters. Everything stays in sync once data starts flowing.'}
+                : "Create your first task to capture the work that matters. Everything stays in sync once data starts flowing."}
           </p>
           <div className="flex flex-wrap gap-3">
             <Button type="button" data-task-dialog="create" className="gap-2">
@@ -815,8 +942,16 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
               onClick={() => void refetchBoardAndTasks()}
               disabled={tasksQuery.isFetching || boardQuery.isFetching}
             >
-              <RefreshCcw className={cn('h-4 w-4', (tasksQuery.isFetching || boardQuery.isFetching) && 'animate-spin')} />
-              {tasksQuery.isFetching || boardQuery.isFetching ? 'Refreshing' : 'Refresh'}
+              <RefreshCcw
+                className={cn(
+                  "h-4 w-4",
+                  (tasksQuery.isFetching || boardQuery.isFetching) &&
+                    "animate-spin",
+                )}
+              />
+              {tasksQuery.isFetching || boardQuery.isFetching
+                ? "Refreshing"
+                : "Refresh"}
             </Button>
           </div>
         </motion.div>
@@ -828,7 +963,9 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
           <Card className="border-border/70 bg-card/60 shadow-lg shadow-black/15">
             <CardHeader>
               <CardTitle>Account snapshot</CardTitle>
-              <CardDescription>Your personal overview stays in sync with the API session.</CardDescription>
+              <CardDescription>
+                Your personal overview stays in sync with the API session.
+              </CardDescription>
             </CardHeader>
             <CardContent className="space-y-5">
               <div className="flex items-center gap-3">
@@ -836,8 +973,14 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
                   {getInitials(user)}
                 </div>
                 <div className="flex flex-col">
-                  <span className="text-sm font-medium text-foreground">{user.name ?? user.email ?? 'TaskForge member'}</span>
-                  {user.email && <span className="text-xs text-muted-foreground">{user.email}</span>}
+                  <span className="text-sm font-medium text-foreground">
+                    {user.name ?? user.email ?? "TaskForge member"}
+                  </span>
+                  {user.email && (
+                    <span className="text-xs text-muted-foreground">
+                      {user.email}
+                    </span>
+                  )}
                 </div>
               </div>
               <div className="grid gap-3 text-sm">
@@ -845,24 +988,43 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
                   <span className="flex items-center gap-2 text-foreground">
                     <Timer className="h-4 w-4 text-primary" /> Active tasks
                   </span>
-                  {tasksQuery.isLoading ? <Skeleton className="h-4 w-10" /> : <span className="font-medium text-foreground">{activeTasks}</span>}
+                  {tasksQuery.isLoading ? (
+                    <Skeleton className="h-4 w-10" />
+                  ) : (
+                    <span className="font-medium text-foreground">
+                      {activeTasks}
+                    </span>
+                  )}
                 </div>
                 <div className="flex items-center justify-between text-muted-foreground">
                   <span className="flex items-center gap-2 text-foreground">
                     <ListTodo className="h-4 w-4 text-primary" /> Up next
                   </span>
-                  {tasksQuery.isLoading ? <Skeleton className="h-4 w-10" /> : <span className="font-medium text-foreground">{todoTasks}</span>}
+                  {tasksQuery.isLoading ? (
+                    <Skeleton className="h-4 w-10" />
+                  ) : (
+                    <span className="font-medium text-foreground">
+                      {todoTasks}
+                    </span>
+                  )}
                 </div>
                 <div className="flex items-center justify-between text-muted-foreground">
                   <span className="flex items-center gap-2 text-foreground">
                     <CheckCircle2 className="h-4 w-4 text-primary" /> Completed
                   </span>
-                  {tasksQuery.isLoading ? <Skeleton className="h-4 w-10" /> : <span className="font-medium text-foreground">{completedTasks}</span>}
+                  {tasksQuery.isLoading ? (
+                    <Skeleton className="h-4 w-10" />
+                  ) : (
+                    <span className="font-medium text-foreground">
+                      {completedTasks}
+                    </span>
+                  )}
                 </div>
               </div>
               {isEmpty ? (
                 <p className="text-xs text-muted-foreground">
-                  No tasks yet—your next idea will appear here as soon as you create it.
+                  No tasks yet—your next idea will appear here as soon as you
+                  create it.
                 </p>
               ) : null}
             </CardContent>
@@ -884,7 +1046,7 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
                     key={option.value}
                     type="button"
                     size="sm"
-                    variant={isActive ? 'default' : 'secondary'}
+                    variant={isActive ? "default" : "secondary"}
                     onClick={() => setStatusFilter(option.value)}
                   >
                     {option.label}
@@ -896,8 +1058,14 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
           <div className="flex flex-wrap items-center gap-3">
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <Button type="button" size="sm" variant="outline" className="gap-2">
-                  <ArrowUpDown className="h-4 w-4" /> {sortOptions.find((option) => option.value === sortBy)?.label}
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  className="gap-2"
+                >
+                  <ArrowUpDown className="h-4 w-4" />{" "}
+                  {sortOptions.find((option) => option.value === sortBy)?.label}
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="w-56">
@@ -910,14 +1078,18 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
                     className="flex items-center gap-2"
                   >
                     <span>{option.label}</span>
-                    {sortBy === option.value ? <Check className="ml-auto h-4 w-4 text-primary" /> : null}
+                    {sortBy === option.value ? (
+                      <Check className="ml-auto h-4 w-4 text-primary" />
+                    ) : null}
                   </DropdownMenuItem>
                 ))}
               </DropdownMenuContent>
             </DropdownMenu>
-            {(tasksQuery.isFetching || boardQuery.isFetching) && !tasksQuery.isLoading ? (
+            {(tasksQuery.isFetching || boardQuery.isFetching) &&
+            !tasksQuery.isLoading ? (
               <span className="flex items-center gap-2 text-xs text-muted-foreground">
-                <Loader2 className="h-3.5 w-3.5 animate-spin" /> Syncing latest changes…
+                <Loader2 className="h-3.5 w-3.5 animate-spin" /> Syncing latest
+                changes…
               </span>
             ) : null}
           </div>
@@ -926,7 +1098,10 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
         <div>
           <p className="text-sm text-muted-foreground">
             Showing {visibleTaskCount} of {totalTasks} tasks
-            {statusFilter !== 'ALL' ? ` in ${statusLabels[statusFilter]} status` : ''}.
+            {statusFilter !== "ALL"
+              ? ` in ${statusLabels[statusFilter]} status`
+              : ""}
+            .
           </p>
         </div>
 
@@ -935,6 +1110,23 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
             <AlertTitle>Unable to load tasks</AlertTitle>
             <AlertDescription>
               {tasksQuery.error.message}
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="ml-3"
+                onClick={() => void refetchBoardAndTasks()}
+              >
+                Try again
+              </Button>
+            </AlertDescription>
+          </Alert>
+        ) : null}
+        {boardQuery.error ? (
+          <Alert variant="destructive">
+            <AlertTitle>Unable to load board</AlertTitle>
+            <AlertDescription>
+              {boardQuery.error.message}
               <Button
                 type="button"
                 variant="outline"
@@ -984,11 +1176,18 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
             <div className="flex h-16 w-16 items-center justify-center rounded-full bg-primary/10 text-primary">
               <ClipboardList className="h-8 w-8" />
             </div>
-            <h3 className="mt-6 text-xl font-semibold text-foreground">No tasks yet</h3>
+            <h3 className="mt-6 text-xl font-semibold text-foreground">
+              No tasks yet
+            </h3>
             <p className="mt-2 max-w-lg text-sm text-muted-foreground">
-              Your workspace is ready. Start by creating a task to see it appear in the live kanban preview.
+              Your workspace is ready. Start by creating a task to see it appear
+              in the live kanban preview.
             </p>
-            <Button type="button" data-task-dialog="create" className="mt-6 gap-2">
+            <Button
+              type="button"
+              data-task-dialog="create"
+              className="mt-6 gap-2"
+            >
               <PlusCircle className="h-4 w-4" /> Create your first task
             </Button>
           </motion.div>
@@ -1005,14 +1204,14 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
             accessibility={{
               screenReaderInstructions: {
                 draggable:
-                  'To pick up a task, press space or enter. Use arrow keys to move between columns. Press space or enter again to drop.',
+                  "Focus a task drag handle, then press space or enter to pick it up. Use arrow keys to move between columns. Press space or enter again to drop.",
               },
               announcements: {
                 onDragStart: ({ active }) => {
-                  const task = taskMap.get(active.id as string);
+                  const task = renderedTaskMap.get(active.id as string);
                   const status = findStatusForTask(active.id as string);
                   if (!task || !status) {
-                    return 'Task picked up.';
+                    return "Task picked up.";
                   }
                   return `Picked up ${task.title}. ${statusLabels[status]} lane. ${buildPositionAnnouncement(
                     task.id,
@@ -1021,29 +1220,29 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
                 },
                 onDragOver: ({ active, over }) => {
                   if (!over) {
-                    return 'Dragging task.';
+                    return "Dragging task.";
                   }
                   const status = findStatusForTask(over.id as string);
                   if (!status) {
-                    return 'Dragging task.';
+                    return "Dragging task.";
                   }
-                  const task = taskMap.get(active.id as string);
+                  const task = renderedTaskMap.get(active.id as string);
                   return task
                     ? `Moving ${task.title} over ${statusLabels[status]} lane.`
                     : `Moving over ${statusLabels[status]} lane.`;
                 },
                 onDragEnd: ({ active, over }) => {
                   if (!over) {
-                    return 'Task dropped.';
+                    return "Task dropped.";
                   }
-                  const task = taskMap.get(active.id as string);
+                  const task = renderedTaskMap.get(active.id as string);
                   const status = findStatusForTask(over.id as string);
                   if (!task || !status) {
-                    return 'Task dropped.';
+                    return "Task dropped.";
                   }
                   return `Dropped ${task.title} in ${statusLabels[status]} lane.`;
                 },
-                onDragCancel: () => 'Task movement cancelled.',
+                onDragCancel: () => "Task movement cancelled.",
               },
             }}
           >
@@ -1055,7 +1254,7 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
                   meta={column.meta}
                   tasks={column.tasks}
                   index={index}
-                  dragActive={dragActive && !moveTask.isPending && isBoardReady}
+                  dragActive={dragActive && canDragTasks}
                   activeId={activeId}
                   editableTaskIds={editableTaskIds}
                   draggableTaskIds={draggableTaskIds}
@@ -1074,9 +1273,9 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
       </section>
 
       <footer className="text-xs text-muted-foreground">
-        Tracking {totalTasks} {totalTasks === 1 ? 'task' : 'tasks'} across your workspace.
+        Tracking {totalTasks} {totalTasks === 1 ? "task" : "tasks"} across your
+        workspace.
       </footer>
     </div>
   );
 }
-


### PR DESCRIPTION
### Motivation
- Make board-load failures explicit and prevent unsafe drag interactions when the board is not ready, errored, or a move is pending.
- Ensure tasks present only on the board (not in the paginated list cache) participate correctly in drag overlay and screen-reader announcements.
- Separate drag activation from card actions so keyboard activation opens Edit while a dedicated handle controls dragging.
- Add API coverage for board read/move behavior to prevent regressions in ordering and permission/isolation logic.

### Description
- Render a destructive retryable `Alert` when `boardQuery.error` is present and gate all drag affordances behind a single `canDragTasks` boolean (`isBoardReady && !boardQuery.error && !moveTask.isPending`).
- Build the drag `renderedTaskMap` from `orderedTasksByStatus` and use it for `activeTask`, drag `DragOverlay`, and announcement text so board-only tasks are recognized during drag operations while preserving list-cache-based edit eligibility.
- Add a dedicated drag-handle (`GripVertical`) wired to `useSortable` activator via `setActivatorNodeRef` and move sortable `attributes`/`listeners` onto the handle while keeping the Edit button outside the activator path.
- Add e2e API tests in `apps/api/tests/tasks.e2e.test.ts` covering authenticated `GET /tasks/board`, same-lane reorder and cross-lane moves via `PATCH /tasks/board/move`, invalid `targetIndex`, not-found task, unauthenticated access, and user isolation; and clean up formatting/whitespace in changed files.

### Testing
- Ran targeted UI unit tests with `pnpm -C apps/web exec vitest ...` (targeted dashboard and client tests) and the Vitest runs passed.
- Ran `pnpm -C apps/api prisma:generate` and `pnpm -C apps/api typecheck`, both of which succeeded.
- Ran `pnpm -C apps/web typecheck`, which failed in this environment due to a TypeScript declaration parse error in `@vitejs/plugin-react` and is treated as an environment/toolchain mismatch (not a functional regression).
- Ran API e2e with `pnpm -C apps/api exec jest --runTestsByPath tests/tasks.e2e.test.ts --runInBand`, which could not complete in this environment because `testcontainers` could not find a container runtime, so full e2e execution is expected to pass in CI or a local environment with Docker available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea0dfb7b3083228613f260223c2b04)