### PR TITLE
milestone-4: refresh kanban + tags documentation and QA guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,31 @@ Quick validation command:
 pnpm -C apps/api run lint:http
 ```
 
+
+## Kanban Board + Tag Workflow (Milestone 4)
+
+### Board behavior summary
+- **Board order** enables true manual reordering (same-column + cross-column).
+- **Sorted views** (due date, priority, recently updated) allow status moves across columns but do not allow same-column reorder.
+- In sorted views, the move payload still includes `targetIndex`, but placement is recalculated by the active sort after mutation/refetch.
+
+### Docker and drag/drop notes
+- Use a Chromium-based browser (Chrome/Edge) when validating HTML5 DnD inside Dockerized dev environments.
+- Start containers with `make up`, then open `http://localhost:3000` from the host OS browser (avoid in-container headless validation for tactile drag UX).
+- If drag feels unresponsive, ensure both `web` and `api` containers are healthy via `docker ps` and confirm `NEXT_PUBLIC_API_BASE_URL` points to `http://localhost:4000/api/taskforge`.
+
+### Run the Kanban `.http` pack
+Use the API request pack to validate board + tags quickly:
+```bash
+pnpm -C apps/api run lint:http
+# then run apps/api/tests/kanban.http in your HTTP client
+```
+
+### QA checklists (Milestone 4)
+- Manual: `docs/testing/milestone4-manual-checklist.md`
+- Automated: `docs/testing/milestone4-automated.md`
+- Task sequence + implementation notes: `docs/tasks/milestone4/sequence.md`
+
 ## Continuous Integration
 - The GitHub Actions workflow (`.github/workflows/ci.yml`) provisions a PostgreSQL service, runs `prisma generate`, and applies migrations via `prisma migrate deploy` before executing the Jest suite in `apps/api`.
 - Frontend tests run through `pnpm test` in `apps/web`; the CI job executes that script when present.

--- a/README.md
+++ b/README.md
@@ -153,9 +153,10 @@ pnpm -C apps/api run lint:http
 - **Board order** enables true manual reordering (same-column + cross-column).
 - **Sorted views** (due date, priority, recently updated) allow status moves across columns but do not allow same-column reorder.
 - In sorted views, the move payload still includes `targetIndex`, but placement is recalculated by the active sort after mutation/refetch.
+- Board moves are persisted through `PATCH /api/taskforge/v1/tasks/board/move` with `{ taskId, targetStatus, targetIndex }`.
 
 ### Docker and drag/drop notes
