### PR TITLE
milestone-4: board filters + search with URL-synced Kanban views

### DIFF
--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -940,18 +940,42 @@ export const openApiDocument: OpenAPIV3.Document = {
         security: [{ bearerAuth: [] }, { sessionCookie: [] }],
         parameters: [
           {
+            name: 'status',
+            in: 'query',
+            schema: { type: 'string', enum: ['TODO', 'IN_PROGRESS', 'DONE'] },
+            description: 'Filter board tasks by workflow status.',
+          },
+          {
+            name: 'priority',
+            in: 'query',
+            schema: { type: 'string', enum: ['LOW', 'MEDIUM', 'HIGH'] },
+            description: 'Filter board tasks by priority.',
+          },
+          {
             name: 'tag',
             in: 'query',
-            required: false,
-            description: 'Filter board tasks that include the specified tag(s). Repeat the parameter to require multiple tags.',
-            schema: {
-              oneOf: [
-                { type: 'string' },
-                { type: 'array', items: { type: 'string' } },
-              ],
-            },
             style: 'form',
             explode: true,
+            schema: { type: 'array', items: { type: 'string' } },
+            description: 'Filter board tasks that include the specified tag(s). Repeat the parameter to require multiple tags.',
+          },
+          {
+            name: 'q',
+            in: 'query',
+            schema: { type: 'string', minLength: 1 },
+            description: 'Case-insensitive search over the title and description.',
+          },
+          {
+            name: 'dueFrom',
+            in: 'query',
+            schema: { type: 'string', format: 'date-time' },
+            description: 'Only return board tasks due on or after this ISO timestamp.',
+          },
+          {
+            name: 'dueTo',
+            in: 'query',
+            schema: { type: 'string', format: 'date-time' },
+            description: 'Only return board tasks due on or before this ISO timestamp.',
           },
         ],
         responses: {
@@ -968,6 +992,17 @@ export const openApiDocument: OpenAPIV3.Document = {
                 schema: { $ref: '#/components/schemas/BoardResponse' },
                 examples: {
                   default: { value: boardResponse.example as Record<string, unknown> },
+                },
+              },
+            },
+          },
+          '400': {
+            description: 'Invalid query parameters',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/ErrorResponse' },
+                examples: {
+                  invalidFilters: taskListInvalidFiltersExample,
                 },
               },
             },

