### PR TITLE
milestone-5: daily digest query service

### DIFF
--- a/apps/api/prisma/migrations/20260519120000_add_daily_digest_timezone/migration.sql
+++ b/apps/api/prisma/migrations/20260519120000_add_daily_digest_timezone/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "EmailPreference"
+ADD COLUMN "dailyDigestTimezone" TEXT NOT NULL DEFAULT 'UTC';

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -119,6 +119,7 @@ model EmailPreference {
   welcomeEmailEnabled Boolean  @default(true)
   dailyDigestEnabled  Boolean  @default(false)
   dailyDigestHourUtc  Int?
+  dailyDigestTimezone String   @default("UTC")
   createdAt           DateTime @default(now())
   updatedAt           DateTime @updatedAt
   user                User     @relation(fields: [userId], references: [id], onDelete: Cascade)

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -31,12 +31,14 @@ async function main() {
       welcomeEmailEnabled: true,
       dailyDigestEnabled: false,
       dailyDigestHourUtc: null,
+      dailyDigestTimezone: 'UTC',
     },
     create: {
       userId: demoUser.id,
       welcomeEmailEnabled: true,
       dailyDigestEnabled: false,
       dailyDigestHourUtc: null,
+      dailyDigestTimezone: 'UTC',
     },
   });
 }

--- a/apps/api/src/notifications/digest-query-service.ts
+++ b/apps/api/src/notifications/digest-query-service.ts
@@ -2,8 +2,6 @@ import type { PrismaClient, TaskStatus } from '@prisma/client';
 
 import { taskWithTagsInclude, toTaskBoardItemDTO } from '../repositories/task-mapper';
 
-const MS_PER_DAY = 24 * 60 * 60 * 1000;
-
 export interface DailyDigestTaskSummary {
   id: string;
   title: string;
@@ -143,13 +141,19 @@ export function computeUtcWindowBoundaries(
 } {
   const localDate = toLocalDateParts(now, timezone);
   const startOfTodayUtc = localMidnightToUtc(localDate.year, localDate.month, localDate.day, timezone);
-  const startOfTomorrowUtc = new Date(startOfTodayUtc.getTime() + MS_PER_DAY);
+  const startOfTomorrowUtc = localMidnightToUtc(localDate.year, localDate.month, localDate.day + 1, timezone);
+  const dueSoonUntilUtc = localMidnightToUtc(
+    localDate.year,
+    localDate.month,
+    localDate.day + 1 + dueSoonDays,
+    timezone,
+  );
 
   return {
     startOfTodayUtc,
     startOfTomorrowUtc,
-    dueSoonUntilUtc: new Date(startOfTomorrowUtc.getTime() + dueSoonDays * MS_PER_DAY),
-    recentlyUpdatedSinceUtc: new Date(now.getTime() - recentlyUpdatedDays * MS_PER_DAY),
+    dueSoonUntilUtc,
+    recentlyUpdatedSinceUtc: addUtcDays(now, -recentlyUpdatedDays),
   };
 }
 
@@ -189,11 +193,21 @@ function localMidnightToUtc(year: number, month: number, day: number, timezone: 
   const tzYear = Number(partsInTz.find(part => part.type === 'year')?.value);
   const tzMonth = Number(partsInTz.find(part => part.type === 'month')?.value);
   const tzDay = Number(partsInTz.find(part => part.type === 'day')?.value);
-  const tzHour = Number(partsInTz.find(part => part.type === 'hour')?.value);
+  const tzHour = normalizeIntlHour(Number(partsInTz.find(part => part.type === 'hour')?.value));
   const tzMinute = Number(partsInTz.find(part => part.type === 'minute')?.value);
   const tzSecond = Number(partsInTz.find(part => part.type === 'second')?.value);
 
   const asUtcFromTzView = Date.UTC(tzYear, tzMonth - 1, tzDay, tzHour, tzMinute, tzSecond);
   const offsetMs = asUtcFromTzView - utcGuess.getTime();
   return new Date(utcGuess.getTime() - offsetMs);
+}
+
+function normalizeIntlHour(hour: number): number {
+  return hour === 24 ? 0 : hour;
+}
+
+function addUtcDays(date: Date, days: number): Date {
+  const next = new Date(date);
+  next.setUTCDate(next.getUTCDate() + days);
+  return next;
 }

--- a/apps/api/src/notifications/digest-query-service.ts
+++ b/apps/api/src/notifications/digest-query-service.ts
@@ -1,4 +1,4 @@
-import type { PrismaClient, TaskStatus } from '@prisma/client';
+import type { Prisma, PrismaClient, TaskStatus } from '@prisma/client';
 
 import { taskWithTagsInclude, toTaskBoardItemDTO } from '../repositories/task-mapper';
 
@@ -51,11 +51,25 @@ export class DailyDigestQueryService {
     const maxTasksPerGroup = Math.max(1, options.maxTasksPerGroup ?? 10);
 
     const boundaries = computeUtcWindowBoundaries(now, timezone, dueSoonDays, recentlyUpdatedDays);
+    const where: Prisma.TaskWhereInput = {
+      userId,
+      OR: [
+        {
+          status: { not: 'DONE' },
+          dueDate: { lt: boundaries.dueSoonUntilUtc },
+        },
+        {
+          status: { not: 'DONE' },
+          updatedAt: { gte: boundaries.recentlyUpdatedSinceUtc },
+        },
+        {
+          status: 'TODO',
+        },
+      ],
+    };
 
     const tasks = await this.prisma.task.findMany({
-      where: {
-        userId,
-      },
+      where,
       include: taskWithTagsInclude,
       orderBy: [{ dueDate: 'asc' }, { updatedAt: 'desc' }, { createdAt: 'desc' }, { id: 'asc' }],
     });
@@ -73,29 +87,36 @@ export class DailyDigestQueryService {
       } satisfies DailyDigestTaskSummary;
     });
 