-- Use a Chromium-based browser (Chrome/Edge) when validating HTML5 DnD inside Dockerized dev environments.
+- Use a Chromium-based browser (Chrome/Edge) when validating pointer/keyboard drag interactions inside Dockerized dev environments.
 - Start containers with `make up`, then open `http://localhost:3000` from the host OS browser (avoid in-container headless validation for tactile drag UX).
 - If drag feels unresponsive, ensure both `web` and `api` containers are healthy via `docker ps` and confirm `NEXT_PUBLIC_API_BASE_URL` points to `http://localhost:4000/api/taskforge`.
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -36,22 +36,26 @@
 ## Data Model (Prisma Sketch)
 ```prisma
 model User {
-  id        String   @id @default(cuid())
-  email     String   @unique
-  name      String?
-  image     String?
-  provider  String?
-  createdAt DateTime @default(now())
-  tasks     Task[]
+  id            String   @id @default(uuid()) @db.Uuid
+  email         String   @unique
+  passwordHash  String?
+  name          String?
+  image         String?
+  emailVerified DateTime?
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+  tasks         Task[]
+  tags          Tag[]
 }
 
 model Task {
-  id          String       @id @default(cuid())
-  userId      String
+  id          String       @id @default(uuid()) @db.Uuid
+  userId      String       @db.Uuid
   title       String
   description String?
   status      TaskStatus   @default(TODO)
   priority    TaskPriority @default(MEDIUM)
+  boardOrder  Int          @default(0)
   dueDate     DateTime?
   createdAt   DateTime     @default(now())
   updatedAt   DateTime     @updatedAt
@@ -94,6 +98,8 @@ enum TaskPriority { LOW MEDIUM HIGH }
 - `POST /api/v1/tasks`
 - `PATCH /api/v1/tasks/:id`
 - `DELETE /api/v1/tasks/:id`
+- `GET /api/v1/tasks/board?status=&priority=&tag=&q=&dueFrom=&dueTo=`
+- `PATCH /api/v1/tasks/board/move`
 - `GET /api/v1/tags`
 - `POST /api/v1/tags`
 - Docs: `GET /api/taskforge/docs`
@@ -110,7 +116,7 @@ enum TaskPriority { LOW MEDIUM HIGH }
 ## Milestone 4 — Kanban + Tags (Shipped Behavior)
 
 ### Goals
-- Deliver a board-first workflow where status changes happen in one drag interaction and persist through `/api/taskforge/v1/board/move`.
+- Deliver a board-first workflow where status changes happen in one drag interaction and persist through `PATCH /api/taskforge/v1/tasks/board/move`.
 - Keep tagging lightweight: users can create tags once, reuse them from dialogs/filters, and trust normalization (`trim + lowercase uniqueness`) to avoid duplicates.
 - Preserve fast feedback with optimistic updates while preventing invisible data corruption when mutations fail.
 
@@ -133,17 +139,17 @@ sequenceDiagram
     participant U as User
     participant B as Web Board UI
     participant C as React Query Cache
-    participant A as API (/board/move)
+    participant A as API (/tasks/board/move)
     participant D as DB
 
     U->>B: Drag card to destination lane
     B->>C: onMutate() optimistic lane/index update
     C-->>B: Immediate re-render (<100ms target)
-    B->>A: POST move {taskId,targetStatus,targetIndex}
+    B->>A: PATCH move {taskId,targetStatus,targetIndex}
     A->>D: Persist status + boardOrder
     alt success
       D-->>A: Commit
-      A-->>B: 200 updated task
+      A-->>B: 200 board read model
       B->>C: Invalidate/refetch board + tasks
       C-->>B: Canonical sorted/manual placement
     else failure

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -106,6 +106,59 @@ enum TaskPriority { LOW MEDIUM HIGH }
 - Email: Nodemailer adapter; MailHog dev; free SMTP prod.
 - Monorepo rationale: shared types, unified tooling, single CI.
 
+
+## Milestone 4 — Kanban + Tags (Shipped Behavior)
+
+### Goals
+- Deliver a board-first workflow where status changes happen in one drag interaction and persist through `/api/taskforge/v1/board/move`.
+- Keep tagging lightweight: users can create tags once, reuse them from dialogs/filters, and trust normalization (`trim + lowercase uniqueness`) to avoid duplicates.
+- Preserve fast feedback with optimistic updates while preventing invisible data corruption when mutations fail.
+
+### Success Metrics
+- **Interaction speed:** median drag-to-visual-update under 100 ms on local/dev environments (optimistic move visible immediately after drop).
+- **Reliability:** board and list views reconverge within one refetch cycle after every successful move mutation.
+- **Recovery quality:** failed optimistic moves rollback cleanly and show actionable feedback (toast + restored card position).
+- **Tag quality:** no duplicate labels per user (`@@unique([userId, label])` enforced in schema + API conflict handling).
+
+### UX Notes (mirrors implementation)
+- **Manual Board Order mode:** same-column reorder and cross-column placement are both enabled; drop indicators show exact insertion points.
+- **Sorted modes (Due date / Priority / Updated):** same-column reorder is intentionally disabled; cross-column drops only change status from the user perspective.
+- **Hidden index behavior in sorted modes:** client sends deterministic `targetIndex` (end of destination lane) while rendered position is recalculated by active sort after mutation/refetch.
+- **Drop affordance:** sorted modes highlight the entire destination column, not a line-level insertion marker.
+- **Helper copy:** users are told to switch to Board order for explicit manual ordering.
+
+### Drag + Optimistic Update Lifecycle
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant B as Web Board UI
+    participant C as React Query Cache
+    participant A as API (/board/move)
+    participant D as DB
+
+    U->>B: Drag card to destination lane
+    B->>C: onMutate() optimistic lane/index update
+    C-->>B: Immediate re-render (<100ms target)
+    B->>A: POST move {taskId,targetStatus,targetIndex}
+    A->>D: Persist status + boardOrder
+    alt success
+      D-->>A: Commit
+      A-->>B: 200 updated task
+      B->>C: Invalidate/refetch board + tasks
+      C-->>B: Canonical sorted/manual placement
+    else failure
+      D-->>A: Error/conflict
+      A-->>B: 4xx/5xx
+      B->>C: Rollback previous snapshot
+      B-->>U: Error toast + original position restored
+    end
+```
+
+### QA References (Milestone 4)
+- Manual checklist: `docs/testing/milestone4-manual-checklist.md`
+- Automated/API checks: `docs/testing/milestone4-automated.md`
+- HTTP pack: `apps/api/tests/kanban.http`
+
 ## Milestones (7 days)
 - **Day 1:** Monorepo setup, Tailwind + shadcn/ui, Express + Prisma scaffold, Dockerfiles, compose, CI skeleton.
 - **Day 2:** Frontend OAuth (GitHub/Google) with NextAuth, guarded routes, session UI, and the `/auth/session-bridge` flow to mint API cookies.

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -92,16 +92,16 @@ enum TaskPriority { LOW MEDIUM HIGH }
 ```
 
 ## API (v1)
-- `GET /api/v1/health`
-- `GET /api/v1/me`
-- `GET /api/v1/tasks?status=&priority=&tag=&q=&dueFrom=&dueTo=&page=&pageSize=`
-- `POST /api/v1/tasks`
-- `PATCH /api/v1/tasks/:id`
-- `DELETE /api/v1/tasks/:id`
-- `GET /api/v1/tasks/board?status=&priority=&tag=&q=&dueFrom=&dueTo=`
-- `PATCH /api/v1/tasks/board/move`
-- `GET /api/v1/tags`
-- `POST /api/v1/tags`
+- `GET /api/taskforge/v1/health`
+- `GET /api/taskforge/v1/me`
+- `GET /api/taskforge/v1/tasks?status=&priority=&tag=&q=&dueFrom=&dueTo=&page=&pageSize=`
+- `POST /api/taskforge/v1/tasks`
+- `PATCH /api/taskforge/v1/tasks/:id`
+- `DELETE /api/taskforge/v1/tasks/:id`
+- `GET /api/taskforge/v1/tasks/board?status=&priority=&tag=&q=&dueFrom=&dueTo=`
+- `PATCH /api/taskforge/v1/tasks/board/move`
+- `GET /api/taskforge/v1/tags`
+- `POST /api/taskforge/v1/tags`
 - Docs: `GET /api/taskforge/docs`
 - OpenAPI reference: [`docs/openapi.json`](./openapi.json)
 

--- a/docs/adr/0005-kanban-tag-ordering-and-optimistic-updates.md
+++ b/docs/adr/0005-kanban-tag-ordering-and-optimistic-updates.md
@@ -1,0 +1,27 @@
+# ADR 0005 — Kanban Ordering, Tag Strategy, and Optimistic Move Semantics
+
+**Status:** Accepted
+
+## Context
+Milestone 4 introduced the board endpoint surface, drag-and-drop UX, and reusable tags. We needed one documented policy that aligns product behavior, API payloads, and QA expectations, especially for sorted views where visible order is derived and not fully user-controlled.
+
+## Decision
+1. **Single move payload remains stable**: keep `{ taskId, targetStatus, targetIndex }` for both manual and sorted board modes.
+2. **Two interaction modes**:
+   - **Board order (manual):** same-column reorder + cross-column placement are enabled and persisted.
+   - **Derived sort modes:** same-column reorder is disabled; cross-column drag updates status only from the user’s perspective.
+3. **Deterministic hidden index in sorted mode**: cross-column moves in sorted views submit an end-of-lane `targetIndex`; the card is then rendered by the active sort after mutation/refetch.
+4. **Optimistic first, safe rollback**: UI applies immediate optimistic cache changes, then rolls back on error and shows feedback.
+5. **Tag strategy**: tags are user-scoped, unique by normalized label, and reused across task dialogs and filters to prevent taxonomy drift.
+
+## Consequences
+- UX is predictable: manual mode communicates precise ordering control, while sorted mode communicates status-only movement.
+- API remains simple and backwards-compatible for clients and `.http` regression packs.
+- QA can assert deterministic behavior across modes using one checklist + one move contract.
+- Ordering and tag behavior now have a durable architectural record tied to Milestone 4.
+
+## Related docs
+- `docs/tasks/milestone4/05-sorted-board-drag-rules.md`
+- `docs/tasks/milestone4/04-kanban-optimistic-updates.md`
+- `docs/tasks/milestone4/06-tag-schema-and-api.md`
+- `apps/api/tests/kanban.http`

--- a/docs/adr/0005-kanban-tag-ordering-and-optimistic-updates.md
+++ b/docs/adr/0005-kanban-tag-ordering-and-optimistic-updates.md
@@ -6,7 +6,7 @@
 Milestone 4 introduced the board endpoint surface, drag-and-drop UX, and reusable tags. We needed one documented policy that aligns product behavior, API payloads, and QA expectations, especially for sorted views where visible order is derived and not fully user-controlled.
 
 ## Decision
-1. **Single move payload remains stable**: keep `{ taskId, targetStatus, targetIndex }` for both manual and sorted board modes.
+1. **Single move endpoint and payload remain stable**: keep `PATCH /api/taskforge/v1/tasks/board/move` with `{ taskId, targetStatus, targetIndex }` for both manual and sorted board modes.
 2. **Two interaction modes**:
    - **Board order (manual):** same-column reorder + cross-column placement are enabled and persisted.
    - **Derived sort modes:** same-column reorder is disabled; cross-column drag updates status only from the user’s perspective.

--- a/docs/tasks/milestone4/10-kanban-docs.md
+++ b/docs/tasks/milestone4/10-kanban-docs.md
@@ -4,13 +4,13 @@
 - Refresh PRD/README to describe the Kanban experience, tag strategy, and optimistic update behavior.
 - Add diagrams or screenshots that help stakeholders understand the new flows.
 
-**Status:** New.
+**Status:** Done.
 
 ## Acceptance Criteria
-- [ ] PRD includes Kanban goals, success metrics, and UX notes that mirror the shipped implementation.
-- [ ] README gains setup/testing instructions for the board (e.g., enabling drag/drop in Docker, running the `.http` pack).
-- [ ] Any new decisions about tags/board ordering are captured in an ADR amendment or a new ADR, including the sorted-view drag behavior from `05-sorted-board-drag-rules.md`.
+- [x] PRD includes Kanban goals, success metrics, and UX notes that mirror the shipped implementation.
+- [x] README gains setup/testing instructions for the board (e.g., enabling drag/drop in Docker, running the `.http` pack).
+- [x] Any new decisions about tags/board ordering are captured in an ADR amendment or a new ADR, including the sorted-view drag behavior from `05-sorted-board-drag-rules.md`.
 
 ## Notes
-- Link to the manual/automated test checklists so QA can validate Milestone 4 quickly.
-- Consider embedding a lightweight mermaid sequence diagram for drag/drop + optimistic update lifecycle.
+- Linked the manual/automated test checklists so QA can validate Milestone 4 quickly.
+- Embedded a lightweight mermaid sequence diagram for drag/drop + optimistic update lifecycle.

--- a/docs/testing/milestone4-automated.md
+++ b/docs/testing/milestone4-automated.md
@@ -1,0 +1,16 @@
+# Milestone 4 Automated Checks — Kanban and Tags
+
+## API / contract checks
+- `apps/api/tests/kanban.http` covers board fetch, move mutation, and tag endpoints.
+- Jest/Supertest coverage for board move and tag constraints should pass in CI.
+
+## Recommended local commands
+```bash
+pnpm -C apps/api test
+pnpm -C apps/api run lint:http
+```
+
+## Focus assertions
+- Move contract stays `{ taskId, targetStatus, targetIndex }`.
+- Sorted-view moves remain deterministic via hidden end-of-lane index.
+- Tag uniqueness/ownership constraints are enforced server-side.

--- a/docs/testing/milestone4-automated.md
+++ b/docs/testing/milestone4-automated.md
@@ -6,6 +6,7 @@
 
 ## Recommended local commands
 ```bash
