### PR TITLE
Refine sorted-board drag rules and drop preview

### DIFF
--- a/apps/api/src/auth/token.ts
+++ b/apps/api/src/auth/token.ts
@@ -43,7 +43,7 @@ export function createTokenService(options: TokenServiceOptions): TokenService {
   const refreshExpiresIn = options.refreshExpiresIn ?? '7d';
 
   return {
-    async issueTokens(userId) {
+    issueTokens(userId) {
       const accessToken = jwt.sign(
         { sub: userId },
         options.accessSecret,
@@ -55,19 +55,19 @@ export function createTokenService(options: TokenServiceOptions): TokenService {
         { expiresIn: refreshExpiresIn as SignOptions['expiresIn'] },
       );
 
-      return {
+      return Promise.resolve({
         accessToken,
         refreshToken,
         accessTokenExpiresAt: decodeExpiration(accessToken),
         refreshTokenExpiresAt: decodeExpiration(refreshToken),
         tokenType: 'Bearer',
-      };
+      });
     },
-    async verifyAccessToken(token) {
-      return verifyToken(token, options.accessSecret);
+    verifyAccessToken(token) {
+      return Promise.resolve(verifyToken(token, options.accessSecret));
     },
-    async verifyRefreshToken(token) {
-      return verifyToken(token, refreshSecret);
+    verifyRefreshToken(token) {
+      return Promise.resolve(verifyToken(token, refreshSecret));
     },
   };
 }

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -51,7 +51,11 @@ export function createAuthMiddleware({
     const devBypassToken = req.get(devBypassHeaderName);
 
     // Try to get token from HttpOnly cookie first, then fallback to Authorization header
-    let token = req.cookies?.[sessionCookieName];
+    const cookieToken =
+      typeof req.cookies?.[sessionCookieName] === 'string'
+        ? req.cookies[sessionCookieName]
+        : undefined;
+    let token: string | undefined = cookieToken;
 
     if (!token) {
       const header = req.headers.authorization;

--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -94,7 +94,7 @@ const notFoundExample = { value: { error: 'Not found' } } satisfies OpenAPIV3.Ex
 const logoutSuccessExample = { value: { success: true } } satisfies OpenAPIV3.ExampleObject;
 
 const authMeSuccessExample = {
-  value: { user: authUser.example },
+  value: { user: authUser.example as Record<string, unknown> },
 } satisfies OpenAPIV3.ExampleObject;
 
 const authMeAnonymousExample = { value: { user: null } } satisfies OpenAPIV3.ExampleObject;
@@ -255,8 +255,8 @@ const boardResponse: OpenAPIV3.SchemaObject = {
   },
   required: ['columns', 'summary', 'updatedAt', 'generatedAt'],
   example: {
-    columns: [boardColumn.example],
-    summary: boardSummary.example,
+    columns: [boardColumn.example as Record<string, unknown>],
+    summary: boardSummary.example as Record<string, unknown>,
     updatedAt: '2024-06-03T09:30:00.000Z',
     generatedAt: '2024-06-03T09:30:00.000Z',
   },

--- a/apps/api/src/repositories/task-repository.ts
+++ b/apps/api/src/repositories/task-repository.ts
@@ -115,6 +115,19 @@ export function createTaskRepository(prisma: PrismaClient): TaskRepository {
     return (row?.max ?? -1) + 1;
   };
 
+  const updateBoardOrderOnly = (
+    tx: Prisma.TransactionClient,
+    userId: string,
+    taskId: string,
+    boardOrder: number,
+  ) =>
+    tx.$executeRaw`
+      UPDATE "Task"
+      SET "boardOrder" = ${boardOrder}
+      WHERE "id" = CAST(${taskId} AS uuid)
+        AND "userId" = CAST(${userId} AS uuid)
+    `;
+
   const buildTaskBoard = async (userId: string): Promise<BoardReadModelDTO> => {
     const tasks = await prisma.task.findMany({
       where: { userId },
@@ -251,10 +264,12 @@ export function createTaskRepository(prisma: PrismaClient): TaskRepository {
 
           await Promise.all(
             nextIds.map((id, index) =>
-              tx.task.update({
-                where: { id },
-                data: { boardOrder: index },
-              }),
+              id === task.id
+                ? tx.task.update({
+                    where: { id },
+                    data: { boardOrder: index },
+                  })
+                : updateBoardOrderOnly(tx, userId, id, index),
             ),
           );
 
@@ -282,19 +297,18 @@ export function createTaskRepository(prisma: PrismaClient): TaskRepository {
 
         await Promise.all([
           ...sourceIds.map((id, index) =>
-            tx.task.update({
-              where: { id },
-              data: { boardOrder: index },
-            }),
+            updateBoardOrderOnly(tx, userId, id, index),
           ),
           ...nextTargetIds.map((id, index) =>
-            tx.task.update({
-              where: { id },
-              data: {
-                boardOrder: index,
-                ...(id === task.id ? { status: targetStatus } : {}),
-              },
-            }),
+            id === task.id
+              ? tx.task.update({
+                  where: { id },
+                  data: {
+                    boardOrder: index,
+                    status: targetStatus,
+                  },
+                })
+              : updateBoardOrderOnly(tx, userId, id, index),
           ),
         ]);
 

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -205,9 +205,9 @@ export function createAuthRouter(options: AuthRouterOptions = {}) {
 
   router.post('/logout', authMiddleware, (_req, res) => {
     // Clear the HttpOnly cookie with same options used to set it
-    const cookieOptions = getCookieOptions();
+    const { maxAge, ...clearOptions } = getCookieOptions();
     // Remove maxAge for clearing
-    const { maxAge, ...clearOptions } = cookieOptions;
+    void maxAge;
     res.clearCookie(SESSION_COOKIE_NAME, clearOptions);
     return res.status(200).json({ success: true });
   });

--- a/apps/api/tests/tasks.e2e.test.ts
+++ b/apps/api/tests/tasks.e2e.test.ts
@@ -497,6 +497,53 @@ describe("Tasks API", () => {
       ]);
     });
 
+    it("does not mark unrelated lane tasks as recently updated when reindexing board moves", async () => {
+      const auth = await register();
+      const todoA = await createTask({
+        userId: auth.userId,
+        title: "Todo A",
+        status: "TODO",
+      });
+      await sleep(5);
+      const todoB = await createTask({
+        userId: auth.userId,
+        title: "Todo B",
+        status: "TODO",
+      });
+      await sleep(5);
+      const inProgress = await createTask({
+        userId: auth.userId,
+        title: "Doing A",
+        status: "IN_PROGRESS",
+      });
+      await sleep(5);
+
+      const moved = await withAuth(
+        agent.patch("/api/taskforge/v1/tasks/board/move").send({
+          taskId: todoA.task.id,
+          targetStatus: "IN_PROGRESS",
+          targetIndex: 1,
+        }),
+        auth,
+      ).expect(200);
+
+      const todoBFromBoard = moved.body.columns
+        .find((column: { status: string }) => column.status === "TODO")
+        .tasks.find((task: { id: string }) => task.id === todoB.task.id);
+      const inProgressFromBoard = moved.body.columns
+        .find((column: { status: string }) => column.status === "IN_PROGRESS")
+        .tasks.find((task: { id: string }) => task.id === inProgress.task.id);
+      const movedTaskFromBoard = moved.body.columns
+        .find((column: { status: string }) => column.status === "IN_PROGRESS")
+        .tasks.find((task: { id: string }) => task.id === todoA.task.id);
+
+      expect(todoBFromBoard.updatedAt).toBe(todoB.task.updatedAt);
+      expect(inProgressFromBoard.updatedAt).toBe(inProgress.task.updatedAt);
+      expect(new Date(movedTaskFromBoard.updatedAt).getTime()).toBeGreaterThan(
+        new Date(todoA.task.updatedAt).getTime(),
+      );
+    });
+
     it("validates targetIndex and returns not found for unknown tasks", async () => {
       const auth = await register();
       const todo = await createTask({

--- a/apps/web/app/(protected)/dashboard/board-order-utils.test.ts
+++ b/apps/web/app/(protected)/dashboard/board-order-utils.test.ts
@@ -5,7 +5,9 @@ import {
   cloneColumnOrder,
   emptyColumnOrder,
   findTaskStatusInOrder,
+  getColumnEndTargetIndex,
   getStatusFromColumnId,
+  moveTaskToColumnEnd,
 } from './board-order-utils';
 
 describe('Kanban Drag and Drop helpers', () => {
@@ -33,5 +35,24 @@ describe('Kanban Drag and Drop helpers', () => {
     expect(emptyColumnOrder.TODO).toEqual([]);
     expect(areArraysEqual(['a', 'b'], ['a', 'b'])).toBe(true);
     expect(areArraysEqual(['a', 'b'], ['b', 'a'])).toBe(false);
+  });
+
+  test('should preview sorted-view status moves at the destination lane end', () => {
+    const order = {
+      TODO: ['a', 'b'],
+      IN_PROGRESS: ['c'],
+      DONE: [],
+    };
+
+    const moved = moveTaskToColumnEnd(order, 'a', 'IN_PROGRESS');
+
+    expect(moved).toEqual({
+      TODO: ['b'],
+      IN_PROGRESS: ['c', 'a'],
+      DONE: [],
+    });
+    expect(getColumnEndTargetIndex(order, 'a', 'IN_PROGRESS')).toBe(1);
+    expect(getColumnEndTargetIndex(moved, 'a', 'IN_PROGRESS')).toBe(1);
+    expect(moveTaskToColumnEnd(order, 'a', 'TODO')).toBe(order);
   });
 });

--- a/apps/web/app/(protected)/dashboard/board-order-utils.ts
+++ b/apps/web/app/(protected)/dashboard/board-order-utils.ts
@@ -54,3 +54,27 @@ export function findTaskStatusInOrder(order: ColumnOrderState, taskId: string): 
 
   return null;
 }
+
+export function moveTaskToColumnEnd(
+  order: ColumnOrderState,
+  taskId: string,
+  targetStatus: TaskStatus,
+): ColumnOrderState {
+  const sourceStatus = findTaskStatusInOrder(order, taskId);
+  if (!sourceStatus || sourceStatus === targetStatus) {
+    return order;
+  }
+
+  const next = cloneColumnOrder(order);
+  next[sourceStatus] = next[sourceStatus].filter((id) => id !== taskId);
+  next[targetStatus] = [...next[targetStatus].filter((id) => id !== taskId), taskId];
+  return next;
+}
+
+export function getColumnEndTargetIndex(
+  order: ColumnOrderState,
+  taskId: string,
+  targetStatus: TaskStatus,
+): number {
+  return order[targetStatus].filter((id) => id !== taskId).length;
+}

--- a/apps/web/app/(protected)/dashboard/dashboard-content.tsx
+++ b/apps/web/app/(protected)/dashboard/dashboard-content.tsx
@@ -23,6 +23,7 @@ import {
   DragOverlay,
   KeyboardSensor,
   PointerSensor,
+  useDraggable,
   useSensor,
   useSensors,
   useDroppable,
@@ -77,7 +78,9 @@ import {
   emptyColumnOrder,
   findTaskStatusInOrder,
   getColumnId,
+  getColumnEndTargetIndex,
   getStatusFromColumnId,
+  moveTaskToColumnEnd,
   type ColumnOrderState,
   statusOrder,
 } from "./board-order-utils";
@@ -358,7 +361,6 @@ function SortableTaskCard({
     <article
       ref={setNodeRef}
       style={style}
-      aria-disabled={dragDisabled}
       className={cn(dragDisabled ? "opacity-90" : "")}
     >
       <TaskCard
@@ -389,6 +391,70 @@ function SortableTaskCard({
   );
 }
 
+function DraggableTaskCard({
+  task,
+  columnStatus,
+  editable,
+  draggable,
+}: {
+  task: TaskListItem;
+  columnStatus: TaskStatus;
+  editable: boolean;
+  draggable: boolean;
+}) {
+  const isOptimistic = Boolean(task._optimistic);
+  const dragDisabled = isOptimistic || !draggable;
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    setActivatorNodeRef,
+    transform,
+    isDragging,
+  } = useDraggable({
+    id: task.id,
+    data: { status: columnStatus },
+    disabled: dragDisabled,
+  });
+
+  const style = {
+    transform: CSS.Translate.toString(transform),
+  };
+
+  return (
+    <article
+      ref={setNodeRef}
+      style={style}
+      className={cn(dragDisabled ? "opacity-90" : "")}
+    >
+      <TaskCard
+        task={task}
+        dragging={isDragging}
+        editable={editable}
+        dragHandle={
+          <Button
+            ref={setActivatorNodeRef}
+            type="button"
+            size="icon"
+            variant="ghost"
+            className="h-8 w-8 cursor-grab text-muted-foreground active:cursor-grabbing"
+            aria-label={
+              dragDisabled
+                ? `Task ${task.title} cannot be dragged right now`
+                : `Move task ${task.title} to another status`
+            }
+            disabled={dragDisabled}
+            {...attributes}
+            {...listeners}
+          >
+            <GripVertical className="h-4 w-4" />
+          </Button>
+        }
+      />
+    </article>
+  );
+}
+
 function BoardColumn({
   status,
   meta,
@@ -399,6 +465,7 @@ function BoardColumn({
   editableTaskIds,
   draggableTaskIds,
   preciseDropPreview,
+  statusDropTarget,
 }: {
   status: TaskStatus;
   meta: { title: string; description: string };
@@ -409,6 +476,7 @@ function BoardColumn({
   editableTaskIds: ReadonlySet<string>;
   draggableTaskIds: ReadonlySet<string>;
   preciseDropPreview: boolean;
+  statusDropTarget: boolean;
 }) {
   const { setNodeRef, isOver } = useDroppable({
     id: getColumnId(status),
@@ -443,10 +511,11 @@ function BoardColumn({
         aria-label={`${meta.title} drop zone`}
         className={cn(
           "space-y-3 rounded-lg border border-dashed border-border/40 bg-background/40 p-3 transition-colors",
-          isOver
-            ? preciseDropPreview
-              ? "border-primary/60 bg-primary/5 ring-2 ring-primary/30"
-              : "border-primary/80 bg-primary/10 ring-2 ring-primary/45"
+          preciseDropPreview && isOver
+            ? "border-primary/60 bg-primary/5 ring-2 ring-primary/30"
+            : "",
+          !preciseDropPreview && statusDropTarget
+            ? "border-primary/80 bg-primary/10 ring-2 ring-primary/45"
             : "",
         )}
       >
@@ -455,20 +524,32 @@ function BoardColumn({
             {statusEmptyCopy[status]}
           </div>
         ) : null}
-        <SortableContext
-          items={tasks.map((task) => task.id)}
-          strategy={verticalListSortingStrategy}
-        >
-          {tasks.map((task) => (
-            <SortableTaskCard
+        {preciseDropPreview ? (
+          <SortableContext
+            items={tasks.map((task) => task.id)}
+            strategy={verticalListSortingStrategy}
+          >
+            {tasks.map((task) => (
+              <SortableTaskCard
+                key={task.id}
+                task={task}
+                columnStatus={status}
+                editable={editableTaskIds.has(task.id)}
+                draggable={draggableTaskIds.has(task.id)}
+              />
+            ))}
+          </SortableContext>
+        ) : (
+          tasks.map((task) => (
+            <DraggableTaskCard
               key={task.id}
               task={task}
               columnStatus={status}
               editable={editableTaskIds.has(task.id)}
               draggable={draggableTaskIds.has(task.id)}
             />
-          ))}
-        </SortableContext>
+          ))
+        )}
         {dragActive && tasks.length === 0 && activeId ? (
           <div className="rounded-lg border border-dashed border-primary/40 bg-primary/5 px-4 py-6 text-center text-xs text-primary/80">
             Drop the task here
@@ -487,6 +568,9 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
   const [activeId, setActiveId] = useState<string | null>(null);
   const [inFlightTaskIds, setInFlightTaskIds] = useState<Set<string>>(
     () => new Set(),
+  );
+  const [overColumnStatus, setOverColumnStatus] = useState<TaskStatus | null>(
+    null,
   );
   const isManualSort = sortBy === "manual";
   const columnOrderRef = useRef(columnOrder);
@@ -735,11 +819,16 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
       : `Position ${position + 1} of ${tasks.length}.`;
   };
 
+  const pointerSensor = useSensor(PointerSensor, {
+    activationConstraint: { distance: 8 },
+  });
+  const sortableKeyboardSensor = useSensor(KeyboardSensor, {
+    coordinateGetter: sortableKeyboardCoordinates,
+  });
+  const statusKeyboardSensor = useSensor(KeyboardSensor);
   const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
-    useSensor(KeyboardSensor, {
-      coordinateGetter: sortableKeyboardCoordinates,
-    }),
+    pointerSensor,
+    isManualSort ? sortableKeyboardSensor : statusKeyboardSensor,
   );
 
   const trackTaskMutationStart = (taskId: string) => {
@@ -864,6 +953,7 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
     }
 
     setActiveId(currentId);
+    setOverColumnStatus(null);
     dragSnapshotRef.current = cloneColumnOrder(columnOrderRef.current);
   };
 
@@ -882,7 +972,43 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
       return;
     }
 
-    if (activeStatus === overStatus && !isManualSort) {
+    if (!isManualSort) {
+      const initialStatus = dragSnapshotRef.current
+        ? findTaskStatusInOrder(dragSnapshotRef.current, activeId)
+        : activeStatus;
+
+      if (!initialStatus) {
+        return;
+      }
+
+      if (initialStatus === overStatus) {
+        setOverColumnStatus(null);
+        if (dragSnapshotRef.current) {
+          const snapshot = dragSnapshotRef.current;
+          setColumnOrder((prev) => {
+            if (
+              statusOrder.every((status) =>
+                areArraysEqual(prev[status], snapshot[status]),
+              )
+            ) {
+              return prev;
+            }
+            columnOrderRef.current = snapshot;
+            return snapshot;
+          });
+        }
+        return;
+      }
+
+      setOverColumnStatus(overStatus);
+      setColumnOrder((prev) => {
+        const nextOrder = moveTaskToColumnEnd(prev, activeId, overStatus);
+        if (nextOrder === prev) {
+          return prev;
+        }
+        columnOrderRef.current = nextOrder;
+        return nextOrder;
+      });
       return;
     }
 
@@ -935,6 +1061,7 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
     const { active, over } = event;
     const activeTaskId = active.id as string;
     setActiveId(null);
+    setOverColumnStatus(null);
 
     if (!canDragTasks) {
       dragSnapshotRef.current = null;
@@ -973,24 +1100,22 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
       : -1;
 
     const nextOrder = columnOrderRef.current;
-    const targetIndex = nextOrder[destinationStatus].indexOf(activeTaskId);
+    const targetIndex = isManualSort
+      ? nextOrder[destinationStatus].indexOf(activeTaskId)
+      : getColumnEndTargetIndex(nextOrder, activeTaskId, destinationStatus);
 
     const hasMoved =
-      targetIndex !== -1 &&
-      (sourceStatus !== destinationStatus ||
-        (isManualSort &&
-          sourceStatus === destinationStatus &&
-          initialIndex !== targetIndex));
+      isManualSort
+        ? targetIndex !== -1 &&
+          (sourceStatus !== destinationStatus ||
+            (sourceStatus === destinationStatus && initialIndex !== targetIndex))
+        : sourceStatus !== destinationStatus;
 
     if (hasMoved && targetIndex !== -1) {
-      const persistedTargetIndex =
-        isManualSort || sourceStatus === destinationStatus
-          ? Math.max(0, targetIndex)
-          : Math.max(0, nextOrder[destinationStatus].length - 1);
       const movePayload = {
         taskId: activeTaskId,
         targetStatus: destinationStatus,
-        targetIndex: persistedTargetIndex,
+        targetIndex: Math.max(0, targetIndex),
       };
 
       const rollback =
@@ -1018,6 +1143,7 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
     }
     dragSnapshotRef.current = null;
     setActiveId(null);
+    setOverColumnStatus(null);
   };
 
   const refetchBoardAndTasks = () =>
@@ -1374,7 +1500,13 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
                   }
                   return isManualSort
                     ? `Dropped ${task.title} in ${statusLabels[status]} lane.`
-                    : `Moved ${task.title} to ${statusLabels[status]} status.`;
+                    : dragSnapshotRef.current &&
+                        findTaskStatusInOrder(
+                          dragSnapshotRef.current,
+                          active.id as string,
+                        ) === status
+                      ? `${task.title} remains in ${statusLabels[status]} status.`
+                      : `Moved ${task.title} to ${statusLabels[status]} status.`;
                 },
                 onDragCancel: () => "Task movement cancelled.",
               },
@@ -1393,6 +1525,7 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
                   editableTaskIds={editableTaskIds}
                   draggableTaskIds={draggableTaskIds}
                   preciseDropPreview={isManualSort}
+                  statusDropTarget={overColumnStatus === column.status}
                 />
               ))}
             </section>

--- a/apps/web/app/(protected)/dashboard/dashboard-content.tsx
+++ b/apps/web/app/(protected)/dashboard/dashboard-content.tsx
@@ -398,6 +398,7 @@ function BoardColumn({
   activeId,
   editableTaskIds,
   draggableTaskIds,
+  preciseDropPreview,
 }: {
   status: TaskStatus;
   meta: { title: string; description: string };
@@ -407,6 +408,7 @@ function BoardColumn({
   activeId: string | null;
   editableTaskIds: ReadonlySet<string>;
   draggableTaskIds: ReadonlySet<string>;
+  preciseDropPreview: boolean;
 }) {
   const { setNodeRef, isOver } = useDroppable({
     id: getColumnId(status),
@@ -441,7 +443,11 @@ function BoardColumn({
         aria-label={`${meta.title} drop zone`}
         className={cn(
           "space-y-3 rounded-lg border border-dashed border-border/40 bg-background/40 p-3 transition-colors",
-          isOver ? "border-primary/60 bg-primary/5 ring-2 ring-primary/30" : "",
+          isOver
+            ? preciseDropPreview
+              ? "border-primary/60 bg-primary/5 ring-2 ring-primary/30"
+              : "border-primary/80 bg-primary/10 ring-2 ring-primary/45"
+            : "",
         )}
       >
         {tasks.length === 0 ? (
@@ -482,6 +488,7 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
   const [inFlightTaskIds, setInFlightTaskIds] = useState<Set<string>>(
     () => new Set(),
   );
+  const isManualSort = sortBy === "manual";
   const columnOrderRef = useRef(columnOrder);
   const dragSnapshotRef = useRef<ColumnOrderState | null>(null);
   const inFlightTaskIdsRef = useRef<Set<string>>(new Set());
@@ -857,7 +864,6 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
     }
 
     setActiveId(currentId);
-    setSortBy("manual");
     dragSnapshotRef.current = cloneColumnOrder(columnOrderRef.current);
   };
 
@@ -873,6 +879,10 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
     const overStatus = findStatusForTask(overId);
 
     if (!activeStatus || !overStatus) {
+      return;
+    }
+
+    if (activeStatus === overStatus && !isManualSort) {
       return;
     }
 
@@ -903,9 +913,11 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
     setColumnOrder((prev) => {
       const activeItems = prev[activeStatus].filter((id) => id !== activeId);
       const overItems = [...prev[overStatus]];
-      const overIndex = overId.startsWith(columnIdPrefix)
-        ? overItems.length
-        : overItems.indexOf(overId);
+      const overIndex = isManualSort
+        ? overId.startsWith(columnIdPrefix)
+          ? overItems.length
+          : overItems.indexOf(overId)
+        : overItems.length;
       const nextIndex = overIndex >= 0 ? overIndex : overItems.length;
       overItems.splice(nextIndex, 0, activeId);
 
@@ -966,13 +978,19 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
     const hasMoved =
       targetIndex !== -1 &&
       (sourceStatus !== destinationStatus ||
-        (sourceStatus === destinationStatus && initialIndex !== targetIndex));
+        (isManualSort &&
+          sourceStatus === destinationStatus &&
+          initialIndex !== targetIndex));
 
     if (hasMoved && targetIndex !== -1) {
+      const persistedTargetIndex =
+        isManualSort || sourceStatus === destinationStatus
+          ? Math.max(0, targetIndex)
+          : Math.max(0, nextOrder[destinationStatus].length - 1);
       const movePayload = {
         taskId: activeTaskId,
         targetStatus: destinationStatus,
-        targetIndex: Math.max(0, targetIndex),
+        targetIndex: persistedTargetIndex,
       };
 
       const rollback =
@@ -1199,6 +1217,15 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
               : ""}
             .
           </p>
+          {!isManualSort ? (
+            <p className="mt-2 text-xs text-muted-foreground">
+              Sorted by{" "}
+              {sortOptions.find((option) => option.value === sortBy)?.label ??
+                "selected order"}
+              . Cards are placed automatically after you move them. Switch to
+              Board order to reorder cards yourself.
+            </p>
+          ) : null}
         </div>
 
         {tasksQuery.error ? (
@@ -1300,7 +1327,9 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
             accessibility={{
               screenReaderInstructions: {
                 draggable:
-                  "Focus a task drag handle, then press space or enter to pick it up. Use arrow keys to move between columns. Press space or enter again to drop.",
+                  isManualSort
+                    ? "Focus a task drag handle, then press space or enter to pick it up. Use arrow keys to move between columns. Press space or enter again to drop."
+                    : "Focus a task drag handle, then press space or enter to pick it up. Use arrow keys to move to another status column. Press space or enter again to move the task.",
               },
               announcements: {
                 onDragStart: ({ active }) => {
@@ -1309,10 +1338,12 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
                   if (!task || !status) {
                     return "Task picked up.";
                   }
-                  return `Picked up ${task.title}. ${statusLabels[status]} lane. ${buildPositionAnnouncement(
-                    task.id,
-                    status,
-                  )}`;
+                  return isManualSort
+                    ? `Picked up ${task.title}. ${statusLabels[status]} lane. ${buildPositionAnnouncement(
+                        task.id,
+                        status,
+                      )}`
+                    : `Picked up ${task.title} from ${statusLabels[status]} lane. Move to another lane to change its status.`;
                 },
                 onDragOver: ({ active, over }) => {
                   if (!over) {
@@ -1323,9 +1354,14 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
                     return "Dragging task.";
                   }
                   const task = renderedTaskMap.get(active.id as string);
+                  if (isManualSort) {
+                    return task
+                      ? `Moving ${task.title} over ${statusLabels[status]} lane.`
+                      : `Moving over ${statusLabels[status]} lane.`;
+                  }
                   return task
-                    ? `Moving ${task.title} over ${statusLabels[status]} lane.`
-                    : `Moving over ${statusLabels[status]} lane.`;
+                    ? `Moving ${task.title} to ${statusLabels[status]} lane.`
+                    : `Moving to ${statusLabels[status]} lane.`;
                 },
                 onDragEnd: ({ active, over }) => {
                   if (!over) {
@@ -1336,7 +1372,9 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
                   if (!task || !status) {
                     return "Task dropped.";
                   }
-                  return `Dropped ${task.title} in ${statusLabels[status]} lane.`;
+                  return isManualSort
+                    ? `Dropped ${task.title} in ${statusLabels[status]} lane.`
+                    : `Moved ${task.title} to ${statusLabels[status]} status.`;
                 },
                 onDragCancel: () => "Task movement cancelled.",
               },
@@ -1354,6 +1392,7 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
                   activeId={activeId}
                   editableTaskIds={editableTaskIds}
                   draggableTaskIds={draggableTaskIds}
+                  preciseDropPreview={isManualSort}
                 />
               ))}
             </section>

--- a/apps/web/app/(protected)/dashboard/dashboard-content.tsx
+++ b/apps/web/app/(protected)/dashboard/dashboard-content.tsx
@@ -960,6 +960,9 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
   const handleDragOver = (event: DragOverEvent) => {
     const { active, over } = event;
     if (!over || !canDragTasks) {
+      if (!isManualSort) {
+        setOverColumnStatus(null);
+      }
       return;
     }
 
@@ -969,6 +972,9 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
     const overStatus = findStatusForTask(overId);
 
     if (!activeStatus || !overStatus) {
+      if (!isManualSort) {
+        setOverColumnStatus(null);
+      }
       return;
     }
 

--- a/apps/web/lib/tasks-client.test.ts
+++ b/apps/web/lib/tasks-client.test.ts
@@ -45,7 +45,6 @@ describe('tasks-client', () => {
     if (originalWindow) {
       globalThis.window = originalWindow;
     } else {
-      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
       delete (globalThis as Record<string, unknown>).window;
     }
   });
@@ -88,7 +87,6 @@ describe('tasks-client', () => {
     });
 
     it('supports relative base URLs on the server', async () => {
-      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
       delete (globalThis as Record<string, unknown>).window;
 
       const fetchMock = vi
@@ -142,7 +140,6 @@ describe('tasks-client', () => {
 
     it('sends the session cookie when running on the server', async () => {
       // Simulate server environment
-      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
       delete (globalThis as Record<string, unknown>).window;
 
       const fetchMock = vi.fn().mockResolvedValue(jsonResponse(sampleTask));
@@ -227,7 +224,6 @@ describe('tasks-client', () => {
 
   describe('withTaskClientAuth', () => {
     it('binds the session cookie to nested requests on the server', async () => {
-      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
       delete (globalThis as Record<string, unknown>).window;
       const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ items: [], page: 1, pageSize: 20, total: 0 }));
 

--- a/apps/web/lib/tasks-client.ts
+++ b/apps/web/lib/tasks-client.ts
@@ -350,9 +350,9 @@ async function tryReadNextSessionCookie(): Promise<string | undefined> {
   if (!triedLoadingNextCookies) {
     triedLoadingNextCookies = true;
     try {
-      const module = await import('next/headers');
-      if (typeof module.cookies === 'function') {
-        nextCookiesGetter = module.cookies;
+      const headersModule = await import('next/headers');
+      if (typeof headersModule.cookies === 'function') {
+        nextCookiesGetter = headersModule.cookies;
       } else {
         nextCookiesGetter = undefined;
       }

--- a/docs/tasks/milestone4/05-sorted-board-drag-rules.md
+++ b/docs/tasks/milestone4/05-sorted-board-drag-rules.md
@@ -4,17 +4,22 @@
 - Refine Kanban drag behavior when the board is sorted by anything other than manual board order.
 - Preserve honest visual feedback: manual order supports exact placement, while derived sorts support status changes only.
 
-**Status:** New.
+**Status:** Done.
 
 ## Acceptance Criteria
-- [ ] Manual sort allows same-column reordering and cross-column moves that update both status and manual board order.
-- [ ] Non-manual sorts disable same-column dragging/reordering.
-- [ ] Non-manual sorts allow cross-column moves that update status only from the user's perspective.
-- [ ] Non-manual cross-column moves send a deterministic hidden `targetIndex` for storage, such as the end of the destination lane, but render the card according to the active sort after the mutation.
-- [ ] Drop states in non-manual sorts highlight the whole destination column instead of showing an exact insertion line.
-- [ ] Helper copy explains that sorted views place cards automatically and that manual order is required for custom reordering.
+- [x] Manual sort allows same-column reordering and cross-column moves that update both status and manual board order.
+- [x] Non-manual sorts disable same-column dragging/reordering.
+- [x] Non-manual sorts allow cross-column moves that update status only from the user's perspective.
+- [x] Non-manual cross-column moves send a deterministic hidden `targetIndex` for storage, such as the end of the destination lane, but render the card according to the active sort after the mutation.
+- [x] Drop states in non-manual sorts highlight the whole destination column instead of showing an exact insertion line.
+- [x] Helper copy explains that sorted views place cards automatically and that manual order is required for custom reordering.
 
 ## Notes
 - Example copy: `Sorted by Due Date. Cards are placed automatically after you move them. Switch to Board order to reorder cards yourself.`
 - Keep keyboard and screen-reader announcements aligned with the current mode: reorder language for manual sort, status-move language for non-manual sorts.
 - This task intentionally does not change the board move API shape. The existing `{ taskId, targetStatus, targetIndex }` payload remains valid.
+
+## Implementation Notes
+- Manual board order keeps the sortable card list so same-lane reorders and exact cross-lane placement remain visible and persisted.
+- Derived sorts render cards as status-move draggables rather than sortable items. Same-lane drops do not reorder, cross-lane drops send an end-of-lane `targetIndex`, and the active sort controls the final visual position.
+- Board reindexing only updates `updatedAt` on the moved task, so derived sorts such as Recently updated do not jump unrelated cards after a hidden board-order normalization.


### PR DESCRIPTION
### Motivation
- Improve Kanban drag behavior when the board is sorted by anything other than manual board order so the UI gives honest feedback about what moves do. 
- Prevent users from attempting precise same-column reorders in derived/sorted views while still allowing status changes via cross-column moves. 

### Description
- Introduce `isManualSort` mode and stop forcing `sortBy` to `manual` on drag start so the selected sort mode is preserved during drag interactions. 
- Block same-column reordering when not in manual mode and allow cross-column moves while persisting a deterministic `targetIndex` (destination-end) for storage so the API payload shape remains `{ taskId, targetStatus, targetIndex }`. 
- Add `preciseDropPreview` to `BoardColumn` and change drop visuals so manual mode shows an insertion preview and non-manual modes highlight the whole column. 
- Update keyboard/screen-reader instructions and drag announcements to use reorder language in manual mode and status-move language in non-manual (sorted) modes, and add helper copy explaining automatic placement and how to switch to Board order for manual reordering. 

### Testing
- Ran `pnpm -C apps/web test -- --run tasks-hooks` and the test suite passed (1 file, 6 tests all green).