-    const overdue = taskSummaries.filter(task =>
-      Boolean(task.dueDate) && new Date(task.dueDate as string) < boundaries.startOfTodayUtc && task.status !== 'DONE');
+    const overdue = taskSummaries
+      .filter(task =>
+        Boolean(task.dueDate) && new Date(task.dueDate as string) < boundaries.startOfTodayUtc && task.status !== 'DONE')
+      .sort(compareDueDigestTasks);
 
-    const dueToday = taskSummaries.filter(task => {
-      if (!task.dueDate || task.status === 'DONE') {
-        return false;
-      }
-      const due = new Date(task.dueDate);
-      return due >= boundaries.startOfTodayUtc && due < boundaries.startOfTomorrowUtc;
-    });
+    const dueToday = taskSummaries
+      .filter(task => {
+        if (!task.dueDate || task.status === 'DONE') {
+          return false;
+        }
+        const due = new Date(task.dueDate);
+        return due >= boundaries.startOfTodayUtc && due < boundaries.startOfTomorrowUtc;
+      })
+      .sort(compareDueDigestTasks);
 
-    const dueSoon = taskSummaries.filter(task => {
-      if (!task.dueDate || task.status === 'DONE') {
-        return false;
-      }
-      const due = new Date(task.dueDate);
-      return due >= boundaries.startOfTomorrowUtc && due < boundaries.dueSoonUntilUtc;
-    });
+    const dueSoon = taskSummaries
+      .filter(task => {
+        if (!task.dueDate || task.status === 'DONE') {
+          return false;
+        }
+        const due = new Date(task.dueDate);
+        return due >= boundaries.startOfTomorrowUtc && due < boundaries.dueSoonUntilUtc;
+      })
+      .sort(compareDueDigestTasks);
 
-    const recentlyUpdated = taskSummaries.filter(task =>
-      new Date(task.updatedAt) >= boundaries.recentlyUpdatedSinceUtc && task.status !== 'DONE');
+    const recentlyUpdated = taskSummaries
+      .filter(task => new Date(task.updatedAt) >= boundaries.recentlyUpdatedSinceUtc && task.status !== 'DONE')
+      .sort(compareUpdatedDigestTasks);
 
-    const blockedByStatus = taskSummaries.filter(task => task.status === 'TODO');
+    const blockedByStatus = taskSummaries.filter(task => task.status === 'TODO').sort(compareBlockedDigestTasks);
 
     return {
       generatedAt: now.toISOString(),
@@ -126,6 +147,60 @@ export class DailyDigestQueryService {
       ],
     };
   }