+pnpm lint
 pnpm -C apps/api test
 pnpm -C apps/api run lint:http
 ```

--- a/docs/testing/milestone4-manual-checklist.md
+++ b/docs/testing/milestone4-manual-checklist.md
@@ -1,0 +1,28 @@
+# Milestone 4 Manual Checklist — Kanban, Tags, Optimistic Moves
+
+## Preconditions
+- `make up` is running and both `api` + `web` containers are healthy.
+- Seed or create at least 5 tasks spanning TODO / IN_PROGRESS / DONE.
+- Create at least 3 tags and assign overlapping tags to tasks.
+
+## Board order mode
+- [ ] Drag within same column changes visible order and persists after refresh.
+- [ ] Cross-column drag updates status and keeps dropped insertion position.
+- [ ] Keyboard/screen-reader messaging uses reorder language in this mode.
+
+## Sorted views mode
+- [ ] Switch sort to Due date (or Priority/Updated).
+- [ ] Same-column drag is blocked/disabled.
+- [ ] Cross-column drag succeeds as a status move.
+- [ ] Card final position follows active sort after mutation/refetch (not exact drop slot).
+- [ ] Destination column-level highlight is shown instead of insertion-line marker.
+
+## Optimistic + rollback behavior
+- [ ] Successful drag updates UI immediately before network response completes.
+- [ ] Simulated failure (invalid token / forced API error) restores prior card position.
+- [ ] Error toast/message appears and user can retry move.
+
+## Tags + filtering
+- [ ] Creating a new tag makes it available in task dialogs and filters.
+- [ ] Duplicate label variants (spacing/case) are rejected or normalized consistently.
+- [ ] Filtering by tag narrows board/list to matching tasks only.


### PR DESCRIPTION
### Motivation
- Capture and align the shipped Kanban experience (manual vs sorted modes), tag normalization strategy, and optimistic-update lifecycle in product docs so engineering, QA, and product share a single source of truth. 
- Provide practical setup and validation guidance for the board (Docker drag/drop tips and `.http` usage) so QA can exercise Milestone 4 quickly and reproducibly. 
- Record a durable architectural decision covering move payload semantics, sorted-view behavior, and tag uniqueness to avoid future drift. 

### Description
- Added a `Milestone 4 — Kanban + Tags` section to `docs/PRD.md` that includes goals, success metrics, UX notes, and a Mermaid sequence diagram for the drag + optimistic update lifecycle. 
- Updated `README.md` with Kanban board guidance, Docker/drag-drop validation tips, and instructions for running the Kanban `.http` pack. 
- Introduced ADR `docs/adr/0005-kanban-tag-ordering-and-optimistic-updates.md` that documents the move contract (`{ taskId, targetStatus, targetIndex }`), sorted vs manual modes, deterministic hidden index behavior, optimistic rollback expectations, and tag normalization policy. 
- Added QA artifacts `docs/testing/milestone4-manual-checklist.md` and `docs/testing/milestone4-automated.md` and referenced the existing `apps/api/tests/kanban.http` HTTP pack for automated contract checks. 

### Testing
- Ran `pnpm -C apps/api run lint:http`, which executed the HTTP lint/validation and completed successfully (validated 3 HTTP files).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04c81acfe08322b6efcfe72acd6d27)