### PR TITLE
Add tag support to board: display tags, tag selector with search, and URL-synced filters

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -40,7 +40,3 @@ Explain the purpose of this PR and the outcome in 2–4 sentences.
 
 ## Notes / Follow-ups
 <!-- TODOs for next milestone, known limitations, decisions -->
-
----
-
-If anything in the typecheck output looks noisy after this, paste the exact error lines and I’ll give you the fix line-by-line.

--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -936,8 +936,24 @@ export const openApiDocument: OpenAPIV3.Document = {
         tags: ['Tasks'],
         summary: 'Retrieve the Kanban board read model',
         description:
-          'Returns a board-friendly representation of tasks grouped by status lanes. Requires a valid JWT via `Authorization` header or the `tf_session` cookie.',
+          'Returns a board-friendly representation of tasks grouped by status lanes. Repeating `tag` requires tasks to include every selected tag. Requires a valid JWT via `Authorization` header or the `tf_session` cookie.',
         security: [{ bearerAuth: [] }, { sessionCookie: [] }],
+        parameters: [
+          {
+            name: 'tag',
+            in: 'query',
+            required: false,
+            description: 'Filter board tasks that include the specified tag(s). Repeat the parameter to require multiple tags.',
+            schema: {
+              oneOf: [
+                { type: 'string' },
+                { type: 'array', items: { type: 'string' } },
+              ],
+            },
+            style: 'form',
+            explode: true,
+          },
+        ],
         responses: {
           '200': {
             description: 'Task board',

--- a/apps/api/src/repositories/task-repository.ts
+++ b/apps/api/src/repositories/task-repository.ts
@@ -46,6 +46,10 @@ export interface TaskListOptions {
   dueTo?: Date;
 }
 
+export interface TaskBoardOptions {
+  tags?: string[];
+}
+
 export interface TaskListResult {
   items: TaskRecordDTO[];
   total: number;
@@ -54,7 +58,7 @@ export interface TaskListResult {
 export interface TaskRepository {
   listTasks(userId: string, options?: TaskListOptions): Promise<TaskListResult>;
   getTask(userId: string, taskId: string): Promise<TaskRecordDTO | null>;
-  getTaskBoard(userId: string): Promise<BoardReadModelDTO>;
+  getTaskBoard(userId: string, options?: TaskBoardOptions): Promise<BoardReadModelDTO>;
   moveTaskOnBoard(
     userId: string,
     input: BoardMoveRequestDTO,
@@ -128,9 +132,31 @@ export function createTaskRepository(prisma: PrismaClient): TaskRepository {
         AND "userId" = CAST(${userId} AS uuid)
     `;
 
-  const buildTaskBoard = async (userId: string): Promise<BoardReadModelDTO> => {
+  const buildTaskBoard = async (userId: string, options?: TaskBoardOptions): Promise<BoardReadModelDTO> => {
+    const andFilters: Prisma.TaskWhereInput[] = [];
+
+    if (options?.tags?.length) {
+      for (const label of options.tags) {
+        andFilters.push({
+          TaskTag: {
+            some: {
+              tag: {
+                label: {
+                  equals: label,
+                  mode: 'insensitive',
+                },
+              },
+            },
+          },
+        });
+      }
+    }
+
     const tasks = await prisma.task.findMany({
-      where: { userId },
+      where: {
+        userId,
+        ...(andFilters.length ? { AND: andFilters } : {}),
+      },
       include: taskWithTagsInclude,
     });
 
@@ -226,8 +252,8 @@ export function createTaskRepository(prisma: PrismaClient): TaskRepository {
       return task ? toTaskRecordDTO(task) : null;
     },
 
-    async getTaskBoard(userId) {
-      return buildTaskBoard(userId);
+    async getTaskBoard(userId, options) {
+      return buildTaskBoard(userId, options);
     },
 
     async moveTaskOnBoard(userId, input) {

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -37,6 +37,12 @@ const TaskListQuerySchema = z
     }
   });
 
+const TaskBoardQuerySchema = z
+  .object({
+    tag: z.union([z.string().trim().min(1), z.array(z.string().trim().min(1))]).optional(),
+  })
+  .passthrough();
+
 const TaskIdParamSchema = z.object({
   id: z
     .string({ required_error: 'Task id is required', invalid_type_error: 'Invalid identifier' })
@@ -107,12 +113,26 @@ export function createTaskRouter(taskRepository?: TaskRepository) {
 
   router.get('/board', async (req, res, next) => {
     try {
+      const parseQuery = TaskBoardQuerySchema.safeParse(req.query);
+      if (!parseQuery.success) {
+        return res
+          .status(400)
+          .json({ error: 'Invalid payload', details: parseQuery.error.flatten() });
+      }
+
       const user = res.locals.user;
       if (!user) {
         return res.status(401).json({ error: 'Unauthorized' });
       }
 
-      const board = await repository.getTaskBoard(user.id);
+      const { tag } = parseQuery.data;
+      const normalizedTags = normalizeTagLabels(
+        Array.isArray(tag) ? tag : tag ? [tag] : undefined,
+      );
+
+      const board = await repository.getTaskBoard(user.id, {
+        tags: normalizedTags.length ? normalizedTags : undefined,
+      });
       res.set('ETag', `"${board.updatedAt}"`);
       res.json(board);
     } catch (error) {

--- a/apps/api/tests/tasks.e2e.test.ts
+++ b/apps/api/tests/tasks.e2e.test.ts
@@ -414,6 +414,47 @@ describe("Tasks API", () => {
       expect(response.body).toEqual({ error: "Unauthorized" });
     });
 
+    it("filters board data by repeated tag query params", async () => {
+      const auth = await register();
+
+      const matching = await createTask({
+        userId: auth.userId,
+        title: "Frontend API work",
+        status: "TODO",
+        tags: ["frontend", "api"],
+      });
+      await createTask({
+        userId: auth.userId,
+        title: "Frontend only work",
+        status: "IN_PROGRESS",
+        tags: ["frontend"],
+      });
+      await createTask({
+        userId: auth.userId,
+        title: "API only work",
+        status: "DONE",
+        tags: ["api"],
+      });
+
+      const response = await withAuth(
+        agent.get("/api/taskforge/v1/tasks/board?tag=frontend&tag=api"),
+        auth,
+      ).expect(200);
+
+      expect(response.body.summary).toEqual(
+        expect.objectContaining({
+          totalTasks: 1,
+          totalsByStatus: { TODO: 1, IN_PROGRESS: 0, DONE: 0 },
+        }),
+      );
+      expect(
+        response.body.columns.flatMap(
+          (column: { tasks: Array<{ id: string }> }) =>
+            column.tasks.map((task) => task.id),
+        ),
+      ).toEqual([matching.task.id]);
+    });
+
     it("requires authentication to move tasks on the board", async () => {
       const created = await createTask({
         title: "Unauthenticated board move",

--- a/apps/web/app/(protected)/dashboard/dashboard-content.tsx
+++ b/apps/web/app/(protected)/dashboard/dashboard-content.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { motion } from "framer-motion";
 import {
   ArrowUpDown,
@@ -581,8 +588,12 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
   const pathname = usePathname();
   const router = useRouter();
   const searchParams = useSearchParams();
+  const urlTagFilters = useMemo(
+    () => sanitizeTags(searchParams.getAll("tag")),
+    [searchParams],
+  );
   const [statusFilter, setStatusFilter] = useState<"ALL" | TaskStatus>("ALL");
-  const [tagFilters, setTagFilters] = useState<string[]>([]);
+  const [tagFilters, setTagFilters] = useState<string[]>(() => urlTagFilters);
   const [sortBy, setSortBy] = useState<SortOption>("manual");
   const [columnOrder, setColumnOrder] = useState<ColumnOrderState>(() =>
     cloneColumnOrder(emptyColumnOrder),
@@ -800,27 +811,39 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
   );
 
   useEffect(() => {
-    const urlTags = sanitizeTags(searchParams.getAll("tag"));
     setTagFilters((previous) =>
-      previous.length === urlTags.length &&
-      previous.every((value, index) => value === urlTags[index])
+      previous.length === urlTagFilters.length &&
+      previous.every((value, index) => value === urlTagFilters[index])
         ? previous
-        : urlTags,
+        : urlTagFilters,
     );
-  }, [searchParams]);
+  }, [urlTagFilters]);
 
-  useEffect(() => {
-    const params = new URLSearchParams(searchParams.toString());
-    params.delete("tag");
-    for (const tag of tagFilters) {
-      params.append("tag", tag);
-    }
-    const next = params.toString();
-    const current = searchParams.toString();
-    if (next !== current) {
-      router.replace(next ? `${pathname}?${next}` : pathname, { scroll: false });
-    }
-  }, [pathname, router, searchParams, tagFilters]);
+  const handleTagFiltersChange = useCallback(
+    (nextTags: string[]) => {
+      const nextTagFilters = sanitizeTags(nextTags);
+      setTagFilters((previous) =>
+        previous.length === nextTagFilters.length &&
+        previous.every((value, index) => value === nextTagFilters[index])
+          ? previous
+          : nextTagFilters,
+      );
+
+      const params = new URLSearchParams(searchParams.toString());
+      params.delete("tag");
+      for (const tag of nextTagFilters) {
+        params.append("tag", tag);
+      }
+      const next = params.toString();
+      const current = searchParams.toString();
+      if (next !== current) {
+        router.replace(next ? `${pathname}?${next}` : pathname, {
+          scroll: false,
+        });
+      }
+    },
+    [pathname, router, searchParams],
+  );
 
   const availableTags = useMemo(() => {
     const collected: string[] = [];
@@ -1366,7 +1389,7 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
           <div className="w-full max-w-sm">
             <TaskTagSelector
               value={tagFilters}
-              onChange={setTagFilters}
+              onChange={handleTagFiltersChange}
               availableTags={availableTags}
               placeholder="Filter by tags"
               emptyHint="Choose one or more tags to scope the board."

--- a/apps/web/app/(protected)/dashboard/dashboard-content.tsx
+++ b/apps/web/app/(protected)/dashboard/dashboard-content.tsx
@@ -66,6 +66,7 @@ import { useToast } from "@/components/ui/use-toast";
 import {
   useMoveTaskOnBoard,
   useTaskBoardQuery,
+  useTagsQuery,
   useTasksQuery,
   type TaskListItem,
 } from "@/lib/tasks-hooks";
@@ -602,7 +603,10 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
     pageSize: 50,
     tag: tagFilters.length > 0 ? tagFilters : undefined,
   });
-  const boardQuery = useTaskBoardQuery();
+  const boardQuery = useTaskBoardQuery({
+    tag: tagFilters.length > 0 ? tagFilters : undefined,
+  });
+  const tagsQuery = useTagsQuery();
   const moveTask = useMoveTaskOnBoard();
   const { toast } = useToast();
 
@@ -820,14 +824,14 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
 
   const availableTags = useMemo(() => {
     const collected: string[] = [];
-    for (const task of tasksQuery.tasks) {
-      collected.push(...task.tags);
+    for (const tag of tagsQuery.tags) {
+      collected.push(tag.label);
     }
     for (const tag of tagFilters) {
       collected.push(tag);
     }
     return sanitizeTags(collected);
-  }, [tagFilters, tasksQuery.tasks]);
+  }, [tagFilters, tagsQuery.tags]);
 
   const firstName = user.name?.split(" ")[0] ?? "there";
 

--- a/apps/web/app/(protected)/dashboard/dashboard-content.tsx
+++ b/apps/web/app/(protected)/dashboard/dashboard-content.tsx
@@ -39,6 +39,7 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import type { TaskPriority, TaskStatus } from "@taskforge/shared";
 
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -69,6 +70,8 @@ import {
   type TaskListItem,
 } from "@/lib/tasks-hooks";
 import { cn } from "@/lib/utils";
+import { sanitizeTags } from "@/lib/task-tags";
+import { TaskTagSelector } from "@/components/tasks/task-tag-selector";
 
 import type { DashboardUser } from "./types";
 import {
@@ -297,6 +300,20 @@ function TaskCard({
             <p className="text-xs text-muted-foreground">
               Due {formatDueDate(task.dueDate)}
             </p>
+            {task.tags.length > 0 ? (
+              <div className="flex flex-wrap gap-1.5">
+                {task.tags.map((tag) => (
+                  <Badge
+                    key={`${task.id}-${tag}`}
+                    variant="outline"
+                    title={tag}
+                    className="max-w-28 truncate border-violet-300/60 bg-violet-500/10 text-violet-900 dark:border-violet-200/40 dark:text-violet-100"
+                  >
+                    {tag}
+                  </Badge>
+                ))}
+              </div>
+            ) : null}
           </div>
           <div className="flex flex-col items-start gap-2 sm:items-end">
             {dragHandle}
@@ -560,7 +577,11 @@ function BoardColumn({
   );
 }
 export function DashboardContent({ user }: { user: DashboardUser }) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const searchParams = useSearchParams();
   const [statusFilter, setStatusFilter] = useState<"ALL" | TaskStatus>("ALL");
+  const [tagFilters, setTagFilters] = useState<string[]>([]);
   const [sortBy, setSortBy] = useState<SortOption>("manual");
   const [columnOrder, setColumnOrder] = useState<ColumnOrderState>(() =>
     cloneColumnOrder(emptyColumnOrder),
@@ -577,7 +598,10 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
   const dragSnapshotRef = useRef<ColumnOrderState | null>(null);
   const inFlightTaskIdsRef = useRef<Set<string>>(new Set());
 
-  const tasksQuery = useTasksQuery({ pageSize: 50 });
+  const tasksQuery = useTasksQuery({
+    pageSize: 50,
+    tag: tagFilters.length > 0 ? tagFilters : undefined,
+  });
   const boardQuery = useTaskBoardQuery();
   const moveTask = useMoveTaskOnBoard();
   const { toast } = useToast();
@@ -770,6 +794,40 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
       boardQuery.data?.summary.totalsByStatus.TODO ?? tasksByStatus.TODO.length,
     [boardQuery.data, tasksByStatus.TODO.length],
   );
+
+  useEffect(() => {
+    const urlTags = sanitizeTags(searchParams.getAll("tag"));
+    setTagFilters((previous) =>
+      previous.length === urlTags.length &&
+      previous.every((value, index) => value === urlTags[index])
+        ? previous
+        : urlTags,
+    );
+  }, [searchParams]);
+
+  useEffect(() => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete("tag");
+    for (const tag of tagFilters) {
+      params.append("tag", tag);
+    }
+    const next = params.toString();
+    const current = searchParams.toString();
+    if (next !== current) {
+      router.replace(next ? `${pathname}?${next}` : pathname, { scroll: false });
+    }
+  }, [pathname, router, searchParams, tagFilters]);
+
+  const availableTags = useMemo(() => {
+    const collected: string[] = [];
+    for (const task of tasksQuery.tasks) {
+      collected.push(...task.tags);
+    }
+    for (const tag of tagFilters) {
+      collected.push(tag);
+    }
+    return sanitizeTags(collected);
+  }, [tagFilters, tasksQuery.tasks]);
 
   const firstName = user.name?.split(" ")[0] ?? "there";
 
@@ -1301,6 +1359,16 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
               })}
             </div>
           </div>
+          <div className="w-full max-w-sm">
+            <TaskTagSelector
+              value={tagFilters}
+              onChange={setTagFilters}
+              availableTags={availableTags}
+              placeholder="Filter by tags"
+              emptyHint="Choose one or more tags to scope the board."
+              ariaLabel="Filter board by tag"
+            />
+          </div>
           <div className="flex flex-wrap items-center gap-3">
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
@@ -1346,6 +1414,9 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
             Showing {visibleTaskCount} of {totalTasks} tasks
             {statusFilter !== "ALL"
               ? ` in ${statusLabels[statusFilter]} status`
+              : ""}
+            {tagFilters.length > 0
+              ? ` with tags: ${tagFilters.join(", ")}`
               : ""}
             .
           </p>

--- a/apps/web/components/tasks/task-dialog-host.tsx
+++ b/apps/web/components/tasks/task-dialog-host.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useState } from 'react';
 
 import { useToast } from '@/components/ui/use-toast';
 import { sanitizeTags } from '@/lib/task-tags';
-import { useTasksQuery } from '@/lib/tasks-hooks';
+import { useTagsQuery } from '@/lib/tasks-hooks';
 
 import { TaskCreateDialog } from './task-create-dialog';
 import { TaskEditDialog } from './task-edit-dialog';
@@ -14,8 +14,8 @@ type ActiveDialog = { type: 'create' } | { type: 'edit'; taskId: string } | null
 export function TaskDialogHost() {
   const [activeDialog, setActiveDialog] = useState<ActiveDialog>(null);
   const { toast } = useToast();
-  const tasksQuery = useTasksQuery({ pageSize: 100 });
-  const availableTags = sanitizeTags(tasksQuery.tasks.flatMap((task) => task.tags));
+  const tagsQuery = useTagsQuery();
+  const availableTags = sanitizeTags(tagsQuery.tags.map((tag) => tag.label));
 
   const handleDocumentClick = useCallback(
     (event: MouseEvent) => {

--- a/apps/web/components/tasks/task-dialog-host.tsx
+++ b/apps/web/components/tasks/task-dialog-host.tsx
@@ -3,6 +3,8 @@
 import { useCallback, useEffect, useState } from 'react';
 
 import { useToast } from '@/components/ui/use-toast';
+import { sanitizeTags } from '@/lib/task-tags';
+import { useTasksQuery } from '@/lib/tasks-hooks';
 
 import { TaskCreateDialog } from './task-create-dialog';
 import { TaskEditDialog } from './task-edit-dialog';
@@ -12,6 +14,8 @@ type ActiveDialog = { type: 'create' } | { type: 'edit'; taskId: string } | null
 export function TaskDialogHost() {
   const [activeDialog, setActiveDialog] = useState<ActiveDialog>(null);
   const { toast } = useToast();
+  const tasksQuery = useTasksQuery({ pageSize: 100 });
+  const availableTags = sanitizeTags(tasksQuery.tasks.flatMap((task) => task.tags));
 
   const handleDocumentClick = useCallback(
     (event: MouseEvent) => {
@@ -68,12 +72,18 @@ export function TaskDialogHost() {
 
   return (
     <>
-      <TaskCreateDialog open={activeDialog?.type === 'create'} onOpenChange={handleCreateOpenChange} trigger={null} />
+      <TaskCreateDialog
+        open={activeDialog?.type === 'create'}
+        onOpenChange={handleCreateOpenChange}
+        trigger={null}
+        availableTags={availableTags}
+      />
       <TaskEditDialog
         taskId={activeTaskId}
         open={activeDialog?.type === 'edit'}
         onOpenChange={handleEditOpenChange}
         onTaskIdChange={handleEditTaskIdChange}
+        availableTags={availableTags}
       />
     </>
   );

--- a/apps/web/components/tasks/task-tag-selector.tsx
+++ b/apps/web/components/tasks/task-tag-selector.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState, type ComponentPropsWithoutRef } from 'react';
+import { useEffect, useMemo, useState, type ComponentPropsWithoutRef, type KeyboardEvent } from 'react';
 import { useCommandState } from 'cmdk';
 import { Filter, Tag, X } from 'lucide-react';
 
@@ -112,6 +112,15 @@ export function TaskTagSelector({
     onChange(value.filter((existing) => existing.toLowerCase() !== key));
   }
 
+  function handleInputKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+    if (event.key !== 'Backspace' || inputValue.length > 0 || value.length === 0) {
+      return;
+    }
+
+    event.preventDefault();
+    onChange(value.slice(0, -1));
+  }
+
   function isTagSelected(tag: string) {
     return normalizedSelected.includes(tag.toLowerCase());
   }
@@ -150,6 +159,7 @@ export function TaskTagSelector({
               placeholder="Search or create tags"
               aria-label="Search available tags"
               onCreate={handleCreateTag}
+              onKeyDown={handleInputKeyDown}
             />
             <CommandList>
               <CommandEmpty>

--- a/apps/web/components/tasks/task-tag-selector.tsx
+++ b/apps/web/components/tasks/task-tag-selector.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState, type ComponentPropsWithoutRef } from 'react';
+import { useEffect, useMemo, useState, type ComponentPropsWithoutRef } from 'react';
 import { useCommandState } from 'cmdk';
 import { Filter, Tag, X } from 'lucide-react';
 
@@ -62,9 +62,26 @@ export function TaskTagSelector({
 }: TaskTagSelectorProps) {
   const [open, setOpen] = useState(false);
   const [inputValue, setInputValue] = useState('');
+  const [debouncedInput, setDebouncedInput] = useState('');
 
   const normalizedSelected = useMemo(() => value.map((tag) => tag.toLowerCase()), [value]);
   const options = useMemo(() => sanitizeTags([...availableTags, ...value]), [availableTags, value]);
+  const filteredOptions = useMemo(() => {
+    if (!debouncedInput.trim()) {
+      return options;
+    }
+
+    const search = debouncedInput.trim().toLowerCase();
+    return options.filter((tag) => tag.toLowerCase().includes(search));
+  }, [debouncedInput, options]);
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      setDebouncedInput(inputValue);
+    }, 180);
+
+    return () => window.clearTimeout(timeout);
+  }, [inputValue]);
 
   const buttonLabel =
     value.length > 0 ? `${value.length} tag${value.length === 1 ? '' : 's'} selected` : placeholder;
@@ -146,7 +163,7 @@ export function TaskTagSelector({
                 </div>
               </CommandEmpty>
               <CommandGroup heading="Tags">
-                {options.map((tag) => (
+                {filteredOptions.map((tag) => (
                   <CommandItem key={tag} value={tag} onSelect={(value) => toggleTag(value)} aria-checked={isTagSelected(tag)}>
                     <span className="flex-1 text-sm capitalize">{tag}</span>
                     {isTagSelected(tag) ? <span className="text-xs text-primary">Selected</span> : null}

--- a/apps/web/components/tasks/task-tag-selector.tsx
+++ b/apps/web/components/tasks/task-tag-selector.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useEffect, useMemo, useState, type ComponentPropsWithoutRef, type KeyboardEvent } from 'react';
-import { useCommandState } from 'cmdk';
 import { Filter, Tag, X } from 'lucide-react';
 
 import { Badge } from '@/components/ui/badge';
@@ -25,25 +24,22 @@ interface CommandInputWithCreateProps
   extends Omit<CommandInputProps, 'value' | 'onValueChange' | 'onKeyDown'> {
   value: string;
   onValueChange: (value: string) => void;
+  canCreate: boolean;
   onCreate: () => void;
   onKeyDown?: CommandInputProps['onKeyDown'];
 }
 
-function CommandInputWithCreate({ value, onValueChange, onCreate, onKeyDown, ...props }: CommandInputWithCreateProps) {
-  const filteredItemCount = useCommandState((state) => state.filtered.count);
-
+function CommandInputWithCreate({ value, onValueChange, canCreate, onCreate, onKeyDown, ...props }: CommandInputWithCreateProps) {
   return (
     <CommandInput
       {...props}
       value={value}
       onValueChange={onValueChange}
       onKeyDown={(event) => {
-        if (event.key === 'Enter' && value.trim()) {
-          if (filteredItemCount === 0) {
-            event.preventDefault();
-            onCreate();
-            return;
-          }
+        if (event.key === 'Enter' && canCreate) {
+          event.preventDefault();
+          onCreate();
+          return;
         }
 
         onKeyDown?.(event);
@@ -74,6 +70,14 @@ export function TaskTagSelector({
     const search = debouncedInput.trim().toLowerCase();
     return options.filter((tag) => tag.toLowerCase().includes(search));
   }, [debouncedInput, options]);
+  const canCreateTag = useMemo(() => {
+    const search = inputValue.trim().toLowerCase();
+    if (!search) {
+      return false;
+    }
+
+    return !options.some((tag) => tag.toLowerCase().includes(search));
+  }, [inputValue, options]);
 
   useEffect(() => {
     const timeout = window.setTimeout(() => {
@@ -103,6 +107,10 @@ export function TaskTagSelector({
   }
 
   function handleCreateTag() {
+    if (!canCreateTag) {
+      return;
+    }
+
     toggleTag(inputValue);
     setOpen(false);
   }
@@ -158,6 +166,7 @@ export function TaskTagSelector({
               onValueChange={setInputValue}
               placeholder="Search or create tags"
               aria-label="Search available tags"
+              canCreate={canCreateTag}
               onCreate={handleCreateTag}
               onKeyDown={handleInputKeyDown}
             />
@@ -165,7 +174,7 @@ export function TaskTagSelector({
               <CommandEmpty>
                 <div className="space-y-2">
                   <p>No tags found.</p>
-                  {inputValue.trim() ? (
+                  {canCreateTag ? (
                     <Button variant="secondary" size="sm" className="w-full" type="button" onClick={handleCreateTag}>
                       Create “{inputValue.trim()}”
                     </Button>

--- a/apps/web/lib/tasks-client.test.ts
+++ b/apps/web/lib/tasks-client.test.ts
@@ -6,6 +6,8 @@ import {
   createTask,
   deleteTask,
   getTask,
+  getTaskBoard,
+  listTags,
   listTasks,
   setBrowserTaskClientAuthState,
   TaskClientError,
@@ -204,6 +206,49 @@ describe('tasks-client', () => {
       expect(fetchMock).toHaveBeenCalledTimes(1);
       const [url, init] = fetchMock.mock.calls[0];
       expect(url).toBe(`${API_BASE_URL}/v1/tasks/${sampleTask.id}`);
+      expect((init as RequestInit)?.method).toBe('GET');
+    });
+  });
+
+  describe('getTaskBoard', () => {
+    it('serializes repeated tag filters', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        jsonResponse({
+          columns: [],
+          summary: {
+            totalsByStatus: { TODO: 0, IN_PROGRESS: 0, DONE: 0 },
+            overdueByStatus: { TODO: 0, IN_PROGRESS: 0, DONE: 0 },
+            totalTasks: 0,
+            totalOverdue: 0,
+          },
+          updatedAt: '2024-06-01T00:00:00.000Z',
+          generatedAt: '2024-06-01T00:00:00.000Z',
+        }),
+      );
+
+      await getTaskBoard(
+        { tag: ['frontend', 'api'] },
+        { baseUrl: API_BASE_URL, fetchImpl: fetchMock },
+      );
+
+      const [url] = fetchMock.mock.calls[0];
+      const parsedUrl = new URL(url as string);
+      expect(parsedUrl.pathname).toBe('/api/taskforge/v1/tasks/board');
+      expect(parsedUrl.searchParams.getAll('tag')).toEqual(['frontend', 'api']);
+    });
+  });
+
+  describe('listTags', () => {
+    it('requests tag summaries from the tags endpoint', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        jsonResponse({ items: [{ label: 'api', count: 2 }] }),
+      );
+
+      const result = await listTags({ baseUrl: API_BASE_URL, fetchImpl: fetchMock });
+
+      expect(result).toEqual({ items: [{ label: 'api', count: 2 }] });
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe(`${API_BASE_URL}/v1/tags`);
       expect((init as RequestInit)?.method).toBe('GET');
     });
   });

--- a/apps/web/lib/tasks-client.ts
+++ b/apps/web/lib/tasks-client.ts
@@ -3,6 +3,8 @@ import {
   type BoardReadModelDTO,
   type TaskBoardItemDTO,
   type TaskDTO,
+  type TagDTO,
+  type TagListItemDTO,
   type TaskRecordDTO,
   type TaskPriority,
   type TaskStatus,
@@ -84,6 +86,16 @@ const TagSummarySchema = z.object({
   count: z.number().int().min(0),
 });
 
+const TagRecordSchema = z.object({
+  id: z.string().uuid(),
+  label: NonEmptyTrimmedString,
+}) as z.ZodType<TagDTO>;
+
+const TagListItemSchema = z.object({
+  label: NonEmptyTrimmedString,
+  count: z.number().int().min(0),
+}) as z.ZodType<TagListItemDTO>;
+
 const BoardColumnSchema = z.object({
   status: TaskStatusSchema,
   title: NonEmptyTrimmedString,
@@ -127,6 +139,10 @@ const TaskListResponseSchema = z.object({
   page: z.number().int().min(1),
   pageSize: z.number().int().min(1).max(100),
   total: z.number().int().min(0),
+});
+
+const TagListResponseSchema = z.object({
+  items: z.array(TagListItemSchema),
 });
 
 const TaskDeleteResponseSchema = z.object({
@@ -211,10 +227,25 @@ const TaskListQuerySchema = z
     }
   });
 
+const BoardQuerySchema = z
+  .object({
+    tag: z
+      .union([NonEmptyTrimmedString, z.array(NonEmptyTrimmedString)])
+      .optional()
+      .transform((value) => {
+        if (!value) {
+          return undefined;
+        }
+        return Array.isArray(value) ? value : [value];
+      }),
+  });
+
 export type TaskListResponse = z.infer<typeof TaskListResponseSchema>;
 export type TaskDeleteResponse = z.infer<typeof TaskDeleteResponseSchema>;
 export type TaskBoardResponse = z.infer<typeof BoardResponseSchema>;
 export type BoardMoveInput = z.infer<typeof BoardMoveSchema>;
+export type TagListResponse = z.infer<typeof TagListResponseSchema>;
+export type TagRecord = z.infer<typeof TagRecordSchema>;
 
 export type CreateTaskInput = Omit<TaskDTO, 'id'>;
 export type UpdateTaskInput = Partial<Omit<TaskDTO, 'id'>>;
@@ -229,7 +260,12 @@ export type TaskListQuery = {
   dueTo?: string;
 };
 
+export type TaskBoardQuery = {
+  tag?: string | string[];
+};
+
 type NormalizedTaskListQuery = z.infer<typeof TaskListQuerySchema>;
+type NormalizedTaskBoardQuery = z.infer<typeof BoardQuerySchema>;
 
 export type TaskClientErrorKind = 'validation' | 'http' | 'network' | 'serialization';
 
@@ -675,12 +711,39 @@ export async function getTask(
   );
 }
 
-export async function getTaskBoard(options?: TaskClientRequestOptions): Promise<BoardReadModelDTO> {
+export async function getTaskBoard(
+  params?: TaskBoardQuery,
+  options?: TaskClientRequestOptions,
+): Promise<BoardReadModelDTO> {
+  let normalizedQuery: NormalizedTaskBoardQuery | undefined;
+  if (params) {
+    const parsed = BoardQuerySchema.safeParse(params);
+    if (!parsed.success) {
+      throw new TaskClientError('Board filters were invalid.', {
+        kind: 'validation',
+        issues: parsed.error.issues,
+      });
+    }
+    normalizedQuery = parsed.data;
+  }
+
   return requestJson(
     'v1/tasks/board',
     {
       method: 'GET',
+      query: toQueryRecord(normalizedQuery),
       schema: BoardResponseSchema,
+    },
+    options,
+  );
+}
+
+export async function listTags(options?: TaskClientRequestOptions): Promise<TagListResponse> {
+  return requestJson(
+    'v1/tags',
+    {
+      method: 'GET',
+      schema: TagListResponseSchema,
     },
     options,
   );

--- a/apps/web/lib/tasks-hooks.test.ts
+++ b/apps/web/lib/tasks-hooks.test.ts
@@ -187,6 +187,88 @@ describe('tasks-hooks board cache helpers', () => {
     });
   });
 
+  it('matches board tag filters case-insensitively during optimistic edits', () => {
+    const updated = __testing.applyTaskUpdateToBoard(
+      board,
+      '11111111-1111-4111-8111-111111111111',
+      {
+        title: 'Finalize contract',
+        updatedAt: '2024-06-15T12:00:00.000Z',
+      },
+      new Date('2024-06-15T00:00:00.000Z'),
+      { tag: ['API'] },
+    );
+
+    expect(updated.columns[0]).toMatchObject({
+      status: 'TODO',
+      total: 1,
+    });
+    expect(updated.columns[0].tasks[0]).toMatchObject({
+      id: '11111111-1111-4111-8111-111111111111',
+      title: 'Finalize contract',
+      tags: ['api'],
+    });
+  });
+
+  it('matches board tag filters case-insensitively when reconciling server tasks', () => {
+    const emptyBoard: TaskBoardResponse = {
+      ...board,
+      columns: board.columns.map((column) => ({
+        ...column,
+        tasks: [],
+        total: 0,
+        overdueCount: 0,
+        tags: [],
+      })),
+      summary: {
+        totalsByStatus: {
+          TODO: 0,
+          IN_PROGRESS: 0,
+          DONE: 0,
+        },
+        overdueByStatus: {
+          TODO: 0,
+          IN_PROGRESS: 0,
+          DONE: 0,
+        },
+        totalTasks: 0,
+        totalOverdue: 0,
+      },
+    };
+    const task: TaskListItem = {
+      id: '11111111-1111-4111-8111-111111111111',
+      title: 'Draft contract',
+      description: 'Matches a mixed-case URL tag filter',
+      status: 'TODO',
+      priority: 'HIGH',
+      dueDate: '2024-06-01T00:00:00.000Z',
+      tags: ['api'],
+      createdAt: '2024-05-01T00:00:00.000Z',
+      updatedAt: '2024-06-15T12:00:00.000Z',
+    };
+
+    const updated = __testing.reconcileTaskInBoard(
+      emptyBoard,
+      task,
+      { tag: ['API'] },
+      new Date('2024-06-15T00:00:00.000Z'),
+    );
+
+    expect(updated.columns[0].tasks).toEqual([
+      {
+        id: '11111111-1111-4111-8111-111111111111',
+        title: 'Draft contract',
+        status: 'TODO',
+        priority: 'HIGH',
+        position: 0,
+        dueDate: '2024-06-01T00:00:00.000Z',
+        tags: ['api'],
+        updatedAt: '2024-06-15T12:00:00.000Z',
+      },
+    ]);
+    expect(updated.summary.totalTasks).toBe(1);
+  });
+
   it('updates and restores every cached board variant under the board root', () => {
     const queryClient = new QueryClient();
     const userScope = 'user-123';

--- a/apps/web/lib/tasks-hooks.test.ts
+++ b/apps/web/lib/tasks-hooks.test.ts
@@ -152,6 +152,64 @@ describe('tasks-hooks board cache helpers', () => {
     expect(updated.generatedAt).toBe('2024-05-02T00:00:00.000Z');
   });
 
+  it('removes a task from a filtered board cache when an edit no longer matches', () => {
+    const updated = __testing.applyTaskUpdateToBoard(
+      board,
+      '11111111-1111-4111-8111-111111111111',
+      {
+        tags: ['docs'],
+        updatedAt: '2024-06-15T12:00:00.000Z',
+      },
+      new Date('2024-06-15T00:00:00.000Z'),
+      { tag: ['api'] },
+    );
+
+    expect(updated.columns[0]).toMatchObject({
+      status: 'TODO',
+      total: 0,
+      overdueCount: 0,
+      tags: [],
+      tasks: [],
+    });
+    expect(updated.summary).toEqual({
+      totalsByStatus: {
+        TODO: 0,
+        IN_PROGRESS: 0,
+        DONE: 1,
+      },
+      overdueByStatus: {
+        TODO: 0,
+        IN_PROGRESS: 0,
+        DONE: 0,
+      },
+      totalTasks: 1,
+      totalOverdue: 0,
+    });
+  });
+
+  it('updates and restores every cached board variant under the board root', () => {
+    const queryClient = new QueryClient();
+    const userScope = 'user-123';
+    const defaultBoardKey = __testing.taskQueryKeys.board(userScope);
+    const filteredBoardKey = __testing.taskQueryKeys.board(userScope, { tag: ['api'] });
+
+    queryClient.setQueryData(defaultBoardKey, board);
+    queryClient.setQueryData(filteredBoardKey, board);
+
+    const snapshots = __testing.collectBoardQueries(queryClient, userScope, (cachedBoard) =>
+      __testing.removeTaskFromBoard(cachedBoard, '11111111-1111-4111-8111-111111111111'),
+    );
+
+    expect(snapshots).toHaveLength(2);
+    expect(queryClient.getQueryData<TaskBoardResponse>(defaultBoardKey)?.summary.totalTasks).toBe(1);
+    expect(queryClient.getQueryData<TaskBoardResponse>(filteredBoardKey)?.summary.totalTasks).toBe(1);
+
+    __testing.restoreBoardSnapshots(queryClient, snapshots);
+
+    expect(queryClient.getQueryData(defaultBoardKey)).toEqual(board);
+    expect(queryClient.getQueryData(filteredBoardKey)).toEqual(board);
+  });
+
   it('inserts a moved task into matching cached lists when it was not already present', () => {
     const list: TaskListData = {
       items: [

--- a/apps/web/lib/tasks-hooks.ts
+++ b/apps/web/lib/tasks-hooks.ts
@@ -82,15 +82,8 @@ type TagQueryResult = UseQueryResult<TagListResponse, TaskClientError>;
 interface InternalTaskMutationContext {
   touchedQueries: Array<[QueryKey, TaskListData | undefined]>;
   optimisticTaskId?: string;
-  boardSnapshot?: TaskBoardResponse;
-  boardRollback?: BoardMoveRollback;
+  boardSnapshots?: Array<[QueryKey, TaskBoardResponse | undefined]>;
   taskSnapshot?: TaskListItem | null;
-}
-
-interface BoardMoveRollback {
-  taskId: string;
-  sourceStatus: TaskStatus;
-  sourceIndex: number;
 }
 
 type TaskMutationContext<TContext extends object = object> =
@@ -307,6 +300,24 @@ function extractFiltersFromKey(queryKey: QueryKey): NormalizedTaskListFilters | 
     }
 
     return maybeFilters as NormalizedTaskListFilters;
+  }
+
+  return undefined;
+}
+
+function extractBoardFiltersFromKey(queryKey: QueryKey): NormalizedTaskBoardFilters | undefined {
+  if (!Array.isArray(queryKey) || queryKey.length < 4) {
+    return undefined;
+  }
+
+  const maybeFilters = queryKey[3];
+  if (maybeFilters && typeof maybeFilters === 'object') {
+    const entries = Object.entries(maybeFilters as Record<string, unknown>).filter(([, value]) => value !== undefined);
+    if (entries.length === 0) {
+      return undefined;
+    }
+
+    return maybeFilters as NormalizedTaskBoardFilters;
   }
 
   return undefined;
@@ -564,11 +575,39 @@ function buildBoardSummary(columns: TaskBoardResponse['columns']): TaskBoardResp
   };
 }
 
+function boardTaskMatchesFilters(
+  task: Pick<TaskListItem, 'tags'>,
+  filters: NormalizedTaskBoardFilters | undefined,
+): boolean {
+  if (!filters?.tag?.length) {
+    return true;
+  }
+
+  return filters.tag.every((tag) => task.tags.includes(tag));
+}
+
+function taskBoardItemFromTask(
+  task: TaskListItem,
+  position: number,
+): TaskBoardResponse['columns'][number]['tasks'][number] {
+  return {
+    id: task.id,
+    title: task.title,
+    status: task.status,
+    priority: task.priority,
+    position,
+    dueDate: task.dueDate,
+    tags: [...task.tags],
+    updatedAt: task.updatedAt,
+  };
+}
+
 function applyTaskUpdateToBoard(
   board: TaskBoardResponse,
   taskId: string,
   patch: Partial<TaskListItem>,
   now: Date = new Date(),
+  filters?: NormalizedTaskBoardFilters,
 ): TaskBoardResponse {
   const columns = board.columns.map((column) => ({
     ...column,
@@ -597,15 +636,17 @@ function applyTaskUpdateToBoard(
 
   sourceColumn.tasks.splice(sourceIndex, 1);
 
-  if (nextStatus === sourceColumn.status) {
-    sourceColumn.tasks.splice(sourceIndex, 0, updatedTask);
-  } else {
-    const targetColumn = columns.find((column) => column.status === nextStatus);
-    if (!targetColumn) {
-      return board;
-    }
+  if (boardTaskMatchesFilters(updatedTask, filters)) {
+    if (nextStatus === sourceColumn.status) {
+      sourceColumn.tasks.splice(sourceIndex, 0, updatedTask);
+    } else {
+      const targetColumn = columns.find((column) => column.status === nextStatus);
+      if (!targetColumn) {
+        return board;
+      }
 
-    targetColumn.tasks.push(updatedTask);
+      targetColumn.tasks.push(updatedTask);
+    }
   }
 
   const nextColumns = rebuildBoardColumns(columns, now);
@@ -614,6 +655,64 @@ function applyTaskUpdateToBoard(
     columns: nextColumns,
     summary: buildBoardSummary(nextColumns),
     updatedAt: patch.updatedAt ?? now.toISOString(),
+  };
+}
+
+function reconcileTaskInBoard(
+  board: TaskBoardResponse,
+  task: TaskListItem,
+  filters?: NormalizedTaskBoardFilters,
+  now: Date = new Date(),
+): TaskBoardResponse {
+  const columns = board.columns.map((column) => ({
+    ...column,
+    tasks: column.tasks.map((boardTask) => ({ ...boardTask })),
+  }));
+  const sourceColumn = columns.find((column) => column.tasks.some((boardTask) => boardTask.id === task.id));
+  const sourceIndex = sourceColumn
+    ? sourceColumn.tasks.findIndex((boardTask) => boardTask.id === task.id)
+    : -1;
+  const matchesFilters = boardTaskMatchesFilters(task, filters);
+
+  if (sourceColumn && sourceIndex !== -1) {
+    sourceColumn.tasks.splice(sourceIndex, 1);
+  }
+
+  if (!matchesFilters) {
+    if (!sourceColumn) {
+      return board;
+    }
+
+    const nextColumns = rebuildBoardColumns(columns, now);
+    return {
+      ...board,
+      columns: nextColumns,
+      summary: buildBoardSummary(nextColumns),
+      updatedAt: task.updatedAt,
+    };
+  }
+
+  const targetColumn = columns.find((column) => column.status === task.status);
+  if (!targetColumn) {
+    return board;
+  }
+
+  const insertIndex =
+    sourceColumn?.status === task.status && sourceIndex >= 0
+      ? sourceIndex
+      : targetColumn.tasks.length;
+  targetColumn.tasks.splice(
+    insertIndex,
+    0,
+    taskBoardItemFromTask(task, insertIndex),
+  );
+
+  const nextColumns = rebuildBoardColumns(columns, now);
+  return {
+    ...board,
+    columns: nextColumns,
+    summary: buildBoardSummary(nextColumns),
+    updatedAt: task.updatedAt,
   };
 }
 
@@ -674,21 +773,6 @@ function normalizeTaskBoardFilters(filters?: TaskBoardQuery): NormalizedTaskBoar
   return Object.keys(normalized).length ? normalized : undefined;
 }
 
-function getBoardMoveRollback(board: TaskBoardResponse, taskId: string): BoardMoveRollback | undefined {
-  for (const column of board.columns) {
-    const sourceIndex = column.tasks.findIndex((task) => task.id === taskId);
-    if (sourceIndex !== -1) {
-      return {
-        taskId,
-        sourceStatus: column.status,
-        sourceIndex,
-      };
-    }
-  }
-
-  return undefined;
-}
-
 function applyOptimisticMoveToBoard(board: TaskBoardResponse, input: MoveTaskVariables): TaskBoardResponse {
   const columns = board.columns.map((column) => ({
     ...column,
@@ -716,47 +800,6 @@ function applyOptimisticMoveToBoard(board: TaskBoardResponse, input: MoveTaskVar
 
   const insertIndex = Math.max(0, Math.min(input.targetIndex, targetColumn.tasks.length));
   targetColumn.tasks.splice(insertIndex, 0, movedTask);
-  const now = new Date();
-  const nextColumns = rebuildBoardColumns(columns, now);
-
-  return {
-    ...board,
-    columns: nextColumns,
-    summary: buildBoardSummary(nextColumns),
-    updatedAt: now.toISOString(),
-  };
-}
-
-function rollbackOptimisticMoveOnBoard(
-  board: TaskBoardResponse,
-  rollback: BoardMoveRollback,
-): TaskBoardResponse {
-  const columns = board.columns.map((column) => ({
-    ...column,
-    tasks: column.tasks.map((task) => ({ ...task })),
-  }));
-  let movedTask: (typeof columns)[number]['tasks'][number] | null = null;
-
-  for (const column of columns) {
-    const index = column.tasks.findIndex((task) => task.id === rollback.taskId);
-    if (index !== -1) {
-      const [task] = column.tasks.splice(index, 1);
-      movedTask = { ...task, status: rollback.sourceStatus };
-      break;
-    }
-  }
-
-  if (!movedTask) {
-    return board;
-  }
-
-  const sourceColumn = columns.find((column) => column.status === rollback.sourceStatus);
-  if (!sourceColumn) {
-    return board;
-  }
-
-  const insertIndex = Math.max(0, Math.min(rollback.sourceIndex, sourceColumn.tasks.length));
-  sourceColumn.tasks.splice(insertIndex, 0, movedTask);
   const now = new Date();
   const nextColumns = rebuildBoardColumns(columns, now);
 
@@ -1136,6 +1179,43 @@ function collectMatchingQueries(
   return touched;
 }
 
+function collectBoardQueries(
+  queryClient: QueryClient,
+  userScope: string,
+  predicate: (
+    board: TaskBoardResponse,
+    filters: NormalizedTaskBoardFilters | undefined,
+  ) => TaskBoardResponse,
+): Array<[QueryKey, TaskBoardResponse | undefined]> {
+  const candidates = queryClient.getQueriesData<TaskBoardResponse>({ queryKey: taskQueryKeys.boardRoot(userScope) });
+  const touched: Array<[QueryKey, TaskBoardResponse | undefined]> = [];
+
+  for (const [key, data] of candidates) {
+    if (!data) {
+      continue;
+    }
+
+    const filters = extractBoardFiltersFromKey(key);
+    const next = predicate(data, filters);
+
+    if (next !== data) {
+      touched.push([key, data]);
+      queryClient.setQueryData(key, next);
+    }
+  }
+
+  return touched;
+}
+
+function restoreBoardSnapshots(
+  queryClient: QueryClient,
+  snapshots: Array<[QueryKey, TaskBoardResponse | undefined]> | undefined,
+): void {
+  for (const [key, snapshot] of snapshots ?? []) {
+    queryClient.setQueryData(key, snapshot);
+  }
+}
+
 function selectTaskFromCache(
   queryClient: QueryClient,
   userScope: string,
@@ -1357,6 +1437,7 @@ export function useUpdateTask(
     onMutate: async ({ id, input }) => {
       await queryClient.cancelQueries({ queryKey: taskQueryKeys.all(userScope) });
       const optimisticUpdatedAt = new Date().toISOString();
+      const taskSnapshot = selectTaskFromCache(queryClient, userScope, id);
 
       const touchedQueries = collectMatchingQueries(queryClient, userScope, (payload) => {
         const existing = payload.items.find((item) => item.id === id);
@@ -1371,20 +1452,20 @@ export function useUpdateTask(
         });
       });
 
-      const boardKey = taskQueryKeys.board(userScope);
-      const boardSnapshot = queryClient.getQueryData<TaskBoardResponse>(boardKey);
-
-      if (boardSnapshot) {
-        queryClient.setQueryData<TaskBoardResponse>(
-          boardKey,
-          applyTaskUpdateToBoard(boardSnapshot, id, {
+      const boardSnapshots = collectBoardQueries(queryClient, userScope, (board, filters) =>
+        applyTaskUpdateToBoard(
+          board,
+          id,
+          {
             ...input,
             updatedAt: optimisticUpdatedAt,
-          }),
-        );
-      }
+          },
+          new Date(optimisticUpdatedAt),
+          filters,
+        ),
+      );
 
-      return { touchedQueries, optimisticTaskId: id, boardSnapshot } satisfies TaskMutationContext;
+      return { touchedQueries, optimisticTaskId: id, boardSnapshots, taskSnapshot } satisfies TaskMutationContext;
     },
     onError: (error, variables, context, mutationContext) => {
       if (context) {
@@ -1392,9 +1473,7 @@ export function useUpdateTask(
           queryClient.setQueryData(key, snapshot);
         }
 
-        if (context.boardSnapshot) {
-          queryClient.setQueryData(taskQueryKeys.board(userScope), context.boardSnapshot);
-        }
+        restoreBoardSnapshots(queryClient, context.boardSnapshots);
       }
 
       onError?.(error, variables, context, mutationContext);
@@ -1410,8 +1489,8 @@ export function useUpdateTask(
         return replaceTaskInList(payload, context?.optimisticTaskId ?? variables.id, taskItem);
       });
 
-      queryClient.setQueryData<TaskBoardResponse | undefined>(taskQueryKeys.board(userScope), (board) =>
-        board ? applyTaskUpdateToBoard(board, variables.id, taskItem) : board,
+      collectBoardQueries(queryClient, userScope, (board, filters) =>
+        reconcileTaskInBoard(board, taskItem, filters),
       );
 
       onSuccess?.(result, variables, context, mutationContext);
@@ -1483,18 +1562,14 @@ export function useMoveTaskOnBoard<TContext extends object = Record<string, neve
         return reconcileTaskInList(payload, movedTask, filters, taskId);
       });
 
-      const boardKey = taskQueryKeys.board(userScope);
-      const boardSnapshot = queryClient.getQueryData<TaskBoardResponse>(boardKey);
-      const boardRollback = boardSnapshot ? getBoardMoveRollback(boardSnapshot, taskId) : undefined;
-      if (boardSnapshot) {
-        queryClient.setQueryData<TaskBoardResponse>(boardKey, applyOptimisticMoveToBoard(boardSnapshot, variables));
-      }
+      const boardSnapshots = collectBoardQueries(queryClient, userScope, (board) =>
+        applyOptimisticMoveToBoard(board, variables),
+      );
 
       const internalContext = {
         touchedQueries,
         optimisticTaskId: taskId,
-        boardSnapshot,
-        boardRollback,
+        boardSnapshots,
         taskSnapshot,
       } satisfies InternalTaskMutationContext;
       const externalContext = await onMutate?.(variables, mutationContext);
@@ -1506,14 +1581,7 @@ export function useMoveTaskOnBoard<TContext extends object = Record<string, neve
           queryClient.setQueryData(key, snapshot);
         }
 
-        const boardRollback = context.boardRollback;
-        if (boardRollback) {
-          queryClient.setQueryData<TaskBoardResponse | undefined>(taskQueryKeys.board(userScope), (board) =>
-            board ? rollbackOptimisticMoveOnBoard(board, boardRollback) : board,
-          );
-        } else if (context.boardSnapshot) {
-          queryClient.setQueryData(taskQueryKeys.board(userScope), context.boardSnapshot);
-        }
+        restoreBoardSnapshots(queryClient, context.boardSnapshots);
       }
 
       onError?.(error, variables, context, mutationContext);
@@ -1618,14 +1686,11 @@ export function useDeleteTask(
         removeTaskFromList(payload, id),
       );
 
-      const boardKey = taskQueryKeys.board(userScope);
-      const boardSnapshot = queryClient.getQueryData<TaskBoardResponse>(boardKey);
+      const boardSnapshots = collectBoardQueries(queryClient, userScope, (board) =>
+        removeTaskFromBoard(board, id),
+      );
 
-      if (boardSnapshot) {
-        queryClient.setQueryData<TaskBoardResponse>(boardKey, removeTaskFromBoard(boardSnapshot, id));
-      }
-
-      return { touchedQueries, optimisticTaskId: id, boardSnapshot } satisfies TaskMutationContext;
+      return { touchedQueries, optimisticTaskId: id, boardSnapshots } satisfies TaskMutationContext;
     },
     onError: (error, variables, context, mutationContext) => {
       if (context) {
@@ -1633,9 +1698,7 @@ export function useDeleteTask(
           queryClient.setQueryData(key, snapshot);
         }
 
-        if (context.boardSnapshot) {
-          queryClient.setQueryData(taskQueryKeys.board(userScope), context.boardSnapshot);
-        }
+        restoreBoardSnapshots(queryClient, context.boardSnapshots);
       }
 
       onError?.(error, variables, context, mutationContext);
@@ -1682,8 +1745,11 @@ export const __testing = {
   selectTaskFromCache,
   mergeMutationContext,
   applyTaskUpdateToBoard,
+  reconcileTaskInBoard,
   applyOptimisticMoveToBoard,
   removeTaskFromList,
   removeTaskFromBoard,
+  collectBoardQueries,
+  restoreBoardSnapshots,
   taskQueryKeys,
 };

--- a/apps/web/lib/tasks-hooks.ts
+++ b/apps/web/lib/tasks-hooks.ts
@@ -583,7 +583,14 @@ function boardTaskMatchesFilters(
     return true;
   }
 
-  return filters.tag.every((tag) => task.tags.includes(tag));
+  const taskTags = new Set(task.tags.map((tag) => tag.trim().toLowerCase()).filter(Boolean));
+  const filterTags = filters.tag.map((tag) => tag.trim().toLowerCase()).filter(Boolean);
+
+  if (filterTags.length === 0) {
+    return true;
+  }
+
+  return filterTags.every((tag) => taskTags.has(tag));
 }
 
 function taskBoardItemFromTask(

--- a/apps/web/lib/tasks-hooks.ts
+++ b/apps/web/lib/tasks-hooks.ts
@@ -19,6 +19,7 @@ import {
   deleteTask,
   getTask,
   listTasks,
+  listTags,
   getTaskBoard,
   moveTaskOnBoard,
   updateTask,
@@ -31,7 +32,9 @@ import type {
   TaskDeleteResponse,
   TaskListQuery,
   TaskListResponse,
+  TaskBoardQuery,
   TaskBoardResponse,
+  TagListResponse,
   TaskRecordDTO,
   UpdateTaskInput,
 } from './tasks-client';
@@ -49,6 +52,7 @@ type TaskQueryFnData = TaskListData;
 type TaskQueryKey = ReturnType<typeof taskQueryKeys.list>;
 type TaskBoardQueryKey = ReturnType<typeof taskQueryKeys.board>;
 type TaskDetailQueryKey = ReturnType<typeof taskQueryKeys.detail>;
+type TagQueryKey = ReturnType<typeof taskQueryKeys.tags>;
 
 type TaskQueryOptions = Omit<
   UseQueryOptions<TaskQueryFnData, TaskClientError, TaskQueryFnData, TaskQueryKey>,
@@ -65,9 +69,15 @@ type TaskDetailQueryOptions = Omit<
   'queryKey' | 'queryFn'
 >;
 
+type TagQueryOptions = Omit<
+  UseQueryOptions<TagListResponse, TaskClientError, TagListResponse, TagQueryKey>,
+  'queryKey' | 'queryFn'
+>;
+
 type TaskListQueryResult = UseQueryResult<TaskQueryFnData, TaskClientError>;
 type TaskBoardQueryResult = UseQueryResult<TaskBoardResponse, TaskClientError>;
 type TaskDetailQueryResult = UseQueryResult<TaskListItem, TaskClientError>;
+type TagQueryResult = UseQueryResult<TagListResponse, TaskClientError>;
 
 interface InternalTaskMutationContext {
   touchedQueries: Array<[QueryKey, TaskListData | undefined]>;
@@ -125,6 +135,21 @@ export interface UseTaskBoardQueryResult {
   rawError: unknown;
 }
 
+export interface UseTagsQueryResult {
+  data: TagListResponse | undefined;
+  tags: TagListResponse['items'];
+  isLoading: boolean;
+  isFetching: boolean;
+  isError: boolean;
+  isSuccess: boolean;
+  status: TagQueryResult['status'];
+  fetchStatus: TagQueryResult['fetchStatus'];
+  refetch: TagQueryResult['refetch'];
+  queryKey: TagQueryKey;
+  error: TaskOperationError | null;
+  rawError: unknown;
+}
+
 export interface UseTaskRecordQueryResult {
   data: TaskListItem | undefined;
   isLoading: boolean;
@@ -167,6 +192,10 @@ interface NormalizedTaskListFilters {
   dueTo?: string;
 }
 
+interface NormalizedTaskBoardFilters {
+  tag?: string[];
+}
+
 const TASK_QUERY_SCOPE = 'tasks';
 
 const FALLBACK_USER_KEY = 'anonymous';
@@ -176,8 +205,11 @@ const taskQueryKeys = {
   all: (userKey: string) => [TASK_QUERY_SCOPE, userKey] as const,
   list: (userKey: string, filters: NormalizedTaskListFilters | undefined) =>
     [...taskQueryKeys.all(userKey), 'list', filters ?? {}] as const,
-  board: (userKey: string) => [...taskQueryKeys.all(userKey), 'board'] as const,
+  boardRoot: (userKey: string) => [...taskQueryKeys.all(userKey), 'board'] as const,
+  board: (userKey: string, filters?: NormalizedTaskBoardFilters | undefined) =>
+    [...taskQueryKeys.boardRoot(userKey), filters ?? {}] as const,
   detail: (userKey: string, taskId: string) => [...taskQueryKeys.all(userKey), 'detail', taskId] as const,
+  tags: (userKey: string) => [...taskQueryKeys.all(userKey), 'tags'] as const,
 };
 
 const OPTIMISTIC_ID_MAP_SCOPE = 'task-optimistic-map';
@@ -624,6 +656,24 @@ function removeTaskFromBoard(board: TaskBoardResponse, taskId: string): TaskBoar
   };
 }
 
+function normalizeTaskBoardFilters(filters?: TaskBoardQuery): NormalizedTaskBoardFilters | undefined {
+  if (!filters) {
+    return undefined;
+  }
+
+  const normalized: NormalizedTaskBoardFilters = {};
+
+  if (filters.tag) {
+    const tags = Array.isArray(filters.tag) ? filters.tag : [filters.tag];
+    const normalizedTags = Array.from(new Set(tags.map((tag) => tag.trim()).filter(Boolean))).sort();
+    if (normalizedTags.length > 0) {
+      normalized.tag = normalizedTags;
+    }
+  }
+
+  return Object.keys(normalized).length ? normalized : undefined;
+}
+
 function getBoardMoveRollback(board: TaskBoardResponse, taskId: string): BoardMoveRollback | undefined {
   for (const column of board.columns) {
     const sourceIndex = column.tasks.findIndex((task) => task.id === taskId);
@@ -851,13 +901,26 @@ export function useTasksQuery(filters?: TaskListQuery, options?: TaskQueryOption
   };
 }
 
-export function useTaskBoardQuery(options?: TaskBoardQueryOptions): UseTaskBoardQueryResult {
+export function useTaskBoardQuery(filters?: TaskBoardQuery, options?: TaskBoardQueryOptions): UseTaskBoardQueryResult {
   const { user, status } = useAuth();
   const queryClient = useQueryClient();
   const previousUserIdRef = useRef<string | null>(null);
+  const filtersSignature = useMemo(() => stableSerialize(filters), [filters]);
+  const normalizedHash = useMemo(() => {
+    const parsedFilters = deserializeFilters(filtersSignature);
+    const normalized = normalizeTaskBoardFilters(parsedFilters);
+    return stableSerialize(normalized);
+  }, [filtersSignature]);
 
   const userScope = scopedQueryKey(user?.id);
-  const queryKey = useMemo(() => taskQueryKeys.board(userScope), [userScope]);
+  const normalizedFilters = useMemo(
+    () => deserializeNormalizedFilters(normalizedHash) as NormalizedTaskBoardFilters | undefined,
+    [normalizedHash],
+  );
+  const queryKey = useMemo(
+    () => taskQueryKeys.board(userScope, normalizedFilters),
+    [userScope, normalizedFilters],
+  );
 
   useEffect(() => {
     if (status !== 'authenticated') {
@@ -883,7 +946,7 @@ export function useTaskBoardQuery(options?: TaskBoardQueryOptions): UseTaskBoard
 
   const query = useQuery({
     queryKey,
-    queryFn: () => getTaskBoard(),
+    queryFn: () => getTaskBoard(normalizedFilters),
     staleTime: 15_000,
     gcTime: 5 * 60_000,
     enabled: effectiveEnabled,
@@ -894,6 +957,63 @@ export function useTaskBoardQuery(options?: TaskBoardQueryOptions): UseTaskBoard
 
   return {
     data: query.data,
+    isLoading: shouldDelayForAuth || query.isLoading,
+    isFetching: shouldDelayForAuth || query.isFetching,
+    isError: query.isError,
+    isSuccess: query.isSuccess,
+    status: query.status,
+    fetchStatus: query.fetchStatus,
+    refetch: query.refetch,
+    queryKey,
+    error: friendlyError,
+    rawError: query.error,
+  };
+}
+
+export function useTagsQuery(options?: TagQueryOptions): UseTagsQueryResult {
+  const { user, status } = useAuth();
+  const queryClient = useQueryClient();
+  const previousUserIdRef = useRef<string | null>(null);
+
+  const userScope = scopedQueryKey(user?.id);
+  const queryKey = useMemo(() => taskQueryKeys.tags(userScope), [userScope]);
+
+  useEffect(() => {
+    if (status !== 'authenticated') {
+      queryClient.removeQueries({ queryKey: taskQueryKeys.all(FALLBACK_USER_KEY) });
+    }
+  }, [queryClient, status]);
+
+  useEffect(() => {
+    const previousUserId = previousUserIdRef.current;
+    const nextUserId = user?.id ?? null;
+
+    if (previousUserId && previousUserId !== nextUserId) {
+      queryClient.removeQueries({ queryKey: taskQueryKeys.all(scopedQueryKey(previousUserId)) });
+    }
+
+    previousUserIdRef.current = nextUserId;
+  }, [queryClient, user?.id]);
+
+  const { enabled: optionsEnabled = true, ...queryOptions } = options ?? {};
+  const isAuthenticated = status === 'authenticated' && Boolean(user?.id);
+  const shouldDelayForAuth = optionsEnabled && status === 'loading';
+  const effectiveEnabled = isAuthenticated && optionsEnabled;
+
+  const query = useQuery({
+    queryKey,
+    queryFn: () => listTags(),
+    staleTime: 60_000,
+    gcTime: 5 * 60_000,
+    enabled: effectiveEnabled,
+    ...queryOptions,
+  });
+
+  const friendlyError = toTaskOperationError(query.error);
+
+  return {
+    data: query.data,
+    tags: query.data?.items ?? [],
     isLoading: shouldDelayForAuth || query.isLoading,
     isFetching: shouldDelayForAuth || query.isFetching,
     isError: query.isError,
@@ -1042,12 +1162,14 @@ function selectTaskFromCache(
     return detail;
   }
 
-  const board = queryClient.getQueryData<TaskBoardResponse>(taskQueryKeys.board(userScope));
-  const boardTask = board?.columns
-    .flatMap((column) => column.tasks)
-    .find((task) => task.id === taskId);
-  if (boardTask) {
-    return taskListItemFromBoardTask(boardTask);
+  const boards = queryClient.getQueriesData<TaskBoardResponse>({ queryKey: taskQueryKeys.boardRoot(userScope) });
+  for (const [, board] of boards) {
+    const boardTask = board?.columns
+      .flatMap((column) => column.tasks)
+      .find((task) => task.id === taskId);
+    if (boardTask) {
+      return taskListItemFromBoardTask(boardTask);
+    }
   }
 
   return null;
@@ -1445,7 +1567,7 @@ export function useMoveTaskOnBoard<TContext extends object = Record<string, neve
       }
 
       void queryClient.refetchQueries({
-        queryKey: taskQueryKeys.board(userScope),
+        queryKey: taskQueryKeys.boardRoot(userScope),
         type: 'active',
       });
       void queryClient.refetchQueries({

--- a/docs/tasks/milestone4/07-tag-management-ui.md
+++ b/docs/tasks/milestone4/07-tag-management-ui.md
@@ -4,13 +4,18 @@
 - Provide a lightweight UI to create/select tags while composing or editing tasks and to show them on Kanban cards.
 - Allow filtering by tag via chip toggles or multiselect near the board header.
 
-**Status:** New.
+**Status:** Done.
 
 ## Acceptance Criteria
-- [ ] Task dialogs (create/edit) let users attach/detach tags with debounced search + inline creation.
-- [ ] Kanban cards render tag pills with accessible color contrast and tooltips when truncated.
-- [ ] Filter controls update the board query parameters and trigger a refetch scoped to the selected tags.
+- [x] Task dialogs (create/edit) let users attach/detach tags with debounced search + inline creation.
+- [x] Kanban cards render tag pills with accessible color contrast and tooltips when truncated.
+- [x] Filter controls update the board query parameters and trigger a refetch scoped to the selected tags.
 
 ## Notes
 - Reuse shared form primitives and keep keyboard shortcuts (Enter to add tag, Backspace to remove) consistent.
 - Cache tag lists client-side to avoid re-fetching on every keystroke; expire the cache when a new tag is created.
+
+## Implementation Notes
+- The dashboard tag filter syncs selected `tag` query parameters to the URL and fetches `/api/taskforge/v1/tasks/board` with repeated `tag` params so the board payload, lane counts, and summary all reflect the selected tags.
+- Tag suggestions come from the Prisma-backed `/api/taskforge/v1/tags` endpoint and are cached through React Query. Selected URL tags are merged into the local options so deep links remain usable before suggestions load.
+- The shared task tag selector supports Enter for inline tag creation and Backspace on an empty input to remove the last selected tag.


### PR DESCRIPTION
### Motivation
- Surface task tags in the board UI and enable filtering the dashboard by tags to help scope work. 
- Provide a reusable tag selector that supports searching/creating tags to improve tag UX when creating/editing tasks. 
- Keep tag filters reflected in the URL so filtered views can be linked or bookmarked.

### Description
- Render task tags on the task card using `Badge` and use `sanitizeTags` to normalize tag lists. 
- Add `tagFilters` state to `DashboardContent`, wire it into `useTasksQuery` to fetch tasks scoped by tags, compute `availableTags` from tasks and selected filters, and sync `tag` params with the URL using `usePathname`, `useRouter`, and `useSearchParams`. 
- Introduce a `TaskTagSelector` control into the dashboard header to pick multiple tags and show the selected tags count, and pass `availableTags` into task create/edit dialogs via `TaskDialogHost`. 
- Improve `TaskTagSelector` with debounced input and client-side filtering (`filteredOptions`) and allow creating new tags from the input, while preserving accessibility and selection behavior.

### Testing
- No automated tests were added or executed as part of this change.