--- a/apps/api/src/repositories/task-repository.ts
+++ b/apps/api/src/repositories/task-repository.ts
@@ -47,7 +47,12 @@ export interface TaskListOptions {
 }
 
 export interface TaskBoardOptions {
+  status?: SharedTaskStatus;
+  priority?: SharedTaskPriority;
   tags?: string[];
+  search?: string;
+  dueFrom?: Date;
+  dueTo?: Date;
 }
 
 export interface TaskListResult {
@@ -134,6 +139,23 @@ export function createTaskRepository(prisma: PrismaClient): TaskRepository {
 
   const buildTaskBoard = async (userId: string, options?: TaskBoardOptions): Promise<BoardReadModelDTO> => {
     const andFilters: Prisma.TaskWhereInput[] = [];
+    if (options?.search) {
+      andFilters.push({
+        OR: [
+          { title: { contains: options.search, mode: 'insensitive' } },
+          { description: { contains: options.search, mode: 'insensitive' } },
+        ],
+      });
+    }
+
+    if (options?.dueFrom || options?.dueTo) {
+      andFilters.push({
+        dueDate: {
+          ...(options?.dueFrom ? { gte: options.dueFrom } : {}),
+          ...(options?.dueTo ? { lte: options.dueTo } : {}),
+        },
+      });
+    }
 
     if (options?.tags?.length) {
       for (const label of options.tags) {
@@ -155,6 +177,8 @@ export function createTaskRepository(prisma: PrismaClient): TaskRepository {
     const tasks = await prisma.task.findMany({
       where: {
         userId,
+        ...(options?.status ? { status: options.status as PrismaTaskStatus } : {}),
+        ...(options?.priority ? { priority: options.priority as PrismaTaskPriority } : {}),
         ...(andFilters.length ? { AND: andFilters } : {}),
       },
       include: taskWithTagsInclude,

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -39,9 +39,27 @@ const TaskListQuerySchema = z
 
 const TaskBoardQuerySchema = z
   .object({
+    status: z.enum(['TODO', 'IN_PROGRESS', 'DONE']).optional(),
+    priority: z.enum(['LOW', 'MEDIUM', 'HIGH']).optional(),
     tag: z.union([z.string().trim().min(1), z.array(z.string().trim().min(1))]).optional(),
+    q: z.string().trim().min(1).optional(),
+    dueFrom: z.string().datetime().optional(),
+    dueTo: z.string().datetime().optional(),
   })
-  .passthrough();
+  .passthrough()
+  .superRefine((data, ctx) => {
+    if (data.dueFrom && data.dueTo) {
+      const from = new Date(data.dueFrom);
+      const to = new Date(data.dueTo);
+      if (from.getTime() > to.getTime()) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['dueFrom'],
+          message: 'dueFrom must be earlier than or equal to dueTo',
+        });
+      }
+    }
+  });
 
 const TaskIdParamSchema = z.object({
   id: z
@@ -125,13 +143,18 @@ export function createTaskRouter(taskRepository?: TaskRepository) {
         return res.status(401).json({ error: 'Unauthorized' });
       }
 
-      const { tag } = parseQuery.data;
+      const { status, priority, tag, q, dueFrom, dueTo } = parseQuery.data;
       const normalizedTags = normalizeTagLabels(
         Array.isArray(tag) ? tag : tag ? [tag] : undefined,
       );
 
       const board = await repository.getTaskBoard(user.id, {
+        status,
+        priority,
         tags: normalizedTags.length ? normalizedTags : undefined,
+        search: q,
+        dueFrom: dueFrom ? new Date(dueFrom) : undefined,
+        dueTo: dueTo ? new Date(dueTo) : undefined,
       });
       res.set('ETag', `"${board.updatedAt}"`);
       res.json(board);

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -11,6 +11,8 @@ import {
 } from '../repositories/task-repository';
 import { normalizeTagLabels } from '../repositories/task-mapper';
 
+const Rfc3339DateTimeSchema = z.string().datetime({ offset: true });
+
 const TaskListQuerySchema = z
   .object({
     page: z.coerce.number().int().positive().default(1),
@@ -19,8 +21,8 @@ const TaskListQuerySchema = z
     priority: z.enum(['LOW', 'MEDIUM', 'HIGH']).optional(),
     tag: z.union([z.string().trim().min(1), z.array(z.string().trim().min(1))]).optional(),
     q: z.string().trim().min(1).optional(),
-    dueFrom: z.string().datetime().optional(),
-    dueTo: z.string().datetime().optional(),
+    dueFrom: Rfc3339DateTimeSchema.optional(),
+    dueTo: Rfc3339DateTimeSchema.optional(),
   })
   .passthrough()
   .superRefine((data, ctx) => {
@@ -43,8 +45,8 @@ const TaskBoardQuerySchema = z
     priority: z.enum(['LOW', 'MEDIUM', 'HIGH']).optional(),
     tag: z.union([z.string().trim().min(1), z.array(z.string().trim().min(1))]).optional(),
     q: z.string().trim().min(1).optional(),
-    dueFrom: z.string().datetime().optional(),
-    dueTo: z.string().datetime().optional(),
+    dueFrom: Rfc3339DateTimeSchema.optional(),
+    dueTo: Rfc3339DateTimeSchema.optional(),
   })
   .passthrough()
   .superRefine((data, ctx) => {

--- a/apps/api/tests/tasks.e2e.test.ts
+++ b/apps/api/tests/tasks.e2e.test.ts
@@ -239,6 +239,35 @@ describe("Tasks API", () => {
       ).toBe(true);
     });
 
+    it("accepts RFC3339 offset timestamps in list due range filters", async () => {
+      const auth = await register();
+
+      const matching = await createTask({
+        userId: auth.userId,
+        title: "Offset list filter",
+        status: "TODO",
+        dueDate: "2026-05-01T09:00:00.000Z",
+      });
+      await createTask({
+        userId: auth.userId,
+        title: "Outside offset list filter",
+        status: "TODO",
+        dueDate: "2026-05-03T09:00:00.000Z",
+      });
+
+      const response = await withAuth(
+        agent.get(
+          "/api/taskforge/v1/tasks?dueFrom=2026-05-01T10%3A00%3A00%2B02%3A00&dueTo=2026-05-01T12%3A00%3A00%2B02%3A00",
+        ),
+        auth,
+      ).expect(200);
+
+      expect(response.body.total).toBe(1);
+      expect(response.body.items.map((task: { id: string }) => task.id)).toEqual([
+        matching.task.id,
+      ]);
+    });
+
     it("rejects invalid due date ranges", async () => {
       const auth = await register();
 
@@ -508,6 +537,38 @@ describe("Tasks API", () => {
           totalsByStatus: { TODO: 0, IN_PROGRESS: 1, DONE: 0 },
         }),
       );
+      expect(
+        response.body.columns.flatMap(
+          (column: { tasks: Array<{ id: string }> }) =>
+            column.tasks.map((task) => task.id),
+        ),
+      ).toEqual([matching.task.id]);
+    });
+
+    it("accepts RFC3339 offset timestamps in board due range filters", async () => {
+      const auth = await register();
+
+      const matching = await createTask({
+        userId: auth.userId,
+        title: "Offset board filter",
+        status: "IN_PROGRESS",
+        dueDate: "2026-05-01T09:00:00.000Z",
+      });
+      await createTask({
+        userId: auth.userId,
+        title: "Outside offset board filter",
+        status: "IN_PROGRESS",
+        dueDate: "2026-05-03T09:00:00.000Z",
+      });
+
+      const response = await withAuth(
+        agent.get(
+          "/api/taskforge/v1/tasks/board?dueFrom=2026-05-01T10%3A00%3A00%2B02%3A00&dueTo=2026-05-01T12%3A00%3A00%2B02%3A00",
+        ),
+        auth,
+      ).expect(200);
+
+      expect(response.body.summary.totalTasks).toBe(1);
       expect(
         response.body.columns.flatMap(
           (column: { tasks: Array<{ id: string }> }) =>

--- a/apps/api/tests/tasks.e2e.test.ts
+++ b/apps/api/tests/tasks.e2e.test.ts
@@ -455,6 +455,87 @@ describe("Tasks API", () => {
       ).toEqual([matching.task.id]);
     });
 
+    it("filters board data by status, priority, search, and due range", async () => {
+      const auth = await register();
+
+      const matching = await createTask({
+        userId: auth.userId,
+        title: "Design board filters",
+        description: "Implement searchable kanban controls",
+        status: "IN_PROGRESS",
+        priority: "HIGH",
+        dueDate: "2026-05-15T12:00:00.000Z",
+        tags: ["design"],
+      });
+      await createTask({
+        userId: auth.userId,
+        title: "Design backlog copy",
+        description: "Matches search but not priority",
+        status: "IN_PROGRESS",
+        priority: "LOW",
+        dueDate: "2026-05-15T12:00:00.000Z",
+        tags: ["design"],
+      });
+      await createTask({
+        userId: auth.userId,
+        title: "Ship board filters",
+        description: "Matches priority but not status",
+        status: "DONE",
+        priority: "HIGH",
+        dueDate: "2026-05-15T12:00:00.000Z",
+        tags: ["design"],
+      });
+      await createTask({
+        userId: auth.userId,
+        title: "Design board archive",
+        description: "Matches everything except due date",
+        status: "IN_PROGRESS",
+        priority: "HIGH",
+        dueDate: "2026-06-20T12:00:00.000Z",
+        tags: ["design"],
+      });
+
+      const response = await withAuth(
+        agent.get(
+          "/api/taskforge/v1/tasks/board?status=IN_PROGRESS&priority=HIGH&q=searchable&dueFrom=2026-05-01T00%3A00%3A00.000Z&dueTo=2026-05-31T23%3A59%3A59.999Z",
+        ),
+        auth,
+      ).expect(200);
+
+      expect(response.body.summary).toEqual(
+        expect.objectContaining({
+          totalTasks: 1,
+          totalsByStatus: { TODO: 0, IN_PROGRESS: 1, DONE: 0 },
+        }),
+      );
+      expect(
+        response.body.columns.flatMap(
+          (column: { tasks: Array<{ id: string }> }) =>
+            column.tasks.map((task) => task.id),
+        ),
+      ).toEqual([matching.task.id]);
+    });
+
+    it("rejects board filters with an inverted due range", async () => {
+      const auth = await register();
+
+      const response = await withAuth(
+        agent.get(
+          "/api/taskforge/v1/tasks/board?dueFrom=2026-05-31T00%3A00%3A00.000Z&dueTo=2026-05-01T00%3A00%3A00.000Z",
+        ),
+        auth,
+      ).expect(400);
+
+      expect(response.body).toEqual(
+        expect.objectContaining({
+          error: "Invalid payload",
+        }),
+      );
+      expect(response.body.details.fieldErrors.dueFrom).toContain(
+        "dueFrom must be earlier than or equal to dueTo",
+      );
+    });
+
     it("requires authentication to move tasks on the board", async () => {
       const created = await createTask({
         title: "Unauthenticated board move",

--- a/apps/web/app/(protected)/dashboard/dashboard-content.tsx
+++ b/apps/web/app/(protected)/dashboard/dashboard-content.tsx
@@ -163,8 +163,15 @@ const sortOptions = [
   { value: "priority", label: "Priority" },
 ] as const;
 const BOARD_FILTERS_STORAGE_KEY = "taskforge.dashboard.filters";
-type DueWindow = "ALL" | "OVERDUE" | "TODAY" | "NEXT_7_DAYS" | "CUSTOM";
-const dueWindows: DueWindow[] = ["ALL", "OVERDUE", "TODAY", "NEXT_7_DAYS"];
+type DueWindow = "ALL" | "PAST" | "TODAY" | "NEXT_7_DAYS" | "CUSTOM";
+const dueWindows: DueWindow[] = ["ALL", "PAST", "TODAY", "NEXT_7_DAYS"];
+const dueWindowLabels: Record<DueWindow, string> = {
+  ALL: "Any due date",
+  PAST: "Due before now",
+  TODAY: "Due today",
+  NEXT_7_DAYS: "Due next 7 days",
+  CUSTOM: "Custom due range",
+};
 
 type SortOption = (typeof sortOptions)[number]["value"];
 
@@ -182,10 +189,172 @@ interface BoardMoveRollback {
   sourceIndex: number;
 }
 
+interface BoardFilterState {
+  statusFilter: "ALL" | TaskStatus;
+  priorityFilter: "ALL" | TaskPriority;
+  dueWindow: DueWindow;
+  customDueRange: { dueFrom?: string; dueTo?: string } | null;
+  searchQuery: string;
+  tagFilters: string[];
+}
+
+function createDefaultBoardFilterState(tagFilters: string[] = []): BoardFilterState {
+  return {
+    statusFilter: "ALL",
+    priorityFilter: "ALL",
+    dueWindow: "ALL",
+    customDueRange: null,
+    searchQuery: "",
+    tagFilters,
+  };
+}
+
+function isTaskStatusFilter(value: string | null): value is TaskStatus {
+  return value === "TODO" || value === "IN_PROGRESS" || value === "DONE";
+}
+
+function isTaskPriorityFilter(value: string | null): value is TaskPriority {
+  return value === "LOW" || value === "MEDIUM" || value === "HIGH";
+}
+
+function normalizeDueWindow(value: string | null | undefined): DueWindow | null {
+  if (value === "OVERDUE") {
+    return "PAST";
+  }
+
+  return dueWindows.includes(value as DueWindow) ? (value as DueWindow) : null;
+}
+
+function parseBoardFiltersFromSearchParams(searchParams: URLSearchParams): BoardFilterState {
+  const state = createDefaultBoardFilterState(sanitizeTags(searchParams.getAll("tag")));
+  const status = searchParams.get("status");
+  const priority = searchParams.get("priority");
+  const dueWindow = normalizeDueWindow(searchParams.get("dueWindow"));
+  const dueFrom = searchParams.get("dueFrom") ?? undefined;
+  const dueTo = searchParams.get("dueTo") ?? undefined;
+
+  if (isTaskStatusFilter(status)) {
+    state.statusFilter = status;
+  }
+
+  if (isTaskPriorityFilter(priority)) {
+    state.priorityFilter = priority;
+  }
+
+  if (dueWindow) {
+    state.dueWindow = dueWindow;
+    state.customDueRange = null;
+  } else if (dueFrom || dueTo) {
+    state.dueWindow = "CUSTOM";
+    state.customDueRange = { dueFrom, dueTo };
+  }
+
+  state.searchQuery = searchParams.get("q") ?? "";
+  return state;
+}
+
+function readBoardFiltersFromStorage(): BoardFilterState | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(BOARD_FILTERS_STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+
+    const parsed = JSON.parse(raw) as Partial<{
+      statusFilter: BoardFilterState["statusFilter"];
+      priorityFilter: BoardFilterState["priorityFilter"];
+      dueWindow: DueWindow | "OVERDUE";
+      dueRange: { dueFrom?: string; dueTo?: string };
+      searchQuery: string;
+      tagFilters: string[];
+    }> | null;
+    if (!parsed) {
+      return null;
+    }
+
+    const state = createDefaultBoardFilterState();
+    const statusFilter = parsed.statusFilter;
+    if (statusFilter === "ALL") {
+      state.statusFilter = statusFilter;
+    } else {
+      const maybeStatus = typeof statusFilter === "string" ? statusFilter : null;
+      if (isTaskStatusFilter(maybeStatus)) {
+        state.statusFilter = maybeStatus;
+      }
+    }
+
+    const priorityFilter = parsed.priorityFilter;
+    if (priorityFilter === "ALL") {
+      state.priorityFilter = priorityFilter;
+    } else {
+      const maybePriority = typeof priorityFilter === "string" ? priorityFilter : null;
+      if (isTaskPriorityFilter(maybePriority)) {
+        state.priorityFilter = maybePriority;
+      }
+    }
+
+    const dueWindow = normalizeDueWindow(parsed.dueWindow);
+    if (dueWindow) {
+      state.dueWindow = dueWindow;
+      state.customDueRange = null;
+    } else if (parsed.dueWindow === "CUSTOM" && (parsed.dueRange?.dueFrom || parsed.dueRange?.dueTo)) {
+      state.dueWindow = "CUSTOM";
+      state.customDueRange = {
+        dueFrom: parsed.dueRange.dueFrom,
+        dueTo: parsed.dueRange.dueTo,
+      };
+    }
+
+    state.searchQuery = typeof parsed.searchQuery === "string" ? parsed.searchQuery : "";
+    state.tagFilters = Array.isArray(parsed.tagFilters) ? sanitizeTags(parsed.tagFilters) : [];
+    return state;
+  } catch {
+    return null;
+  }
+}
+
+function writeBoardFiltersToStorage(state: BoardFilterState, dueRange: { dueFrom?: string; dueTo?: string }) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(
+      BOARD_FILTERS_STORAGE_KEY,
+      JSON.stringify({
+        statusFilter: state.statusFilter,
+        priorityFilter: state.priorityFilter,
+        dueWindow: state.dueWindow,
+        dueRange,
+        searchQuery: state.searchQuery,
+        tagFilters: state.tagFilters,
+      }),
+    );
+  } catch {
+    // Ignore storage failures in restricted browser contexts.
+  }
+}
+
+function clearBoardFiltersFromStorage() {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.localStorage.removeItem(BOARD_FILTERS_STORAGE_KEY);
+  } catch {
+    // Ignore storage failures in restricted browser contexts.
+  }
+}
+
 function getDueRangeForWindow(dueWindow: DueWindow): { dueFrom?: string; dueTo?: string } {
   const now = new Date();
 
-  if (dueWindow === "OVERDUE") {
+  if (dueWindow === "PAST") {
     return { dueTo: now.toISOString() };
   }
 
@@ -617,16 +786,18 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
   const pathname = usePathname();
   const router = useRouter();
   const searchParams = useSearchParams();
-  const urlTagFilters = useMemo(
-    () => sanitizeTags(searchParams.getAll("tag")),
-    [searchParams],
+  const initialSearchParams = new URLSearchParams(searchParams.toString());
+  const initialFilterState = parseBoardFiltersFromSearchParams(initialSearchParams);
+  const hasInitialQuery = initialSearchParams.toString().length > 0;
+  const [hasHydratedFilters, setHasHydratedFilters] = useState(() => hasInitialQuery);
+  const [statusFilter, setStatusFilter] = useState<"ALL" | TaskStatus>(() => initialFilterState.statusFilter);
+  const [priorityFilter, setPriorityFilter] = useState<"ALL" | TaskPriority>(() => initialFilterState.priorityFilter);
+  const [dueWindow, setDueWindow] = useState<DueWindow>(() => initialFilterState.dueWindow);
+  const [customDueRange, setCustomDueRange] = useState<{ dueFrom?: string; dueTo?: string } | null>(
+    () => initialFilterState.customDueRange,
   );
-  const [statusFilter, setStatusFilter] = useState<"ALL" | TaskStatus>("ALL");
-  const [priorityFilter, setPriorityFilter] = useState<"ALL" | TaskPriority>("ALL");
-  const [dueWindow, setDueWindow] = useState<DueWindow>("ALL");
-  const [customDueRange, setCustomDueRange] = useState<{ dueFrom?: string; dueTo?: string } | null>(null);
-  const [searchQuery, setSearchQuery] = useState("");
-  const [tagFilters, setTagFilters] = useState<string[]>(() => urlTagFilters);
+  const [searchQuery, setSearchQuery] = useState(() => initialFilterState.searchQuery);
+  const [tagFilters, setTagFilters] = useState<string[]>(() => initialFilterState.tagFilters);
   const [sortBy, setSortBy] = useState<SortOption>("manual");
   const [columnOrder, setColumnOrder] = useState<ColumnOrderState>(() =>
     cloneColumnOrder(emptyColumnOrder),
@@ -654,23 +825,29 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
     searchQuery.trim().length > 0 ||
     tagFilters.length > 0;
 
-  const tasksQuery = useTasksQuery({
-    pageSize: 50,
-    status: statusFilter === "ALL" ? undefined : statusFilter,
-    priority: priorityFilter === "ALL" ? undefined : priorityFilter,
-    tag: tagFilters.length > 0 ? tagFilters : undefined,
-    q: searchQuery.trim() || undefined,
-    dueFrom: dueRange.dueFrom,
-    dueTo: dueRange.dueTo,
-  });
-  const boardQuery = useTaskBoardQuery({
-    status: statusFilter === "ALL" ? undefined : statusFilter,
-    priority: priorityFilter === "ALL" ? undefined : priorityFilter,
-    tag: tagFilters.length > 0 ? tagFilters : undefined,
-    q: searchQuery.trim() || undefined,
-    dueFrom: dueRange.dueFrom,
-    dueTo: dueRange.dueTo,
-  });
+  const tasksQuery = useTasksQuery(
+    {
+      pageSize: 50,
+      status: statusFilter === "ALL" ? undefined : statusFilter,
+      priority: priorityFilter === "ALL" ? undefined : priorityFilter,
+      tag: tagFilters.length > 0 ? tagFilters : undefined,
+      q: searchQuery.trim() || undefined,
+      dueFrom: dueRange.dueFrom,
+      dueTo: dueRange.dueTo,
+    },
+    { enabled: hasHydratedFilters },
+  );
+  const boardQuery = useTaskBoardQuery(
+    {
+      status: statusFilter === "ALL" ? undefined : statusFilter,
+      priority: priorityFilter === "ALL" ? undefined : priorityFilter,
+      tag: tagFilters.length > 0 ? tagFilters : undefined,
+      q: searchQuery.trim() || undefined,
+      dueFrom: dueRange.dueFrom,
+      dueTo: dueRange.dueTo,
+    },
+    { enabled: hasHydratedFilters },
+  );
   const tagsQuery = useTagsQuery();
   const moveTask = useMoveTaskOnBoard();
   const { toast } = useToast();
@@ -864,66 +1041,39 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
     [boardQuery.data, tasksByStatus.TODO.length],
   );
 
+  const applyBoardFilterState = useCallback((state: BoardFilterState) => {
+    setStatusFilter(state.statusFilter);
+    setPriorityFilter(state.priorityFilter);
+    setDueWindow(state.dueWindow);
+    setCustomDueRange(state.customDueRange);
+    setSearchQuery(state.searchQuery);
+    setTagFilters((previous) =>
+      previous.length === state.tagFilters.length &&
+      previous.every((value, index) => value === state.tagFilters[index])
+        ? previous
+        : state.tagFilters,
+    );
+  }, []);
+
   useEffect(() => {
     const rawQuery = searchParams.toString();
     if (!rawQuery) {
-      const raw = window.localStorage.getItem(BOARD_FILTERS_STORAGE_KEY);
-      if (!raw) {
-        return;
+      if (!hasHydratedFilters) {
+        applyBoardFilterState(readBoardFiltersFromStorage() ?? createDefaultBoardFilterState());
+        setHasHydratedFilters(true);
       }
-      try {
-        const parsed = JSON.parse(raw) as { statusFilter?: typeof statusFilter; priorityFilter?: typeof priorityFilter; dueWindow?: DueWindow; dueRange?: { dueFrom?: string; dueTo?: string }; searchQuery?: string; tagFilters?: string[] };
-        if (parsed.statusFilter === "ALL" || parsed.statusFilter === "TODO" || parsed.statusFilter === "IN_PROGRESS" || parsed.statusFilter === "DONE") {
-          setStatusFilter(parsed.statusFilter);
-        }
-        if (parsed.priorityFilter === "ALL" || parsed.priorityFilter === "LOW" || parsed.priorityFilter === "MEDIUM" || parsed.priorityFilter === "HIGH") {
-          setPriorityFilter(parsed.priorityFilter);
-        }
-        if (parsed.dueWindow && dueWindows.includes(parsed.dueWindow)) {
-          setDueWindow(parsed.dueWindow);
-          setCustomDueRange(null);
-        } else if (parsed.dueWindow === "CUSTOM" && (parsed.dueRange?.dueFrom || parsed.dueRange?.dueTo)) {
-          setDueWindow("CUSTOM");
-          setCustomDueRange({
-            dueFrom: parsed.dueRange.dueFrom,
-            dueTo: parsed.dueRange.dueTo,
-          });
-        }
-        setSearchQuery(typeof parsed.searchQuery === "string" ? parsed.searchQuery : "");
-        setTagFilters(Array.isArray(parsed.tagFilters) ? sanitizeTags(parsed.tagFilters) : []);
-      } catch {}
       return;
     }
 
-    const status = searchParams.get("status");
-    const priority = searchParams.get("priority");
-    const dueWindowParam = searchParams.get("dueWindow") as DueWindow | null;
-    const dueFrom = searchParams.get("dueFrom") ?? undefined;
-    const dueTo = searchParams.get("dueTo") ?? undefined;
-    const q = searchParams.get("q") ?? "";
-
-    setStatusFilter(status === "TODO" || status === "IN_PROGRESS" || status === "DONE" ? status : "ALL");
-    setPriorityFilter(priority === "LOW" || priority === "MEDIUM" || priority === "HIGH" ? priority : "ALL");
-    if (dueWindowParam && dueWindows.includes(dueWindowParam)) {
-      setDueWindow(dueWindowParam);
-      setCustomDueRange(null);
-    } else if (dueFrom || dueTo) {
-      setDueWindow("CUSTOM");
-      setCustomDueRange({ dueFrom, dueTo });
-    } else {
-      setDueWindow("ALL");
-      setCustomDueRange(null);
-    }
-    setSearchQuery(q);
-    setTagFilters((previous) =>
-      previous.length === urlTagFilters.length &&
-      previous.every((value, index) => value === urlTagFilters[index])
-        ? previous
-        : urlTagFilters,
-    );
-  }, [searchParams, urlTagFilters]);
+    applyBoardFilterState(parseBoardFiltersFromSearchParams(new URLSearchParams(rawQuery)));
+    setHasHydratedFilters(true);
+  }, [applyBoardFilterState, hasHydratedFilters, searchParams]);
 
   useEffect(() => {
+    if (!hasHydratedFilters) {
+      return;
+    }
+
     const params = new URLSearchParams(searchParams.toString());
     statusFilter === "ALL" ? params.delete("status") : params.set("status", statusFilter);
     priorityFilter === "ALL" ? params.delete("priority") : params.set("priority", priorityFilter);
@@ -946,8 +1096,23 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
     }
     const next = params.toString();
     if (next !== searchParams.toString()) router.replace(next ? `${pathname}?${next}` : pathname, { scroll: false });
-    window.localStorage.setItem(BOARD_FILTERS_STORAGE_KEY, JSON.stringify({ statusFilter, priorityFilter, dueWindow, dueRange, searchQuery, tagFilters }));
-  }, [dueRange, dueWindow, pathname, priorityFilter, router, searchParams, searchQuery, statusFilter, tagFilters]);
+    writeBoardFiltersToStorage(
+      { statusFilter, priorityFilter, dueWindow, customDueRange, searchQuery, tagFilters },
+      dueRange,
+    );
+  }, [
+    customDueRange,
+    dueRange,
+    dueWindow,
+    hasHydratedFilters,
+    pathname,
+    priorityFilter,
+    router,
+    searchParams,
+    searchQuery,
+    statusFilter,
+    tagFilters,
+  ]);
 
   const handleTagFiltersChange = useCallback(
     (nextTags: string[]) => {
@@ -1511,8 +1676,25 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
               })}
             </div>
             <div className="mt-2 flex flex-wrap gap-2">
-              <Button size="sm" variant={priorityFilter==="ALL"?"default":"secondary"} onClick={() => setPriorityFilter("ALL")}>Any priority</Button>
-              {(["HIGH","MEDIUM","LOW"] as const).map((p) => <Button key={p} size="sm" variant={priorityFilter===p?"default":"secondary"} onClick={() => setPriorityFilter(p)}>{priorityLabels[p]}</Button>)}
+              <Button
+                type="button"
+                size="sm"
+                variant={priorityFilter === "ALL" ? "default" : "secondary"}
+                onClick={() => setPriorityFilter("ALL")}
+              >
+                Any priority
+              </Button>
+              {(["HIGH", "MEDIUM", "LOW"] as const).map((priority) => (
+                <Button
+                  key={priority}
+                  type="button"
+                  size="sm"
+                  variant={priorityFilter === priority ? "default" : "secondary"}
+                  onClick={() => setPriorityFilter(priority)}
+                >
+                  {priorityLabels[priority]}
+                </Button>
+              ))}
             </div>
           </div>
           <div className="w-full max-w-sm">
@@ -1526,11 +1708,24 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
             />
           </div>
           <div className="flex flex-wrap items-center gap-3">
-            <Input value={searchQuery} onChange={(e) => setSearchQuery(e.target.value)} placeholder="Search title or description" className="h-9 w-64" />
+            <label className="sr-only" htmlFor="board-task-search">
+              Search board tasks
+            </label>
+            <Input
+              id="board-task-search"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder="Search title or description"
+              className="h-9 w-64"
+            />
             <DropdownMenu>
-              <DropdownMenuTrigger asChild><Button type="button" size="sm" variant="outline">Due: {dueWindow.replaceAll("_"," ")}</Button></DropdownMenuTrigger>
+              <DropdownMenuTrigger asChild>
+                <Button type="button" size="sm" variant="outline">
+                  Due: {dueWindowLabels[dueWindow]}
+                </Button>
+              </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
-                {(["ALL","OVERDUE","TODAY","NEXT_7_DAYS"] as const).map((dw) => (
+                {dueWindows.map((dw) => (
                   <DropdownMenuItem
                     key={dw}
                     onSelect={() => {
@@ -1538,7 +1733,7 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
                       setCustomDueRange(null);
                     }}
                   >
-                    {dw.replaceAll("_"," ")}
+                    {dueWindowLabels[dw]}
                   </DropdownMenuItem>
                 ))}
               </DropdownMenuContent>
@@ -1609,7 +1804,7 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
                     setCustomDueRange(null);
                     setSearchQuery("");
                     setTagFilters([]);
-                    window.localStorage.removeItem(BOARD_FILTERS_STORAGE_KEY);
+                    clearBoardFiltersFromStorage();
                     router.replace(pathname, { scroll: false });
                   }}
                 >

--- a/apps/web/app/(protected)/dashboard/dashboard-content.tsx
+++ b/apps/web/app/(protected)/dashboard/dashboard-content.tsx
@@ -790,6 +790,7 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
   const initialFilterState = parseBoardFiltersFromSearchParams(initialSearchParams);
   const hasInitialQuery = initialSearchParams.toString().length > 0;
   const [hasHydratedFilters, setHasHydratedFilters] = useState(() => hasInitialQuery);
+  const hasLoadedInitialStoredFiltersRef = useRef(hasInitialQuery);
   const [statusFilter, setStatusFilter] = useState<"ALL" | TaskStatus>(() => initialFilterState.statusFilter);
   const [priorityFilter, setPriorityFilter] = useState<"ALL" | TaskPriority>(() => initialFilterState.priorityFilter);
   const [dueWindow, setDueWindow] = useState<DueWindow>(() => initialFilterState.dueWindow);
@@ -1058,16 +1059,20 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
   useEffect(() => {
     const rawQuery = searchParams.toString();
     if (!rawQuery) {
-      if (!hasHydratedFilters) {
-        applyBoardFilterState(readBoardFiltersFromStorage() ?? createDefaultBoardFilterState());
-        setHasHydratedFilters(true);
-      }
+      const nextState = hasLoadedInitialStoredFiltersRef.current
+        ? createDefaultBoardFilterState()
+        : readBoardFiltersFromStorage() ?? createDefaultBoardFilterState();
+
+      hasLoadedInitialStoredFiltersRef.current = true;
+      applyBoardFilterState(nextState);
+      setHasHydratedFilters(true);
       return;
     }
 
+    hasLoadedInitialStoredFiltersRef.current = true;
     applyBoardFilterState(parseBoardFiltersFromSearchParams(new URLSearchParams(rawQuery)));
     setHasHydratedFilters(true);
-  }, [applyBoardFilterState, hasHydratedFilters, searchParams]);
+  }, [applyBoardFilterState, searchParams]);
 
   useEffect(() => {
     if (!hasHydratedFilters) {

--- a/apps/web/app/(protected)/dashboard/dashboard-content.tsx
+++ b/apps/web/app/(protected)/dashboard/dashboard-content.tsx
@@ -163,7 +163,8 @@ const sortOptions = [
   { value: "priority", label: "Priority" },
 ] as const;
 const BOARD_FILTERS_STORAGE_KEY = "taskforge.dashboard.filters";
-type DueWindow = "ALL" | "OVERDUE" | "TODAY" | "NEXT_7_DAYS";
+type DueWindow = "ALL" | "OVERDUE" | "TODAY" | "NEXT_7_DAYS" | "CUSTOM";
+const dueWindows: DueWindow[] = ["ALL", "OVERDUE", "TODAY", "NEXT_7_DAYS"];
 
 type SortOption = (typeof sortOptions)[number]["value"];
 
@@ -179,6 +180,31 @@ interface BoardMoveRollback {
   taskId: string;
   sourceStatus: TaskStatus;
   sourceIndex: number;
+}
+
+function getDueRangeForWindow(dueWindow: DueWindow): { dueFrom?: string; dueTo?: string } {
+  const now = new Date();
+
+  if (dueWindow === "OVERDUE") {
+    return { dueTo: now.toISOString() };
+  }
+
+  if (dueWindow === "TODAY") {
+    const start = new Date(now);
+    start.setHours(0, 0, 0, 0);
+    const end = new Date(now);
+    end.setHours(23, 59, 59, 999);
+    return { dueFrom: start.toISOString(), dueTo: end.toISOString() };
+  }
+
+  if (dueWindow === "NEXT_7_DAYS") {
+    const end = new Date(now);
+    end.setDate(end.getDate() + 7);
+    end.setHours(23, 59, 59, 999);
+    return { dueFrom: now.toISOString(), dueTo: end.toISOString() };
+  }
+
+  return {};
 }
 
 function getInitials(user: DashboardUser) {
@@ -598,6 +624,7 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
   const [statusFilter, setStatusFilter] = useState<"ALL" | TaskStatus>("ALL");
   const [priorityFilter, setPriorityFilter] = useState<"ALL" | TaskPriority>("ALL");
   const [dueWindow, setDueWindow] = useState<DueWindow>("ALL");
+  const [customDueRange, setCustomDueRange] = useState<{ dueFrom?: string; dueTo?: string } | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
   const [tagFilters, setTagFilters] = useState<string[]>(() => urlTagFilters);
   const [sortBy, setSortBy] = useState<SortOption>("manual");
@@ -615,6 +642,17 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
   const columnOrderRef = useRef(columnOrder);
   const dragSnapshotRef = useRef<ColumnOrderState | null>(null);
   const inFlightTaskIdsRef = useRef<Set<string>>(new Set());
+  const dueRange = useMemo(
+    () => customDueRange ?? getDueRangeForWindow(dueWindow),
+    [customDueRange, dueWindow],
+  );
+  const hasActiveFilters =
+    statusFilter !== "ALL" ||
+    priorityFilter !== "ALL" ||
+    dueWindow !== "ALL" ||
+    Boolean(customDueRange?.dueFrom || customDueRange?.dueTo) ||
+    searchQuery.trim().length > 0 ||
+    tagFilters.length > 0;
 
   const tasksQuery = useTasksQuery({
     pageSize: 50,
@@ -827,47 +865,89 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
   );
 
   useEffect(() => {
+    const rawQuery = searchParams.toString();
+    if (!rawQuery) {
+      const raw = window.localStorage.getItem(BOARD_FILTERS_STORAGE_KEY);
+      if (!raw) {
+        return;
+      }
+      try {
+        const parsed = JSON.parse(raw) as { statusFilter?: typeof statusFilter; priorityFilter?: typeof priorityFilter; dueWindow?: DueWindow; dueRange?: { dueFrom?: string; dueTo?: string }; searchQuery?: string; tagFilters?: string[] };
+        if (parsed.statusFilter === "ALL" || parsed.statusFilter === "TODO" || parsed.statusFilter === "IN_PROGRESS" || parsed.statusFilter === "DONE") {
+          setStatusFilter(parsed.statusFilter);
+        }
+        if (parsed.priorityFilter === "ALL" || parsed.priorityFilter === "LOW" || parsed.priorityFilter === "MEDIUM" || parsed.priorityFilter === "HIGH") {
+          setPriorityFilter(parsed.priorityFilter);
+        }
+        if (parsed.dueWindow && dueWindows.includes(parsed.dueWindow)) {
+          setDueWindow(parsed.dueWindow);
+          setCustomDueRange(null);
+        } else if (parsed.dueWindow === "CUSTOM" && (parsed.dueRange?.dueFrom || parsed.dueRange?.dueTo)) {
+          setDueWindow("CUSTOM");
+          setCustomDueRange({
+            dueFrom: parsed.dueRange.dueFrom,
+            dueTo: parsed.dueRange.dueTo,
+          });
+        }
+        setSearchQuery(typeof parsed.searchQuery === "string" ? parsed.searchQuery : "");
+        setTagFilters(Array.isArray(parsed.tagFilters) ? sanitizeTags(parsed.tagFilters) : []);
+      } catch {}
+      return;
+    }
+
+    const status = searchParams.get("status");
+    const priority = searchParams.get("priority");
+    const dueWindowParam = searchParams.get("dueWindow") as DueWindow | null;
+    const dueFrom = searchParams.get("dueFrom") ?? undefined;
+    const dueTo = searchParams.get("dueTo") ?? undefined;
+    const q = searchParams.get("q") ?? "";
+
+    setStatusFilter(status === "TODO" || status === "IN_PROGRESS" || status === "DONE" ? status : "ALL");
+    setPriorityFilter(priority === "LOW" || priority === "MEDIUM" || priority === "HIGH" ? priority : "ALL");
+    if (dueWindowParam && dueWindows.includes(dueWindowParam)) {
+      setDueWindow(dueWindowParam);
+      setCustomDueRange(null);
+    } else if (dueFrom || dueTo) {
+      setDueWindow("CUSTOM");
+      setCustomDueRange({ dueFrom, dueTo });
+    } else {
+      setDueWindow("ALL");
+      setCustomDueRange(null);
+    }
+    setSearchQuery(q);
     setTagFilters((previous) =>
       previous.length === urlTagFilters.length &&
       previous.every((value, index) => value === urlTagFilters[index])
         ? previous
         : urlTagFilters,
     );
-  }, [urlTagFilters]);
-  useEffect(() => {
-    const status = searchParams.get("status");
-    const priority = searchParams.get("priority");
-    const dueWindowParam = searchParams.get("dueWindow") as DueWindow | null;
-    const q = searchParams.get("q") ?? "";
-    if (status === "TODO" || status === "IN_PROGRESS" || status === "DONE") setStatusFilter(status);
-    if (priority === "LOW" || priority === "MEDIUM" || priority === "HIGH") setPriorityFilter(priority);
-    if (dueWindowParam && ["ALL","OVERDUE","TODAY","NEXT_7_DAYS"].includes(dueWindowParam)) setDueWindow(dueWindowParam);
-    setSearchQuery(q);
-
-    const raw = window.localStorage.getItem(BOARD_FILTERS_STORAGE_KEY);
-    if (!searchParams.toString() && raw) {
-      try {
-        const parsed = JSON.parse(raw) as { statusFilter?: typeof statusFilter; priorityFilter?: typeof priorityFilter; dueWindow?: DueWindow; searchQuery?: string; tagFilters?: string[] };
-        if (parsed.statusFilter) setStatusFilter(parsed.statusFilter);
-        if (parsed.priorityFilter) setPriorityFilter(parsed.priorityFilter);
-        if (parsed.dueWindow) setDueWindow(parsed.dueWindow);
-        if (parsed.searchQuery) setSearchQuery(parsed.searchQuery);
-        if (parsed.tagFilters) setTagFilters(sanitizeTags(parsed.tagFilters));
-      } catch {}
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [searchParams, urlTagFilters]);
 
   useEffect(() => {
     const params = new URLSearchParams(searchParams.toString());
     statusFilter === "ALL" ? params.delete("status") : params.set("status", statusFilter);
     priorityFilter === "ALL" ? params.delete("priority") : params.set("priority", priorityFilter);
-    dueWindow === "ALL" ? params.delete("dueWindow") : params.set("dueWindow", dueWindow);
+    params.delete("dueWindow");
+    params.delete("dueFrom");
+    params.delete("dueTo");
+    if (dueWindow !== "ALL" && dueWindow !== "CUSTOM") {
+      params.set("dueWindow", dueWindow);
+    }
+    if (dueRange.dueFrom) {
+      params.set("dueFrom", dueRange.dueFrom);
+    }
+    if (dueRange.dueTo) {
+      params.set("dueTo", dueRange.dueTo);
+    }
     searchQuery.trim() ? params.set("q", searchQuery.trim()) : params.delete("q");
+    params.delete("tag");
+    for (const tag of tagFilters) {
+      params.append("tag", tag);
+    }
     const next = params.toString();
     if (next !== searchParams.toString()) router.replace(next ? `${pathname}?${next}` : pathname, { scroll: false });
-    window.localStorage.setItem(BOARD_FILTERS_STORAGE_KEY, JSON.stringify({ statusFilter, priorityFilter, dueWindow, searchQuery, tagFilters }));
-  }, [dueWindow, pathname, priorityFilter, router, searchParams, searchQuery, statusFilter, tagFilters]);
+    window.localStorage.setItem(BOARD_FILTERS_STORAGE_KEY, JSON.stringify({ statusFilter, priorityFilter, dueWindow, dueRange, searchQuery, tagFilters }));
+  }, [dueRange, dueWindow, pathname, priorityFilter, router, searchParams, searchQuery, statusFilter, tagFilters]);
 
   const handleTagFiltersChange = useCallback(
     (nextTags: string[]) => {
@@ -879,20 +959,8 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
           : nextTagFilters,
       );
 
-      const params = new URLSearchParams(searchParams.toString());
-      params.delete("tag");
-      for (const tag of nextTagFilters) {
-        params.append("tag", tag);
-      }
-      const next = params.toString();
-      const current = searchParams.toString();
-      if (next !== current) {
-        router.replace(next ? `${pathname}?${next}` : pathname, {
-          scroll: false,
-        });
-      }
     },
-    [pathname, router, searchParams],
+    [],
   );
 
   const availableTags = useMemo(() => {
@@ -909,7 +977,14 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
   const firstName = user.name?.split(" ")[0] ?? "there";
 
   const isEmpty =
-    !tasksQuery.isLoading && !tasksQuery.isError && totalTasks === 0;
+    !hasActiveFilters && !tasksQuery.isLoading && !tasksQuery.isError && totalTasks === 0;
+  const isFilteredEmpty =
+    hasActiveFilters &&
+    !tasksQuery.isLoading &&
+    !tasksQuery.isError &&
+    !boardQuery.isLoading &&
+    !boardQuery.isError &&
+    visibleTaskCount === 0;
   const dragActive = Boolean(activeId);
 
   const renderedTaskMap = useMemo(() => {
@@ -1455,7 +1530,17 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
             <DropdownMenu>
               <DropdownMenuTrigger asChild><Button type="button" size="sm" variant="outline">Due: {dueWindow.replaceAll("_"," ")}</Button></DropdownMenuTrigger>
               <DropdownMenuContent align="end">
-                {(["ALL","OVERDUE","TODAY","NEXT_7_DAYS"] as const).map((dw) => <DropdownMenuItem key={dw} onSelect={() => setDueWindow(dw)}>{dw.replaceAll("_"," ")}</DropdownMenuItem>)}
+                {(["ALL","OVERDUE","TODAY","NEXT_7_DAYS"] as const).map((dw) => (
+                  <DropdownMenuItem
+                    key={dw}
+                    onSelect={() => {
+                      setDueWindow(dw);
+                      setCustomDueRange(null);
+                    }}
+                  >
+                    {dw.replaceAll("_"," ")}
+                  </DropdownMenuItem>
+                ))}
               </DropdownMenuContent>
             </DropdownMenu>
             <DropdownMenu>
@@ -1508,12 +1593,26 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
               : ""}
             .
           </p>
-          {visibleTaskCount === 0 && totalTasks > 0 ? (
+          {isFilteredEmpty ? (
             <Alert className="mt-3">
               <AlertTitle>No tasks match these filters</AlertTitle>
               <AlertDescription>
                 Try widening your filters or reset to see all tasks.
-                <Button size="sm" variant="outline" className="ml-3" onClick={() => { setStatusFilter("ALL"); setPriorityFilter("ALL"); setDueWindow("ALL"); setSearchQuery(""); setTagFilters([]); }}>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="ml-3"
+                  onClick={() => {
+                    setStatusFilter("ALL");
+                    setPriorityFilter("ALL");
+                    setDueWindow("ALL");
+                    setCustomDueRange(null);
+                    setSearchQuery("");
+                    setTagFilters([]);
+                    window.localStorage.removeItem(BOARD_FILTERS_STORAGE_KEY);
+                    router.replace(pathname, { scroll: false });
+                  }}
+                >
                   Reset filters
                 </Button>
               </AlertDescription>
@@ -1723,17 +1822,3 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
     </div>
   );
 }
-  const dueRange = useMemo(() => {
-    const now = new Date();
-    if (dueWindow === "OVERDUE") return { dueTo: now.toISOString() };
-    if (dueWindow === "TODAY") {
-      const start = new Date(now); start.setHours(0, 0, 0, 0);
-      const end = new Date(now); end.setHours(23, 59, 59, 999);
-      return { dueFrom: start.toISOString(), dueTo: end.toISOString() };
-    }
-    if (dueWindow === "NEXT_7_DAYS") {
-      const end = new Date(now); end.setDate(end.getDate() + 7); end.setHours(23, 59, 59, 999);
-      return { dueFrom: now.toISOString(), dueTo: end.toISOString() };
-    }
-    return {};
-  }, [dueWindow]);

--- a/apps/web/app/(protected)/dashboard/dashboard-content.tsx
+++ b/apps/web/app/(protected)/dashboard/dashboard-content.tsx
@@ -52,6 +52,7 @@ import type { TaskPriority, TaskStatus } from "@taskforge/shared";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import {
   Card,
   CardContent,
@@ -161,6 +162,8 @@ const sortOptions = [
   { value: "dueDate", label: "Due date" },
   { value: "priority", label: "Priority" },
 ] as const;
+const BOARD_FILTERS_STORAGE_KEY = "taskforge.dashboard.filters";
+type DueWindow = "ALL" | "OVERDUE" | "TODAY" | "NEXT_7_DAYS";
 
 type SortOption = (typeof sortOptions)[number]["value"];
 
@@ -593,6 +596,9 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
     [searchParams],
   );
   const [statusFilter, setStatusFilter] = useState<"ALL" | TaskStatus>("ALL");
+  const [priorityFilter, setPriorityFilter] = useState<"ALL" | TaskPriority>("ALL");
+  const [dueWindow, setDueWindow] = useState<DueWindow>("ALL");
+  const [searchQuery, setSearchQuery] = useState("");
   const [tagFilters, setTagFilters] = useState<string[]>(() => urlTagFilters);
   const [sortBy, setSortBy] = useState<SortOption>("manual");
   const [columnOrder, setColumnOrder] = useState<ColumnOrderState>(() =>
@@ -612,10 +618,20 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
 
   const tasksQuery = useTasksQuery({
     pageSize: 50,
+    status: statusFilter === "ALL" ? undefined : statusFilter,
+    priority: priorityFilter === "ALL" ? undefined : priorityFilter,
     tag: tagFilters.length > 0 ? tagFilters : undefined,
+    q: searchQuery.trim() || undefined,
+    dueFrom: dueRange.dueFrom,
+    dueTo: dueRange.dueTo,
   });
   const boardQuery = useTaskBoardQuery({
+    status: statusFilter === "ALL" ? undefined : statusFilter,
+    priority: priorityFilter === "ALL" ? undefined : priorityFilter,
     tag: tagFilters.length > 0 ? tagFilters : undefined,
+    q: searchQuery.trim() || undefined,
+    dueFrom: dueRange.dueFrom,
+    dueTo: dueRange.dueTo,
   });
   const tagsQuery = useTagsQuery();
   const moveTask = useMoveTaskOnBoard();
@@ -818,6 +834,40 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
         : urlTagFilters,
     );
   }, [urlTagFilters]);
+  useEffect(() => {
+    const status = searchParams.get("status");
+    const priority = searchParams.get("priority");
+    const dueWindowParam = searchParams.get("dueWindow") as DueWindow | null;
+    const q = searchParams.get("q") ?? "";
+    if (status === "TODO" || status === "IN_PROGRESS" || status === "DONE") setStatusFilter(status);
+    if (priority === "LOW" || priority === "MEDIUM" || priority === "HIGH") setPriorityFilter(priority);
+    if (dueWindowParam && ["ALL","OVERDUE","TODAY","NEXT_7_DAYS"].includes(dueWindowParam)) setDueWindow(dueWindowParam);
+    setSearchQuery(q);
+
+    const raw = window.localStorage.getItem(BOARD_FILTERS_STORAGE_KEY);
+    if (!searchParams.toString() && raw) {
+      try {
+        const parsed = JSON.parse(raw) as { statusFilter?: typeof statusFilter; priorityFilter?: typeof priorityFilter; dueWindow?: DueWindow; searchQuery?: string; tagFilters?: string[] };
+        if (parsed.statusFilter) setStatusFilter(parsed.statusFilter);
+        if (parsed.priorityFilter) setPriorityFilter(parsed.priorityFilter);
+        if (parsed.dueWindow) setDueWindow(parsed.dueWindow);
+        if (parsed.searchQuery) setSearchQuery(parsed.searchQuery);
+        if (parsed.tagFilters) setTagFilters(sanitizeTags(parsed.tagFilters));
+      } catch {}
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    const params = new URLSearchParams(searchParams.toString());
+    statusFilter === "ALL" ? params.delete("status") : params.set("status", statusFilter);
+    priorityFilter === "ALL" ? params.delete("priority") : params.set("priority", priorityFilter);
+    dueWindow === "ALL" ? params.delete("dueWindow") : params.set("dueWindow", dueWindow);
+    searchQuery.trim() ? params.set("q", searchQuery.trim()) : params.delete("q");
+    const next = params.toString();
+    if (next !== searchParams.toString()) router.replace(next ? `${pathname}?${next}` : pathname, { scroll: false });
+    window.localStorage.setItem(BOARD_FILTERS_STORAGE_KEY, JSON.stringify({ statusFilter, priorityFilter, dueWindow, searchQuery, tagFilters }));
+  }, [dueWindow, pathname, priorityFilter, router, searchParams, searchQuery, statusFilter, tagFilters]);
 
   const handleTagFiltersChange = useCallback(
     (nextTags: string[]) => {
@@ -1385,6 +1435,10 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
                 );
               })}
             </div>
+            <div className="mt-2 flex flex-wrap gap-2">
+              <Button size="sm" variant={priorityFilter==="ALL"?"default":"secondary"} onClick={() => setPriorityFilter("ALL")}>Any priority</Button>
+              {(["HIGH","MEDIUM","LOW"] as const).map((p) => <Button key={p} size="sm" variant={priorityFilter===p?"default":"secondary"} onClick={() => setPriorityFilter(p)}>{priorityLabels[p]}</Button>)}
+            </div>
           </div>
           <div className="w-full max-w-sm">
             <TaskTagSelector
@@ -1397,6 +1451,13 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
             />
           </div>
           <div className="flex flex-wrap items-center gap-3">
+            <Input value={searchQuery} onChange={(e) => setSearchQuery(e.target.value)} placeholder="Search title or description" className="h-9 w-64" />
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild><Button type="button" size="sm" variant="outline">Due: {dueWindow.replaceAll("_"," ")}</Button></DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                {(["ALL","OVERDUE","TODAY","NEXT_7_DAYS"] as const).map((dw) => <DropdownMenuItem key={dw} onSelect={() => setDueWindow(dw)}>{dw.replaceAll("_"," ")}</DropdownMenuItem>)}
+              </DropdownMenuContent>
+            </DropdownMenu>
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button
@@ -1447,6 +1508,17 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
               : ""}
             .
           </p>
+          {visibleTaskCount === 0 && totalTasks > 0 ? (
+            <Alert className="mt-3">
+              <AlertTitle>No tasks match these filters</AlertTitle>
+              <AlertDescription>
+                Try widening your filters or reset to see all tasks.
+                <Button size="sm" variant="outline" className="ml-3" onClick={() => { setStatusFilter("ALL"); setPriorityFilter("ALL"); setDueWindow("ALL"); setSearchQuery(""); setTagFilters([]); }}>
+                  Reset filters
+                </Button>
+              </AlertDescription>
+            </Alert>
+          ) : null}
           {!isManualSort ? (
             <p className="mt-2 text-xs text-muted-foreground">
               Sorted by{" "}
@@ -1651,3 +1723,17 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
     </div>
   );
 }
+  const dueRange = useMemo(() => {
+    const now = new Date();
+    if (dueWindow === "OVERDUE") return { dueTo: now.toISOString() };
+    if (dueWindow === "TODAY") {
+      const start = new Date(now); start.setHours(0, 0, 0, 0);
+      const end = new Date(now); end.setHours(23, 59, 59, 999);
+      return { dueFrom: start.toISOString(), dueTo: end.toISOString() };
+    }
+    if (dueWindow === "NEXT_7_DAYS") {
+      const end = new Date(now); end.setDate(end.getDate() + 7); end.setHours(23, 59, 59, 999);
+      return { dueFrom: now.toISOString(), dueTo: end.toISOString() };
+    }
+    return {};
+  }, [dueWindow]);

--- a/apps/web/lib/tasks-client.test.ts
+++ b/apps/web/lib/tasks-client.test.ts
@@ -211,7 +211,7 @@ describe('tasks-client', () => {
   });
 
   describe('getTaskBoard', () => {
-    it('serializes repeated tag filters', async () => {
+    it('serializes board filters', async () => {
       const fetchMock = vi.fn().mockResolvedValue(
         jsonResponse({
           columns: [],
@@ -227,14 +227,44 @@ describe('tasks-client', () => {
       );
 
       await getTaskBoard(
-        { tag: ['frontend', 'api'] },
+        {
+          status: 'IN_PROGRESS',
+          priority: 'HIGH',
+          tag: ['frontend', 'api'],
+          q: ' board search ',
+          dueFrom: '2026-05-01T00:00:00.000Z',
+          dueTo: '2026-05-31T23:59:59.999Z',
+        },
         { baseUrl: API_BASE_URL, fetchImpl: fetchMock },
       );
 
       const [url] = fetchMock.mock.calls[0];
       const parsedUrl = new URL(url as string);
       expect(parsedUrl.pathname).toBe('/api/taskforge/v1/tasks/board');
+      expect(parsedUrl.searchParams.get('status')).toBe('IN_PROGRESS');
+      expect(parsedUrl.searchParams.get('priority')).toBe('HIGH');
       expect(parsedUrl.searchParams.getAll('tag')).toEqual(['frontend', 'api']);
+      expect(parsedUrl.searchParams.get('q')).toBe('board search');
+      expect(parsedUrl.searchParams.get('dueFrom')).toBe('2026-05-01T00:00:00.000Z');
+      expect(parsedUrl.searchParams.get('dueTo')).toBe('2026-05-31T23:59:59.999Z');
+    });
+
+    it('rejects inverted board due ranges before sending a request', async () => {
+      const fetchMock = vi.fn();
+
+      await expect(
+        getTaskBoard(
+          {
+            dueFrom: '2026-05-31T00:00:00.000Z',
+            dueTo: '2026-05-01T00:00:00.000Z',
+          },
+          { baseUrl: API_BASE_URL, fetchImpl: fetchMock },
+        ),
+      ).rejects.toMatchObject({
+        kind: 'validation' satisfies TaskClientError['kind'],
+      });
+
+      expect(fetchMock).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/lib/tasks-client.test.ts
+++ b/apps/web/lib/tasks-client.test.ts
@@ -65,7 +65,7 @@ describe('tasks-client', () => {
           priority: 'MEDIUM',
           tag: ['frontend', 'api'],
           q: '   sprint ',
-          dueFrom: '2024-06-01T00:00:00.000Z',
+          dueFrom: '2024-06-01T02:00:00+02:00',
         },
         { baseUrl: API_BASE_URL, fetchImpl: fetchMock },
       );
@@ -81,7 +81,7 @@ describe('tasks-client', () => {
       expect(parsedUrl.searchParams.get('priority')).toBe('MEDIUM');
       expect(parsedUrl.searchParams.getAll('tag')).toEqual(['frontend', 'api']);
       expect(parsedUrl.searchParams.get('q')).toBe('sprint');
-      expect(parsedUrl.searchParams.get('dueFrom')).toBe('2024-06-01T00:00:00.000Z');
+      expect(parsedUrl.searchParams.get('dueFrom')).toBe('2024-06-01T02:00:00+02:00');
       expect((init as RequestInit)?.credentials).toBe('include');
       const headers = (init as RequestInit).headers as Headers;
       expect(headers.get('accept')).toBe('application/json');
@@ -232,8 +232,8 @@ describe('tasks-client', () => {
           priority: 'HIGH',
           tag: ['frontend', 'api'],
           q: ' board search ',
-          dueFrom: '2026-05-01T00:00:00.000Z',
-          dueTo: '2026-05-31T23:59:59.999Z',
+          dueFrom: '2026-05-01T02:00:00+02:00',
+          dueTo: '2026-06-01T01:59:59+02:00',
         },
         { baseUrl: API_BASE_URL, fetchImpl: fetchMock },
       );
@@ -245,8 +245,8 @@ describe('tasks-client', () => {
       expect(parsedUrl.searchParams.get('priority')).toBe('HIGH');
       expect(parsedUrl.searchParams.getAll('tag')).toEqual(['frontend', 'api']);
       expect(parsedUrl.searchParams.get('q')).toBe('board search');
-      expect(parsedUrl.searchParams.get('dueFrom')).toBe('2026-05-01T00:00:00.000Z');
-      expect(parsedUrl.searchParams.get('dueTo')).toBe('2026-05-31T23:59:59.999Z');
+      expect(parsedUrl.searchParams.get('dueFrom')).toBe('2026-05-01T02:00:00+02:00');
+      expect(parsedUrl.searchParams.get('dueTo')).toBe('2026-06-01T01:59:59+02:00');
     });
 
     it('rejects inverted board due ranges before sending a request', async () => {

--- a/apps/web/lib/tasks-client.ts
+++ b/apps/web/lib/tasks-client.ts
@@ -27,6 +27,7 @@ export type {
 
 const TaskStatusSchema = z.union([z.literal('TODO'), z.literal('IN_PROGRESS'), z.literal('DONE')]);
 const TaskPrioritySchema = z.union([z.literal('LOW'), z.literal('MEDIUM'), z.literal('HIGH')]);
+const QueryDateTimeSchema = z.string().datetime({ offset: true });
 
 const NonEmptyTrimmedString = z.string().trim().min(1);
 
@@ -210,8 +211,8 @@ const TaskListQuerySchema = z
         return Array.isArray(value) ? value : [value];
       }),
     q: z.string().trim().min(1).optional().transform((value) => value?.trim()),
-    dueFrom: z.string().datetime().optional(),
-    dueTo: z.string().datetime().optional(),
+    dueFrom: QueryDateTimeSchema.optional(),
+    dueTo: QueryDateTimeSchema.optional(),
   })
   .superRefine((value, ctx) => {
     if (value.dueFrom && value.dueTo) {
@@ -241,8 +242,8 @@ const BoardQuerySchema = z
         return Array.isArray(value) ? value : [value];
       }),
     q: z.string().trim().min(1).optional().transform((value) => value?.trim()),
-    dueFrom: z.string().datetime().optional(),
-    dueTo: z.string().datetime().optional(),
+    dueFrom: QueryDateTimeSchema.optional(),
+    dueTo: QueryDateTimeSchema.optional(),
   })
   .superRefine((value, ctx) => {
     if (value.dueFrom && value.dueTo) {

--- a/apps/web/lib/tasks-client.ts
+++ b/apps/web/lib/tasks-client.ts
@@ -229,6 +229,8 @@ const TaskListQuerySchema = z
 
 const BoardQuerySchema = z
   .object({
+    status: TaskStatusSchema.optional(),
+    priority: TaskPrioritySchema.optional(),
     tag: z
       .union([NonEmptyTrimmedString, z.array(NonEmptyTrimmedString)])
       .optional()
@@ -238,6 +240,22 @@ const BoardQuerySchema = z
         }
         return Array.isArray(value) ? value : [value];
       }),
+    q: z.string().trim().min(1).optional().transform((value) => value?.trim()),
+    dueFrom: z.string().datetime().optional(),
+    dueTo: z.string().datetime().optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.dueFrom && value.dueTo) {
+      const from = Date.parse(value.dueFrom);
+      const to = Date.parse(value.dueTo);
+      if (!Number.isNaN(from) && !Number.isNaN(to) && from > to) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['dueFrom'],
+          message: 'dueFrom must be earlier than or equal to dueTo.',
+        });
+      }
+    }
   });
 
 export type TaskListResponse = z.infer<typeof TaskListResponseSchema>;
@@ -261,7 +279,12 @@ export type TaskListQuery = {
 };
 
 export type TaskBoardQuery = {
+  status?: TaskStatus;
+  priority?: TaskPriority;
   tag?: string | string[];
+  q?: string;
+  dueFrom?: string;
+  dueTo?: string;
 };
 
 type NormalizedTaskListQuery = z.infer<typeof TaskListQuerySchema>;

--- a/apps/web/lib/tasks-hooks.test.ts
+++ b/apps/web/lib/tasks-hooks.test.ts
@@ -257,6 +257,29 @@ describe('tasks-hooks board cache helpers', () => {
     });
   });
 
+  it('continues checking due filters after a board task title matches search', () => {
+    const updated = __testing.applyTaskUpdateToBoard(
+      board,
+      '11111111-1111-4111-8111-111111111111',
+      {
+        title: 'Draft contract',
+        dueDate: '2024-07-01T00:00:00.000Z',
+        updatedAt: '2024-06-15T12:00:00.000Z',
+      },
+      new Date('2024-06-15T00:00:00.000Z'),
+      {
+        q: 'draft',
+        dueTo: '2024-06-30T23:59:59.999Z',
+      },
+    );
+
+    expect(updated.columns[0]).toMatchObject({
+      status: 'TODO',
+      total: 0,
+      tasks: [],
+    });
+  });
+
   it('reconciles server tasks into board caches when search filters match descriptions', () => {
     const emptyBoard: TaskBoardResponse = {
       ...board,

--- a/apps/web/lib/tasks-hooks.test.ts
+++ b/apps/web/lib/tasks-hooks.test.ts
@@ -210,6 +210,79 @@ describe('tasks-hooks board cache helpers', () => {
     });
   });
 
+  it('removes a task from a filtered board cache when non-tag filters no longer match', () => {
+    const updated = __testing.applyTaskUpdateToBoard(
+      board,
+      '11111111-1111-4111-8111-111111111111',
+      {
+        priority: 'LOW',
+        dueDate: '2024-07-01T00:00:00.000Z',
+        updatedAt: '2024-06-15T12:00:00.000Z',
+      },
+      new Date('2024-06-15T00:00:00.000Z'),
+      {
+        status: 'TODO',
+        priority: 'HIGH',
+        dueTo: '2024-06-30T23:59:59.999Z',
+      },
+    );
+
+    expect(updated.columns[0]).toMatchObject({
+      status: 'TODO',
+      total: 0,
+      tasks: [],
+    });
+    expect(updated.summary.totalTasks).toBe(1);
+  });
+
+  it('reconciles server tasks into board caches when search filters match descriptions', () => {
+    const emptyBoard: TaskBoardResponse = {
+      ...board,
+      columns: board.columns.map((column) => ({
+        ...column,
+        tasks: [],
+        total: 0,
+        overdueCount: 0,
+        tags: [],
+      })),
+      summary: {
+        totalsByStatus: {
+          TODO: 0,
+          IN_PROGRESS: 0,
+          DONE: 0,
+        },
+        overdueByStatus: {
+          TODO: 0,
+          IN_PROGRESS: 0,
+          DONE: 0,
+        },
+        totalTasks: 0,
+        totalOverdue: 0,
+      },
+    };
+    const task: TaskListItem = {
+      id: '11111111-1111-4111-8111-111111111111',
+      title: 'Draft contract',
+      description: 'Contains the board-search phrase',
+      status: 'TODO',
+      priority: 'HIGH',
+      dueDate: '2024-06-01T00:00:00.000Z',
+      tags: ['api'],
+      createdAt: '2024-05-01T00:00:00.000Z',
+      updatedAt: '2024-06-15T12:00:00.000Z',
+    };
+
+    const updated = __testing.reconcileTaskInBoard(
+      emptyBoard,
+      task,
+      { q: 'board-search' },
+      new Date('2024-06-15T00:00:00.000Z'),
+    );
+
+    expect(updated.columns[0].tasks).toHaveLength(1);
+    expect(updated.summary.totalTasks).toBe(1);
+  });
+
   it('matches board tag filters case-insensitively when reconciling server tasks', () => {
     const emptyBoard: TaskBoardResponse = {
       ...board,

--- a/apps/web/lib/tasks-hooks.test.ts
+++ b/apps/web/lib/tasks-hooks.test.ts
@@ -235,6 +235,28 @@ describe('tasks-hooks board cache helpers', () => {
     expect(updated.summary.totalTasks).toBe(1);
   });
 
+  it('keeps partial board tasks in search-filtered caches when description is not loaded', () => {
+    const updated = __testing.applyTaskUpdateToBoard(
+      board,
+      '11111111-1111-4111-8111-111111111111',
+      {
+        priority: 'HIGH',
+        updatedAt: '2024-06-15T12:00:00.000Z',
+      },
+      new Date('2024-06-15T00:00:00.000Z'),
+      { q: 'description-only phrase' },
+    );
+
+    expect(updated.columns[0]).toMatchObject({
+      status: 'TODO',
+      total: 1,
+    });
+    expect(updated.columns[0].tasks[0]).toMatchObject({
+      id: '11111111-1111-4111-8111-111111111111',
+      priority: 'HIGH',
+    });
+  });
+
   it('reconciles server tasks into board caches when search filters match descriptions', () => {
     const emptyBoard: TaskBoardResponse = {
       ...board,

--- a/apps/web/lib/tasks-hooks.ts
+++ b/apps/web/lib/tasks-hooks.ts
@@ -581,21 +581,56 @@ function buildBoardSummary(columns: TaskBoardResponse['columns']): TaskBoardResp
 }
 
 function boardTaskMatchesFilters(
-  task: Pick<TaskListItem, 'tags'>,
+  task: Pick<TaskListItem, 'title' | 'status' | 'priority' | 'dueDate' | 'tags'> & { description?: string },
   filters: NormalizedTaskBoardFilters | undefined,
 ): boolean {
-  if (!filters?.tag?.length) {
+  if (!filters) {
     return true;
   }
 
-  const taskTags = new Set(task.tags.map((tag) => tag.trim().toLowerCase()).filter(Boolean));
-  const filterTags = filters.tag.map((tag) => tag.trim().toLowerCase()).filter(Boolean);
-
-  if (filterTags.length === 0) {
-    return true;
+  if (filters.status && task.status !== filters.status) {
+    return false;
   }
 
-  return filterTags.every((tag) => taskTags.has(tag));
+  if (filters.priority && task.priority !== filters.priority) {
+    return false;
+  }
+
+  if (filters.tag?.length) {
+    const taskTags = new Set(task.tags.map((tag) => tag.trim().toLowerCase()).filter(Boolean));
+    const filterTags = filters.tag.map((tag) => tag.trim().toLowerCase()).filter(Boolean);
+
+    if (filterTags.length > 0 && filterTags.some((tag) => !taskTags.has(tag))) {
+      return false;
+    }
+  }
+
+  if (filters.q) {
+    const haystack = `${task.title} ${task.description ?? ''}`.toLowerCase();
+    if (!haystack.includes(filters.q.toLowerCase())) {
+      return false;
+    }
+  }
+
+  if (filters.dueFrom) {
+    if (!task.dueDate) {
+      return false;
+    }
+    if (Date.parse(task.dueDate) < Date.parse(filters.dueFrom)) {
+      return false;
+    }
+  }
+
+  if (filters.dueTo) {
+    if (!task.dueDate) {
+      return false;
+    }
+    if (Date.parse(task.dueDate) > Date.parse(filters.dueTo)) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 function taskBoardItemFromTask(

--- a/apps/web/lib/tasks-hooks.ts
+++ b/apps/web/lib/tasks-hooks.ts
@@ -609,15 +609,9 @@ function boardTaskMatchesFilters(
     const needle = filters.q.toLowerCase();
     const titleMatches = task.title.toLowerCase().includes(needle);
     const description = task.description;
-    if (titleMatches) {
-      return true;
-    }
+    const descriptionMatches = description === undefined || description.toLowerCase().includes(needle);
 
-    if (description === undefined) {
-      return true;
-    }
-
-    if (!description.toLowerCase().includes(needle)) {
+    if (!titleMatches && !descriptionMatches) {
       return false;
     }
   }

--- a/apps/web/lib/tasks-hooks.ts
+++ b/apps/web/lib/tasks-hooks.ts
@@ -606,8 +606,18 @@ function boardTaskMatchesFilters(
   }
 
   if (filters.q) {
-    const haystack = `${task.title} ${task.description ?? ''}`.toLowerCase();
-    if (!haystack.includes(filters.q.toLowerCase())) {
+    const needle = filters.q.toLowerCase();
+    const titleMatches = task.title.toLowerCase().includes(needle);
+    const description = task.description;
+    if (titleMatches) {
+      return true;
+    }
+
+    if (description === undefined) {
+      return true;
+    }
+
+    if (!description.toLowerCase().includes(needle)) {
       return false;
     }
   }
@@ -1521,6 +1531,7 @@ export function useUpdateTask(
           id,
           {
             ...input,
+            description: input.description ?? taskSnapshot?.description,
             updatedAt: optimisticUpdatedAt,
           },
           new Date(optimisticUpdatedAt),

--- a/apps/web/lib/tasks-hooks.ts
+++ b/apps/web/lib/tasks-hooks.ts
@@ -186,7 +186,12 @@ interface NormalizedTaskListFilters {
 }
 
 interface NormalizedTaskBoardFilters {
+  status?: TaskBoardQuery['status'];
+  priority?: TaskBoardQuery['priority'];
   tag?: string[];
+  q?: string;
+  dueFrom?: string;
+  dueTo?: string;
 }
 
 const TASK_QUERY_SCOPE = 'tasks';
@@ -768,6 +773,13 @@ function normalizeTaskBoardFilters(filters?: TaskBoardQuery): NormalizedTaskBoar
   }
 
   const normalized: NormalizedTaskBoardFilters = {};
+  if (filters.status) {
+    normalized.status = filters.status;
+  }
+
+  if (filters.priority) {
+    normalized.priority = filters.priority;
+  }
 
   if (filters.tag) {
     const tags = Array.isArray(filters.tag) ? filters.tag : [filters.tag];
@@ -775,6 +787,15 @@ function normalizeTaskBoardFilters(filters?: TaskBoardQuery): NormalizedTaskBoar
     if (normalizedTags.length > 0) {
       normalized.tag = normalizedTags;
     }
+  }
+  if (filters.q?.trim()) {
+    normalized.q = filters.q.trim();
+  }
+  if (filters.dueFrom) {
+    normalized.dueFrom = filters.dueFrom;
+  }
+  if (filters.dueTo) {
+    normalized.dueTo = filters.dueTo;
   }
 
   return Object.keys(normalized).length ? normalized : undefined;

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1621,13 +1621,81 @@
           "Tasks"
         ],
         "summary": "Retrieve the Kanban board read model",
-        "description": "Returns a board-friendly representation of tasks grouped by status lanes. Requires a valid JWT via `Authorization` header or the `tf_session` cookie.",
+        "description": "Returns a board-friendly representation of tasks grouped by status lanes. Repeating `tag` requires tasks to include every selected tag. Requires a valid JWT via `Authorization` header or the `tf_session` cookie.",
         "security": [
           {
             "bearerAuth": []
           },
           {
             "sessionCookie": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "TODO",
+                "IN_PROGRESS",
+                "DONE"
+              ]
+            },
+            "description": "Filter board tasks by workflow status."
+          },
+          {
+            "name": "priority",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "LOW",
+                "MEDIUM",
+                "HIGH"
+              ]
+            },
+            "description": "Filter board tasks by priority."
+          },
+          {
+            "name": "tag",
+            "in": "query",
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "description": "Filter board tasks that include the specified tag(s). Repeat the parameter to require multiple tags."
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "description": "Case-insensitive search over the title and description."
+          },
+          {
+            "name": "dueFrom",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "description": "Only return board tasks due on or after this ISO timestamp."
+          },
+          {
+            "name": "dueTo",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "description": "Only return board tasks due on or before this ISO timestamp."
           }
         ],
         "responses": {
@@ -1695,6 +1763,31 @@
                       },
                       "updatedAt": "2024-06-03T09:30:00.000Z",
                       "generatedAt": "2024-06-03T09:30:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid query parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "invalidFilters": {
+                    "value": {
+                      "error": "Invalid payload",
+                      "details": {
+                        "fieldErrors": {
+                          "dueFrom": [
+                            "dueFrom must be earlier than or equal to dueTo"
+                          ]
+                        },
+                        "formErrors": []
+                      }
                     }
                   }
                 }

--- a/docs/tasks/milestone4/08-board-filters-and-search.md
+++ b/docs/tasks/milestone4/08-board-filters-and-search.md
@@ -12,7 +12,7 @@
 - [x] Empty states communicate when filters hide all tasks and provide a reset action.
 
 ## Implementation Notes
-- Board filters now share the `/tasks` list semantics for `status`, `priority`, repeated `tag`, `q`, `dueFrom`, and `dueTo` query parameters.
+- Board filters now share the `/tasks` list semantics for `status`, `priority`, repeated `tag`, `q`, `dueFrom`, and `dueTo` query parameters; due range values accept RFC3339 date-time strings, including timezone offsets.
 - The dashboard may also write a UI-only `dueWindow` token for quick selections such as today or the next 7 days; canonical API filtering still uses `dueFrom` and `dueTo`.
 - The dashboard stores the last-used filter combo in `localStorage` when the URL has no explicit query, and reset clears all filter tokens.
 - Filtered empty states distinguish zero matching results from a genuinely empty workspace.

--- a/docs/tasks/milestone4/08-board-filters-and-search.md
+++ b/docs/tasks/milestone4/08-board-filters-and-search.md
@@ -4,12 +4,17 @@
 - Layer quick filters (status, priority, due window, free-text) above the Kanban board so users can focus on relevant work.
 - Persist filter state in the URL/query params for shareable views and deep links.
 
-**Status:** New.
+**Status:** Done.
 
 ## Acceptance Criteria
-- [ ] Filter controls sync with query params (e.g., `?status=IN_PROGRESS&tag=design`) and restore state on refresh.
-- [ ] API honors the same filters server-side so the board only fetches matching tasks.
-- [ ] Empty states communicate when filters hide all tasks and provide a reset action.
+- [x] Filter controls sync with query params (e.g., `?status=IN_PROGRESS&tag=design`) and restore state on refresh.
+- [x] API honors the same filters server-side so the board only fetches matching tasks.
+- [x] Empty states communicate when filters hide all tasks and provide a reset action.
+
+## Implementation Notes
+- Board filters now share the `/tasks` list semantics for `status`, `priority`, repeated `tag`, `q`, `dueFrom`, and `dueTo` query parameters.
+- The dashboard stores the last-used filter combo in `localStorage` when the URL has no explicit query, and reset clears all filter tokens.
+- Filtered empty states distinguish zero matching results from a genuinely empty workspace.
 
 ## Notes
 - Align filter tokens with the `/tasks` list page so both surfaces share the same semantics and DTOs.

--- a/docs/tasks/milestone4/08-board-filters-and-search.md
+++ b/docs/tasks/milestone4/08-board-filters-and-search.md
@@ -13,6 +13,7 @@
 
 ## Implementation Notes
 - Board filters now share the `/tasks` list semantics for `status`, `priority`, repeated `tag`, `q`, `dueFrom`, and `dueTo` query parameters.
+- The dashboard may also write a UI-only `dueWindow` token for quick selections such as today or the next 7 days; canonical API filtering still uses `dueFrom` and `dueTo`.
 - The dashboard stores the last-used filter combo in `localStorage` when the URL has no explicit query, and reset clears all filter tokens.
 - Filtered empty states distinguish zero matching results from a genuinely empty workspace.
 


### PR DESCRIPTION
### Motivation

- Provide quick filtering (status, priority, due window, tags, free-text) atop the Kanban board so users can focus on relevant work and share deep links.  
- Ensure the board respects the same filter semantics as the `/tasks` list by applying filters server-side for consistent read models.  
- Persist filter combos in the URL and `localStorage` to restore state on refresh and improve return visits.

### Description

- API: extended the board route to accept `status`, `priority`, `q`, `dueFrom`, `dueTo`, and `tag` by updating `TaskBoardQuerySchema` and passing parsed values into `getTaskBoard`, including due-range validation (`apps/api/src/routes/tasks.ts`).
- Repository: added `status`, `priority`, `search`, and due-range support to `TaskBoardOptions` and applied the filters in `buildTaskBoard` so Prisma queries respect `status/priority/search/dueFrom/dueTo` in addition to tag filters (`apps/api/src/repositories/task-repository.ts`).
- Client / Hooks: extended `BoardQuerySchema` and `TaskBoardQuery` types and updated `normalizeTaskBoardFilters` so `useTaskBoardQuery` accepts and canonicalizes the new filters for stable query keys and caching (`apps/web/lib/tasks-client.ts`, `apps/web/lib/tasks-hooks.ts`).
- UI: added quick-filter controls to the dashboard (`status` buttons, `priority` chips, due-window dropdown, free-text `search`, tag selector), wired them to `useTasksQuery`/`useTaskBoardQuery`, synced filter state with URL `searchParams` via `router.replace`, persisted last-used combo in `localStorage` under `BOARD_FILTERS_STORAGE_KEY`, and added a filtered-empty-state with a one-click reset (`apps/web/app/(protected)/dashboard/dashboard-content.tsx`).