+}
+
+const priorityRank: Record<DailyDigestTaskSummary['priority'], number> = {
+  HIGH: 0,
+  MEDIUM: 1,
+  LOW: 2,
+};
+
+function compareDueDigestTasks(left: DailyDigestTaskSummary, right: DailyDigestTaskSummary): number {
+  const leftDue = left.dueDate ? Date.parse(left.dueDate) : Number.POSITIVE_INFINITY;
+  const rightDue = right.dueDate ? Date.parse(right.dueDate) : Number.POSITIVE_INFINITY;
+  const dueDelta = leftDue - rightDue;
+  if (dueDelta !== 0) {
+    return dueDelta;
+  }
+
+  return comparePriorityThenUpdatedThenTitle(left, right);
+}
+
+function compareUpdatedDigestTasks(left: DailyDigestTaskSummary, right: DailyDigestTaskSummary): number {
+  const updatedDelta = Date.parse(right.updatedAt) - Date.parse(left.updatedAt);
+  if (updatedDelta !== 0) {
+    return updatedDelta;
+  }
+
+  return compareDueDigestTasks(left, right);
+}
+
+function compareBlockedDigestTasks(left: DailyDigestTaskSummary, right: DailyDigestTaskSummary): number {
+  const priorityDelta = priorityRank[left.priority] - priorityRank[right.priority];
+  if (priorityDelta !== 0) {
+    return priorityDelta;
+  }
+
+  return compareDueDigestTasks(left, right);
+}
+
+function comparePriorityThenUpdatedThenTitle(left: DailyDigestTaskSummary, right: DailyDigestTaskSummary): number {
+  const priorityDelta = priorityRank[left.priority] - priorityRank[right.priority];
+  if (priorityDelta !== 0) {
+    return priorityDelta;
+  }
+
+  const updatedDelta = Date.parse(right.updatedAt) - Date.parse(left.updatedAt);
+  if (updatedDelta !== 0) {
+    return updatedDelta;
+  }
+
+  const titleDelta = left.title.localeCompare(right.title, undefined, { sensitivity: 'base' });
+  if (titleDelta !== 0) {
+    return titleDelta;
+  }
+
+  return left.id.localeCompare(right.id);
 }
 
 export function computeUtcWindowBoundaries(

--- a/apps/api/src/notifications/digest-query-service.ts
+++ b/apps/api/src/notifications/digest-query-service.ts
@@ -1,0 +1,199 @@
+import type { PrismaClient, TaskStatus } from '@prisma/client';
+
+import { taskWithTagsInclude, toTaskBoardItemDTO } from '../repositories/task-mapper';
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export interface DailyDigestTaskSummary {
+  id: string;
+  title: string;
+  status: TaskStatus;
+  priority: 'LOW' | 'MEDIUM' | 'HIGH';
+  dueDate?: string;
+  updatedAt: string;
+  tags: string[];
+}
+
+export interface DailyDigestGroup {
+  key: 'overdue' | 'dueToday' | 'dueSoon' | 'recentlyUpdated' | 'blockedByStatus';
+  label: string;
+  total: number;
+  tasks: DailyDigestTaskSummary[];
+}
+
+export interface DailyDigestQueryResult {
+  generatedAt: string;
+  timezone: string;
+  window: {
+    startOfTodayUtc: string;
+    startOfTomorrowUtc: string;
+    dueSoonUntilUtc: string;
+    recentlyUpdatedSinceUtc: string;
+  };
+  totalTasksConsidered: number;
+  groups: DailyDigestGroup[];
+}
+
+export interface DailyDigestQueryOptions {
+  now?: Date;
+  timezone?: string;
+  dueSoonDays?: number;
+  recentlyUpdatedDays?: number;
+  maxTasksPerGroup?: number;
+}
+
+export class DailyDigestQueryService {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async queryForUser(userId: string, options: DailyDigestQueryOptions = {}): Promise<DailyDigestQueryResult> {
+    const now = options.now ?? new Date();
+    const timezone = options.timezone ?? 'UTC';
+    const dueSoonDays = Math.max(1, options.dueSoonDays ?? 7);
+    const recentlyUpdatedDays = Math.max(1, options.recentlyUpdatedDays ?? 2);
+    const maxTasksPerGroup = Math.max(1, options.maxTasksPerGroup ?? 10);
+
+    const boundaries = computeUtcWindowBoundaries(now, timezone, dueSoonDays, recentlyUpdatedDays);
+
+    const tasks = await this.prisma.task.findMany({
+      where: {
+        userId,
+      },
+      include: taskWithTagsInclude,
+      orderBy: [{ dueDate: 'asc' }, { updatedAt: 'desc' }, { createdAt: 'desc' }, { id: 'asc' }],
+    });
+
+    const taskSummaries = tasks.map(task => {
+      const boardItem = toTaskBoardItemDTO(task);
+      return {
+        id: boardItem.id,
+        title: boardItem.title,
+        status: boardItem.status as TaskStatus,
+        priority: boardItem.priority,
+        dueDate: boardItem.dueDate,
+        updatedAt: boardItem.updatedAt,
+        tags: boardItem.tags,
+      } satisfies DailyDigestTaskSummary;
+    });
+
+    const overdue = taskSummaries.filter(task =>
+      Boolean(task.dueDate) && new Date(task.dueDate as string) < boundaries.startOfTodayUtc && task.status !== 'DONE');
+
+    const dueToday = taskSummaries.filter(task => {
+      if (!task.dueDate || task.status === 'DONE') {
+        return false;
+      }
+      const due = new Date(task.dueDate);
+      return due >= boundaries.startOfTodayUtc && due < boundaries.startOfTomorrowUtc;
+    });
+
+    const dueSoon = taskSummaries.filter(task => {
+      if (!task.dueDate || task.status === 'DONE') {
+        return false;
+      }
+      const due = new Date(task.dueDate);
+      return due >= boundaries.startOfTomorrowUtc && due < boundaries.dueSoonUntilUtc;
+    });
+
+    const recentlyUpdated = taskSummaries.filter(task =>
+      new Date(task.updatedAt) >= boundaries.recentlyUpdatedSinceUtc && task.status !== 'DONE');
+
+    const blockedByStatus = taskSummaries.filter(task => task.status === 'TODO');
+
+    return {
+      generatedAt: now.toISOString(),
+      timezone,
+      window: {
+        startOfTodayUtc: boundaries.startOfTodayUtc.toISOString(),
+        startOfTomorrowUtc: boundaries.startOfTomorrowUtc.toISOString(),
+        dueSoonUntilUtc: boundaries.dueSoonUntilUtc.toISOString(),
+        recentlyUpdatedSinceUtc: boundaries.recentlyUpdatedSinceUtc.toISOString(),
+      },
+      totalTasksConsidered: taskSummaries.length,
+      groups: [
+        { key: 'overdue', label: 'Overdue', total: overdue.length, tasks: overdue.slice(0, maxTasksPerGroup) },
+        { key: 'dueToday', label: 'Due today', total: dueToday.length, tasks: dueToday.slice(0, maxTasksPerGroup) },
+        { key: 'dueSoon', label: 'Due soon', total: dueSoon.length, tasks: dueSoon.slice(0, maxTasksPerGroup) },
+        {
+          key: 'recentlyUpdated',
+          label: 'Recently updated',
+          total: recentlyUpdated.length,
+          tasks: recentlyUpdated.slice(0, maxTasksPerGroup),
+        },
+        {
+          key: 'blockedByStatus',
+          label: 'Still todo',
+          total: blockedByStatus.length,
+          tasks: blockedByStatus.slice(0, maxTasksPerGroup),
+        },
+      ],
+    };
+  }
+}
+
+export function computeUtcWindowBoundaries(
+  now: Date,
+  timezone: string,
+  dueSoonDays: number,
+  recentlyUpdatedDays: number,
+): {
+  startOfTodayUtc: Date;
+  startOfTomorrowUtc: Date;
+  dueSoonUntilUtc: Date;
+  recentlyUpdatedSinceUtc: Date;
+} {
+  const localDate = toLocalDateParts(now, timezone);
+  const startOfTodayUtc = localMidnightToUtc(localDate.year, localDate.month, localDate.day, timezone);
+  const startOfTomorrowUtc = new Date(startOfTodayUtc.getTime() + MS_PER_DAY);
+
+  return {
+    startOfTodayUtc,
+    startOfTomorrowUtc,
+    dueSoonUntilUtc: new Date(startOfTomorrowUtc.getTime() + dueSoonDays * MS_PER_DAY),
+    recentlyUpdatedSinceUtc: new Date(now.getTime() - recentlyUpdatedDays * MS_PER_DAY),
+  };
+}
+
+function toLocalDateParts(date: Date, timezone: string): { year: number; month: number; day: number } {
+  const formatter = new Intl.DateTimeFormat('en-CA', {
+    timeZone: timezone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+
+  const parts = formatter.formatToParts(date);
+  const year = Number(parts.find(part => part.type === 'year')?.value);
+  const month = Number(parts.find(part => part.type === 'month')?.value);
+  const day = Number(parts.find(part => part.type === 'day')?.value);
+
+  if (!year || !month || !day) {
+    throw new Error(`Unable to compute local date parts for timezone ${timezone}`);
+  }
+
+  return { year, month, day };
+}
+
+function localMidnightToUtc(year: number, month: number, day: number, timezone: string): Date {
+  const utcGuess = new Date(Date.UTC(year, month - 1, day, 0, 0, 0));
+  const partsInTz = new Intl.DateTimeFormat('en-US', {
+    timeZone: timezone,
+    hour12: false,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  }).formatToParts(utcGuess);
+
+  const tzYear = Number(partsInTz.find(part => part.type === 'year')?.value);
+  const tzMonth = Number(partsInTz.find(part => part.type === 'month')?.value);
+  const tzDay = Number(partsInTz.find(part => part.type === 'day')?.value);
+  const tzHour = Number(partsInTz.find(part => part.type === 'hour')?.value);
+  const tzMinute = Number(partsInTz.find(part => part.type === 'minute')?.value);
+  const tzSecond = Number(partsInTz.find(part => part.type === 'second')?.value);
+
+  const asUtcFromTzView = Date.UTC(tzYear, tzMonth - 1, tzDay, tzHour, tzMinute, tzSecond);
+  const offsetMs = asUtcFromTzView - utcGuess.getTime();
+  return new Date(utcGuess.getTime() - offsetMs);
+}

--- a/apps/api/src/notifications/digest-query-service.ts
+++ b/apps/api/src/notifications/digest-query-service.ts
@@ -262,7 +262,24 @@ function toLocalDateParts(date: Date, timezone: string): { year: number; month: 
 }
 
 function localMidnightToUtc(year: number, month: number, day: number, timezone: string): Date {
-  const utcGuess = new Date(Date.UTC(year, month - 1, day, 0, 0, 0));
+  const targetWallTimeUtc = Date.UTC(year, month - 1, day, 0, 0, 0);
+  let candidate = new Date(targetWallTimeUtc);
+
+  for (let attempts = 0; attempts < 4; attempts += 1) {
+    const offsetMs = getTimeZoneOffsetMs(candidate, timezone);
+    const next = new Date(targetWallTimeUtc - offsetMs);
+
+    if (next.getTime() === candidate.getTime()) {
+      return next;
+    }
+
+    candidate = next;
+  }
+
+  return candidate;
+}
+
+function getTimeZoneOffsetMs(date: Date, timezone: string): number {
   const partsInTz = new Intl.DateTimeFormat('en-US', {
     timeZone: timezone,
     hour12: false,
@@ -272,7 +289,7 @@ function localMidnightToUtc(year: number, month: number, day: number, timezone: 
     hour: '2-digit',
     minute: '2-digit',
     second: '2-digit',
-  }).formatToParts(utcGuess);
+  }).formatToParts(date);
 
   const tzYear = Number(partsInTz.find(part => part.type === 'year')?.value);
   const tzMonth = Number(partsInTz.find(part => part.type === 'month')?.value);
@@ -282,8 +299,7 @@ function localMidnightToUtc(year: number, month: number, day: number, timezone: 
   const tzSecond = Number(partsInTz.find(part => part.type === 'second')?.value);
 
   const asUtcFromTzView = Date.UTC(tzYear, tzMonth - 1, tzDay, tzHour, tzMinute, tzSecond);
-  const offsetMs = asUtcFromTzView - utcGuess.getTime();
-  return new Date(utcGuess.getTime() - offsetMs);
+  return asUtcFromTzView - date.getTime();
 }
 
 function normalizeIntlHour(hour: number): number {

--- a/apps/api/src/notifications/digest-query-service.ts
+++ b/apps/api/src/notifications/digest-query-service.ts
@@ -45,7 +45,7 @@ export class DailyDigestQueryService {
 
   async queryForUser(userId: string, options: DailyDigestQueryOptions = {}): Promise<DailyDigestQueryResult> {
     const now = options.now ?? new Date();
-    const timezone = options.timezone ?? 'UTC';
+    const timezone = options.timezone ?? (await this.resolveUserTimezone(userId));
     const dueSoonDays = Math.max(1, options.dueSoonDays ?? 7);
     const recentlyUpdatedDays = Math.max(1, options.recentlyUpdatedDays ?? 2);
     const maxTasksPerGroup = Math.max(1, options.maxTasksPerGroup ?? 10);
@@ -146,6 +146,15 @@ export class DailyDigestQueryService {
         },
       ],
     };
+  }
+
+  private async resolveUserTimezone(userId: string): Promise<string> {
+    const preference = await this.prisma.emailPreference.findUnique({
+      where: { userId },
+      select: { dailyDigestTimezone: true },
+    });
+
+    return preference?.dailyDigestTimezone ?? 'UTC';
   }
 }
 

--- a/apps/api/tests/digest-query-service.test.ts
+++ b/apps/api/tests/digest-query-service.test.ts
@@ -114,6 +114,27 @@ describe('DailyDigestQueryService', () => {
     }
   });
 
+  it('uses the stored digest timezone when no override is provided', async () => {
+    const findMany = jest.fn().mockResolvedValue([]);
+    const findUnique = jest.fn().mockResolvedValue({ dailyDigestTimezone: 'America/New_York' });
+    const prisma = {
+      task: { findMany },
+      emailPreference: { findUnique },
+    } as unknown as PrismaClient;
+    const service = new DailyDigestQueryService(prisma);
+
+    const digest = await service.queryForUser('user-1', {
+      now: new Date('2026-05-19T12:00:00.000Z'),
+    });
+
+    expect(findUnique).toHaveBeenCalledWith({
+      where: { userId: 'user-1' },
+      select: { dailyDigestTimezone: true },
+    });
+    expect(digest.timezone).toBe('America/New_York');
+    expect(digest.window.startOfTodayUtc).toBe('2026-05-19T04:00:00.000Z');
+  });
+
   it('computes timezone-aware daily boundaries', () => {
     const windows = computeUtcWindowBoundaries(
       new Date('2026-05-19T03:30:00.000Z'),

--- a/apps/api/tests/digest-query-service.test.ts
+++ b/apps/api/tests/digest-query-service.test.ts
@@ -1,0 +1,109 @@
+import type { PrismaClient } from '@prisma/client';
+
+import { DailyDigestQueryService, computeUtcWindowBoundaries } from '../src/notifications/digest-query-service';
+
+function createTask(params: {
+  id: string;
+  userId?: string;
+  title: string;
+  status: 'TODO' | 'IN_PROGRESS' | 'DONE';
+  priority?: 'LOW' | 'MEDIUM' | 'HIGH';
+  dueDate?: string;
+  updatedAt?: string;
+  boardOrder?: number;
+  tags?: string[];
+}) {
+  return {
+    id: params.id,
+    userId: params.userId ?? 'user-1',
+    title: params.title,
+    description: null,
+    status: params.status,
+    priority: params.priority ?? 'MEDIUM',
+    boardOrder: params.boardOrder ?? 0,
+    dueDate: params.dueDate ? new Date(params.dueDate) : null,
+    createdAt: new Date('2026-05-01T00:00:00.000Z'),
+    updatedAt: new Date(params.updatedAt ?? '2026-05-19T10:00:00.000Z'),
+    TaskTag: (params.tags ?? []).map((label, index) => ({
+      taskId: params.id,
+      tagId: `tag-${index}`,
+      userId: params.userId ?? 'user-1',
+      tag: {
+        id: `tag-${index}`,
+        userId: params.userId ?? 'user-1',
+        label,
+      },
+    })),
+  };
+}
+
+describe('DailyDigestQueryService', () => {
+  it('returns deterministic user-scoped digest groups with compact task summaries', async () => {
+    const findMany = jest.fn().mockResolvedValue([
+      createTask({ id: 'a', title: 'Overdue task', status: 'TODO', dueDate: '2026-05-18T05:00:00.000Z', tags: ['z', 'a'] }),
+      createTask({ id: 'b', title: 'Due today task', status: 'IN_PROGRESS', dueDate: '2026-05-19T20:00:00.000Z' }),
+      createTask({ id: 'c', title: 'Due soon task', status: 'TODO', dueDate: '2026-05-21T12:00:00.000Z' }),
+      createTask({ id: 'd', title: 'Recent task', status: 'IN_PROGRESS', dueDate: '2026-06-01T00:00:00.000Z', updatedAt: '2026-05-19T11:00:00.000Z' }),
+      createTask({ id: 'e', title: 'Done task', status: 'DONE', dueDate: '2026-05-18T04:00:00.000Z', updatedAt: '2026-05-19T11:00:00.000Z' }),
+    ]);
+
+    const prisma = { task: { findMany } } as unknown as PrismaClient;
+    const service = new DailyDigestQueryService(prisma);
+
+    const digest = await service.queryForUser('user-1', {
+      now: new Date('2026-05-19T12:00:00.000Z'),
+      timezone: 'UTC',
+      dueSoonDays: 3,
+      recentlyUpdatedDays: 2,
+      maxTasksPerGroup: 10,
+    });
+
+    expect(findMany).toHaveBeenCalledTimes(1);
+    expect(findMany).toHaveBeenCalledWith(expect.objectContaining({ where: { userId: 'user-1' } }));
+
+    expect(digest.totalTasksConsidered).toBe(5);
+    expect(digest.groups.map(group => `${group.key}:${group.total}`)).toEqual([
+      'overdue:1',
+      'dueToday:1',
+      'dueSoon:1',
+      'recentlyUpdated:4',
+      'blockedByStatus:2',
+    ]);
+
+    const overdue = digest.groups.find(group => group.key === 'overdue');
+    expect(overdue?.tasks[0]).toEqual(
+      expect.objectContaining({ id: 'a', title: 'Overdue task', tags: ['a', 'z'] }),
+    );
+    expect(overdue?.tasks[0]).not.toHaveProperty('description');
+  });
+
+  it('returns empty groups for users without digest-worthy tasks', async () => {
+    const findMany = jest.fn().mockResolvedValue([]);
+    const prisma = { task: { findMany } } as unknown as PrismaClient;
+    const service = new DailyDigestQueryService(prisma);
+
+    const digest = await service.queryForUser('user-without-tasks', {
+      now: new Date('2026-05-19T12:00:00.000Z'),
+      timezone: 'America/New_York',
+    });
+
+    for (const group of digest.groups) {
+      expect(group.total).toBe(0);
+      expect(group.tasks).toEqual([]);
+    }
+  });
+
+  it('computes timezone-aware daily boundaries', () => {
+    const windows = computeUtcWindowBoundaries(
+      new Date('2026-05-19T03:30:00.000Z'),
+      'America/Los_Angeles',
+      4,
+      1,
+    );
+
+    expect(windows.startOfTodayUtc.toISOString()).toBe('2026-05-18T07:00:00.000Z');
+    expect(windows.startOfTomorrowUtc.toISOString()).toBe('2026-05-19T07:00:00.000Z');
+    expect(windows.dueSoonUntilUtc.toISOString()).toBe('2026-05-23T07:00:00.000Z');
+    expect(windows.recentlyUpdatedSinceUtc.toISOString()).toBe('2026-05-18T03:30:00.000Z');
+  });
+});

--- a/apps/api/tests/digest-query-service.test.ts
+++ b/apps/api/tests/digest-query-service.test.ts
@@ -168,4 +168,16 @@ describe('DailyDigestQueryService', () => {
     expect(fallBack.startOfTodayUtc.toISOString()).toBe('2026-11-01T07:00:00.000Z');
     expect(fallBack.startOfTomorrowUtc.toISOString()).toBe('2026-11-02T08:00:00.000Z');
   });
+
+  it('resolves local midnight using the offset at that local midnight', () => {
+    const windows = computeUtcWindowBoundaries(
+      new Date('2026-04-05T12:00:00.000Z'),
+      'Australia/Sydney',
+      1,
+      1,
+    );
+
+    expect(windows.startOfTodayUtc.toISOString()).toBe('2026-04-04T13:00:00.000Z');
+    expect(windows.startOfTomorrowUtc.toISOString()).toBe('2026-04-05T14:00:00.000Z');
+  });
 });

--- a/apps/api/tests/digest-query-service.test.ts
+++ b/apps/api/tests/digest-query-service.test.ts
@@ -59,7 +59,25 @@ describe('DailyDigestQueryService', () => {
     });
 
     expect(findMany).toHaveBeenCalledTimes(1);
-    expect(findMany).toHaveBeenCalledWith(expect.objectContaining({ where: { userId: 'user-1' } }));
+    expect(findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          userId: 'user-1',
+          OR: expect.arrayContaining([
+            expect.objectContaining({
+              status: { not: 'DONE' },
+              dueDate: { lt: new Date('2026-05-23T00:00:00.000Z') },
+            }),
+            expect.objectContaining({
+              status: { not: 'DONE' },
+              updatedAt: { gte: new Date('2026-05-17T12:00:00.000Z') },
+            }),
+            { status: 'TODO' },
+          ]),
+        }),
+        include: expect.any(Object),
+      }),
+    );
 
     expect(digest.totalTasksConsidered).toBe(5);
     expect(digest.groups.map(group => `${group.key}:${group.total}`)).toEqual([
@@ -75,6 +93,9 @@ describe('DailyDigestQueryService', () => {
       expect.objectContaining({ id: 'a', title: 'Overdue task', tags: ['a', 'z'] }),
     );
     expect(overdue?.tasks[0]).not.toHaveProperty('description');
+
+    const recentlyUpdated = digest.groups.find(group => group.key === 'recentlyUpdated');
+    expect(recentlyUpdated?.tasks.map(task => task.id)).toEqual(['d', 'a', 'b', 'c']);
   });
 
   it('returns empty groups for users without digest-worthy tasks', async () => {

--- a/apps/api/tests/digest-query-service.test.ts
+++ b/apps/api/tests/digest-query-service.test.ts
@@ -106,4 +106,24 @@ describe('DailyDigestQueryService', () => {
     expect(windows.dueSoonUntilUtc.toISOString()).toBe('2026-05-23T07:00:00.000Z');
     expect(windows.recentlyUpdatedSinceUtc.toISOString()).toBe('2026-05-18T03:30:00.000Z');
   });
+
+  it('keeps local day windows aligned across daylight saving transitions', () => {
+    const springForward = computeUtcWindowBoundaries(
+      new Date('2026-03-08T12:00:00.000Z'),
+      'America/Los_Angeles',
+      1,
+      1,
+    );
+    expect(springForward.startOfTodayUtc.toISOString()).toBe('2026-03-08T08:00:00.000Z');
+    expect(springForward.startOfTomorrowUtc.toISOString()).toBe('2026-03-09T07:00:00.000Z');
+
+    const fallBack = computeUtcWindowBoundaries(
+      new Date('2026-11-01T12:00:00.000Z'),
+      'America/Los_Angeles',
+      1,
+      1,
+    );
+    expect(fallBack.startOfTodayUtc.toISOString()).toBe('2026-11-01T07:00:00.000Z');
+    expect(fallBack.startOfTomorrowUtc.toISOString()).toBe('2026-11-02T08:00:00.000Z');
+  });
 });

--- a/docs/tasks/milestone5/01-email-preferences-schema.md
+++ b/docs/tasks/milestone5/01-email-preferences-schema.md
@@ -17,6 +17,6 @@
 - Keep the schema compatible with ADR 0003's SMTP adapter and future multi-provider support.
 
 ## Implementation Notes
-- Added `EmailPreference` with conservative daily digest defaults and a database check that allows only UTC hours 0-23 when a digest hour is set.
+- Added `EmailPreference` with conservative daily digest defaults, a persisted `dailyDigestTimezone` defaulting to `UTC`, and a database check that allows only UTC hours 0-23 when a digest hour is set.
 - Added `NotificationDelivery` for idempotent logical notifications and `NotificationDeliveryAttempt` for auditable provider send attempts.
 - Seed data upserts the local demo user's default email preferences deterministically.

--- a/docs/tasks/milestone5/04-digest-query-service.md
+++ b/docs/tasks/milestone5/04-digest-query-service.md
@@ -4,14 +4,20 @@
 - Create a reusable service that gathers the tasks a user should see in a daily digest.
 - Group work by overdue, due today, due soon, recently updated, and blocked-by-status categories where useful.
 
-**Status:** New.
+**Status:** Completed.
 
 ## Acceptance Criteria
-- [ ] Digest query is user-scoped and never includes another user's tasks.
-- [ ] Service returns deterministic groups, counts, and task summaries suitable for email rendering.
-- [ ] Date windows are timezone-aware and covered by tests.
-- [ ] Query avoids N+1 reads and handles users with no digest-worthy tasks.
+- [x] Digest query is user-scoped and never includes another user's tasks.
+- [x] Service returns deterministic groups, counts, and task summaries suitable for email rendering.
+- [x] Date windows are timezone-aware and covered by tests.
+- [x] Query avoids N+1 reads and handles users with no digest-worthy tasks.
 
 ## Notes
 - Reuse existing task repository filtering and board DTO concepts where they fit.
 - Keep email payloads compact; do not include full markdown descriptions by default.
+
+## Implementation Notes
+- Added `DailyDigestQueryService` for user-scoped digest read models grouped by overdue, due today, due soon, recently updated, and still-todo tasks.
+- Digest task summaries reuse board DTO mapping for compact email-safe fields and sorted tag labels without markdown descriptions.
+- Date windows resolve from a persisted `dailyDigestTimezone` preference by default, allow explicit overrides for preview/testing, and use local calendar midnights so DST transitions do not skew daily buckets.
+- The Prisma query filters to digest-relevant candidates and eager-loads tags in one read to avoid N+1 task/tag access.


### PR DESCRIPTION
### Motivation
- Provide a reusable, user-scoped service that gathers tasks for a daily digest and groups them for compact email rendering.
- Ensure groups are deterministic, timezone-aware, and avoid N+1 queries by reusing existing task repository mappers and includes.
- Keep email payloads compact (no full `description`) and make grouping windowing configurable for testability.

### Description
- Add `DailyDigestQueryService` in `apps/api/src/notifications/digest-query-service.ts` which performs a single `prisma.task.findMany` with `taskWithTagsInclude` and returns grouped summaries for `overdue`, `dueToday`, `dueSoon`, `recentlyUpdated`, and `blockedByStatus` with a `maxTasksPerGroup` cap.
- Implement timezone-aware window computation via `computeUtcWindowBoundaries` and helper functions `toLocalDateParts` / `localMidnightToUtc` to produce `startOfTodayUtc`, `startOfTomorrowUtc`, `dueSoonUntilUtc`, and `recentlyUpdatedSinceUtc` values.
- Use existing mapping helpers (`toTaskBoardItemDTO`) to emit compact `DailyDigestTaskSummary` objects (no `description`).
- Add focused tests in `apps/api/tests/digest-query-service.test.ts` that assert deterministic grouping, user scoping, empty-state handling, tag ordering, and timezone boundary calculations.

### Testing
- Ran TypeScript check with `pnpm -C apps/api exec tsc --noEmit`, which completed successfully.
- Ran `pnpm -C apps/api test -- digest-query-service.test.ts`; Jest execution failed in this environment because `testcontainers` could not start a container runtime (error: "Could not find a working container runtime strategy").
- The new tests are unit-focused and mock `prisma.task.findMany`, and are expected to pass in CI or a developer environment where `testcontainers` can start a PostgreSQL container.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c1e95b118832291bb59c9a2fa00a5)