### PR TITLE
docs: record digest scheduler invocation decision

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ Keep `.env` files aligned with the templates in `infra/env/`. The table below su
 | `SMTP_HOST` / `SMTP_PORT` | `apps/api/.env` | `mailhog` / `1025` | Local Docker sends through MailHog. Production uses Resend SMTP; see `infra/env/api.prod.env.example` and `docs/prod/resend-email-setup.md`. |
 | `SMTP_USER` / `SMTP_PASS` | `apps/api/.env` | _(blank)_ | Production Resend SMTP uses `SMTP_USER=resend` and stores the Resend API key in `SMTP_PASS`. Never commit real credentials. |
 | `EMAIL_FROM` | `apps/api/.env` | `TaskForge <noreply@taskforge.local>` | Production must use a sender on the verified Resend domain. |
+| `EMAIL_DAILY_SEND_LIMIT` | `apps/api/.env` | `100` | Daily digest budget guard. Keep at or below the Resend free daily limit unless the account is upgraded. |
+| `DIGEST_JOB_SECRET` | `apps/api/.env` | `dev-digest-job-secret` | Shared secret for the protected digest job endpoint. Rotate and store securely in production. |
 | `SEED_USER_PASSWORD` | `apps/api/.env` (optional) | `Demo1234!` | Overrides the deterministic password used during seeding. |
 | `BCRYPT_SALT_ROUNDS` | `apps/api/.env` (optional) | `10` | Tune hashing cost if parity with production is required. |
 
@@ -204,5 +206,6 @@ pnpm -C apps/api run lint:http
 - BE: Render or Railway
 - DB: Neon or Supabase
 - Email: Nodemailer SMTP adapter is available. Local Docker defaults to MailHog; production defaults to Resend SMTP (`smtp.resend.com:587`). See `docs/prod/resend-email-setup.md`.
+- Digest scheduling: protected API job endpoint invoked by a free scheduler. Prefer Vercel Cron when available; use GitHub Actions schedule as the free fallback. See `docs/prod/adr/0006-digest-scheduler-invocation.md`.
 
 Task data persists via Prisma. Run migrations before exercising the API in any environment.

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -16,7 +16,7 @@
 - Tasks: title, description (MD), status, priority, **tags**, **dueDate**.
 - Kanban: DnD with optimistic UI.
 - Filters/search: tag/status/due range/text.
-- Email: Nodemailer SMTP adapter with MailHog local defaults and Resend production configuration; welcome emails send after first account creation, while daily digest product flows remain planned.
+- Email: Nodemailer SMTP adapter with MailHog local defaults and Resend production configuration; welcome emails send after first account creation, while daily digest product flows remain planned. The approved digest invocation path is a protected free-tier scheduler endpoint.
 - UI: Next.js, Tailwind, shadcn/ui, Framer Motion, desktop-first dark theme.
 - Docs: Swagger/OpenAPI + ADRs. `.http` pack.
 - Tests: Jest/Supertest for API coverage and Vitest/React Testing Library for frontend coverage.
@@ -30,7 +30,7 @@
 - BE: Express (TS), Zod validation, Prisma (Postgres), Swagger. Auth router issues JWT access/refresh pairs, maintains
   `tf_session` HttpOnly cookies, and exposes a `session-bridge` endpoint for trusted frontends.
 - DB: Neon/Supabase Postgres; Prisma migrations + seed.
-- Email: Nodemailer SMTP adapter; MailHog is available in local compose, and production configuration defaults to Resend SMTP once pre-launch verification is complete.
+- Email: Nodemailer SMTP adapter; MailHog is available in local compose, and production configuration defaults to Resend SMTP once pre-launch verification is complete. Daily digest scheduling uses a protected API job endpoint invoked by Vercel Cron when available, with GitHub Actions schedule as the free fallback.
 - Infra: Dockerfiles + docker-compose; CI with GitHub Actions.
 
 ## Data Model (Prisma Sketch)
@@ -109,7 +109,7 @@ enum TaskPriority { LOW MEDIUM HIGH }
 - Auth: NextAuth + backend JWT verification with dedicated session bridge and shared Prisma adapter.
 - Backend: Express TS + Zod + Swagger.
 - DB: Postgres (Neon/Supabase) + Prisma.
-- Email: ADR 0003 records the Nodemailer adapter, MailHog dev path, and Resend SMTP production default.
+- Email: ADR 0003 records the Nodemailer adapter, MailHog dev path, and Resend SMTP production default. Production ADR 0006 records the free-tier digest scheduler invocation path.
 - Monorepo rationale: shared types, unified tooling, single CI.
 
 

--- a/docs/adr/0003-email-nodemailer-adapters.md
+++ b/docs/adr/0003-email-nodemailer-adapters.md
@@ -22,4 +22,5 @@ The email adapter remains provider-neutral so TaskForge can move to another SMTP
 - Zero cost dev setup; easy local testing.
 - Resend requires a verified sending domain before production sends; SPF and DKIM are mandatory, and DMARC should be configured before launch.
 - Resend's free plan has a daily send limit, so digest delivery needs an explicit send-budget guard.
+- Digest scheduling is a production invocation concern; see `docs/prod/adr/0006-digest-scheduler-invocation.md` for the protected endpoint and free scheduler decision.
 - SMTP provider variance remains; keep all provider details behind configuration and the adapter.

--- a/docs/prod/README.md
+++ b/docs/prod/README.md
@@ -6,3 +6,4 @@ Production and pre-launch operations docs live here. Milestone/task planning fil
 - `database-migration-squash.md` - rules for squashing development Prisma migrations before the first production database exists.
 - `dev-auth-bypass.md` - development bypass behavior and the production expectation that it stays disabled.
 - `adr/0004-hosting-vercel-render-neon.md` - accepted hosting topology decision.
+- `adr/0006-digest-scheduler-invocation.md` - accepted free-tier digest scheduler invocation decision.

--- a/docs/prod/adr/0004-hosting-vercel-render-neon.md
+++ b/docs/prod/adr/0004-hosting-vercel-render-neon.md
@@ -13,3 +13,4 @@ We need free-tier hosting for quick demos and a realistic deployment topology.
 ## Consequences
 - Easy pipelines and env config.
 - Cold starts possible on free plans; document caveats.
+- Scheduled digest delivery is handled separately by ADR 0006 because cron pricing and timing guarantees vary by platform.

--- a/docs/prod/adr/0006-digest-scheduler-invocation.md
+++ b/docs/prod/adr/0006-digest-scheduler-invocation.md
@@ -1,0 +1,42 @@
+# ADR 0006 - Digest Scheduler Invocation
+
+**Status:** Accepted
+
+## Context
+TaskForge needs a daily digest runner that works on free-tier hosting and respects Resend's free daily send budget. The runner must be deterministic, manually dry-runnable, and safe to invoke from CI or hosted scheduling without requiring an always-on worker.
+
+The current production topology targets Vercel for the web app, Render or Railway for the API, and Neon or Supabase for Postgres. Pricing-sensitive notes below were checked against official docs on 2026-05-19. Free-tier constraints matter:
+
+- Vercel Cron is available on all plans, but Hobby cron runs at most once per day with hourly scheduling precision.
+- GitHub Actions scheduled workflows can run within the repository owner's free included minutes, but schedules may be delayed or dropped during high load.
+- Render Cron Jobs have a minimum monthly charge per cron job service, so they do not satisfy a strict free-only requirement.
+- Railway offers a limited free/trial path and paid Hobby usage, so relying on Railway scheduling for production is not the default free-only choice.
+
+## Decision
+Implement digest delivery as an explicit API job endpoint backed by the same deterministic runner used by local scripts and CI smoke checks.
+
+Production invocation should prefer:
+
+1. Vercel Cron calling the protected API job endpoint when the deployed topology can support it within Hobby limits.
+2. GitHub Actions scheduled workflow calling the same endpoint as the free fallback.
+
+The endpoint must require a shared job secret, support dry-run mode, accept an explicit digest date window, and pass an `EMAIL_DAILY_SEND_LIMIT` budget guard to the runner. Production defaults should assume Resend's free daily limit unless the account is upgraded.
+
+Do not use an always-running `node-cron` worker for the production digest schedule.
+
+## Consequences
+- The digest schedule remains compatible with sleeping or cold-starting free-tier API hosts because the job is triggered by an inbound request.
+- The runner stays testable without waiting for wall-clock time because date windows and dry-run behavior are explicit inputs.
+- Vercel Cron gives the cleanest free deployment path for one daily digest, but exact timing is not guaranteed on Hobby.
+- GitHub Actions is a workable fallback, but schedule delivery is best-effort and should not be the only source of observability.
+- The protected endpoint adds a security requirement: production must configure a strong `DIGEST_JOB_SECRET` and reject unauthenticated job requests.
+- Render-native cron can be reconsidered if TaskForge moves off a strict free-only requirement.
+
+## References
+- Vercel Cron usage and pricing: https://vercel.com/docs/cron-jobs/usage-and-pricing
+- Vercel Cron security: https://vercel.com/docs/cron-jobs/manage-cron-jobs
+- GitHub Actions billing and usage: https://docs.github.com/actions/learn-github-actions/usage-limits-billing-and-administration
+- GitHub Actions schedule event behavior: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows
+- Render Cron Jobs billing: https://render.com/docs/cronjobs
+- Railway pricing: https://docs.railway.com/pricing
+- Resend pricing: https://resend.com/pricing

--- a/docs/prod/resend-email-setup.md
+++ b/docs/prod/resend-email-setup.md
@@ -11,6 +11,8 @@ Real outbound email should remain disabled until a future pre-launch issue compl
 - `SMTP_USER=resend`
 - `SMTP_PASS=<RESEND_API_KEY>`
 - `EMAIL_FROM=<verified sender>`
+- `EMAIL_DAILY_SEND_LIMIT=100`
+- `DIGEST_JOB_SECRET=<random job invocation secret>`
 
 The production API env example lives at `infra/env/api.prod.env.example`.
 
@@ -22,6 +24,9 @@ The production API env example lives at `infra/env/api.prod.env.example`.
 4. Add DMARC before enabling production sends.
 5. Create a Resend SMTP API key and set it as `SMTP_PASS`.
 6. Choose `EMAIL_FROM` using the verified domain (example: `TaskForge <noreply@mail.taskforge.example>`).
-7. Run a production-like smoke test against the verified sender before enabling scheduled or user-triggered sends.
+7. Set `EMAIL_DAILY_SEND_LIMIT` at or below the active Resend daily limit. Keep it at `100` or lower on the free plan unless the account is upgraded.
+8. Set `DIGEST_JOB_SECRET` to a strong random value before enabling the protected digest job endpoint.
+9. Configure the free digest scheduler from ADR 0006: prefer Vercel Cron calling the protected endpoint, with GitHub Actions schedule as the fallback.
+10. Run a production-like dry run against the verified sender and digest date window before enabling scheduled or user-triggered real sends.
 
 > Do not commit SMTP secrets to the repository.

--- a/docs/tasks/milestone5/05-digest-scheduler.md
+++ b/docs/tasks/milestone5/05-digest-scheduler.md
@@ -1,24 +1,34 @@
 # Task: Add digest scheduler
 
 ## Summary
-- Add a deterministic daily digest runner that can be called by a hosted scheduler, local script, or CI smoke.
+- Add a deterministic daily digest runner that can be called by a protected job endpoint, local script, or CI smoke.
 - Ensure every eligible user is processed once per digest window.
 
 **Status:** New.
 
+## Production Invocation Decision
+- Accepted decision: use a protected API job endpoint backed by the deterministic runner. See `docs/prod/adr/0006-digest-scheduler-invocation.md`.
+- Preferred free production caller: Vercel Cron, limited to daily Hobby cadence and hourly timing precision.
+- Free fallback caller: GitHub Actions scheduled workflow calling the same endpoint, with best-effort timing.
+- Avoid an always-running `node-cron` worker in production because free-tier hosts can sleep, restart, or scale down.
+
 ## Acceptance Criteria
-- [ ] A CLI/script or protected job endpoint can run digest delivery for a target date window.
+- [ ] A protected job endpoint can run digest delivery for a target date window and requires a shared job secret.
+- [ ] The same runner can be invoked by a local script or CI smoke without depending on wall-clock time.
 - [ ] Runner respects user email preferences and skips users without a verified or deliverable email.
 - [ ] Idempotency prevents duplicate sends for the same user and digest date.
-- [ ] Runner accepts an `EMAIL_DAILY_SEND_LIMIT` or equivalent budget guard; default production docs should assume Resend's free daily limit unless a paid plan is configured.
+- [ ] Runner accepts an `EMAIL_DAILY_SEND_LIMIT` or equivalent budget guard; default production docs assume Resend's free daily limit unless a paid plan is configured.
 - [ ] Job output reports attempted, sent, skipped, and failed counts.
+- [ ] Dry-run mode reports the same counts without recording successful delivery or sending real email.
 
 ## Manual Setup Required
-- Decide how production will invoke the digest runner: hosted cron, platform scheduler, or a protected job endpoint.
-- Set the production digest send budget before enabling the job. For the Resend free plan, keep the budget at or below 100 emails per day unless the account is upgraded.
+- Configure `DIGEST_JOB_SECRET` in production before exposing the job endpoint.
+- Configure the free production caller after deployment: Vercel Cron is preferred; GitHub Actions schedule is the fallback.
+- Set `EMAIL_DAILY_SEND_LIMIT` before enabling the job. For the Resend free plan, keep the budget at or below 100 emails per day unless the account is upgraded.
 - Confirm the first production schedule with a dry run before enabling real sends.
 
 ## Notes
 - Prefer an explicit invocation path over an always-running worker so free-tier hosting remains viable.
 - Make scheduler behavior testable without waiting for wall-clock time.
+- Keep scheduler timing expectations loose on free tiers; the digest date window must drive behavior, not the exact trigger minute.
 - Resend pricing reference for the free daily limit: https://resend.com/pricing

--- a/docs/tasks/milestone5/sequence.md
+++ b/docs/tasks/milestone5/sequence.md
@@ -4,7 +4,7 @@
 2. **02-email-adapter-and-config.md** - Implement the Nodemailer adapter, MailHog dev defaults, Resend SMTP production defaults, and SMTP config validation.
 3. **03-welcome-email-flow.md** - Send a welcome email after first successful registration or OAuth account creation.
 4. **04-digest-query-service.md** - Build the daily digest read model for overdue, due-soon, and recently moved tasks.
-5. **05-digest-scheduler.md** - Add a deterministic digest runner that can be invoked locally, in CI, or by a hosted scheduler while respecting Resend free-tier send limits.
+5. **05-digest-scheduler.md** - Add a deterministic digest runner behind a protected job endpoint, local script, and CI smoke while respecting Resend free-tier send limits.
 6. **06-digest-preview-and-send-api.md** - Expose protected preview/send endpoints for manual QA and future admin tooling.
 7. **07-email-settings-ui.md** - Let users opt in/out of digest emails and choose digest timing from the web app.
 8. **08-digest-preview-ui.md** - Add a dashboard preview surface so users can inspect the digest before enabling it.

--- a/infra/env/api.env.example
+++ b/infra/env/api.env.example
@@ -10,5 +10,7 @@ SMTP_PORT=1025
 SMTP_USER=
 SMTP_PASS=
 EMAIL_FROM=TaskForge <noreply@taskforge.local>
+EMAIL_DAILY_SEND_LIMIT=100
+DIGEST_JOB_SECRET=dev-digest-job-secret
 NODE_ENV=development
 # COOKIE_DOMAIN=.taskforge.app  # Uncomment for production cross-subdomain cookies

--- a/infra/env/api.prod.env.example
+++ b/infra/env/api.prod.env.example
@@ -10,5 +10,7 @@ SMTP_PORT=587
 SMTP_USER=resend
 SMTP_PASS=<RESEND_API_KEY>
 EMAIL_FROM=<verified sender>
+EMAIL_DAILY_SEND_LIMIT=100
+DIGEST_JOB_SECRET=<RANDOM_DIGEST_JOB_SECRET>
 NODE_ENV=production
 # COOKIE_DOMAIN=.taskforge.app  # Uncomment for production cross-subdomain cookies


### PR DESCRIPTION
# Title
milestone-5: Document free-tier digest scheduler invocation decision

## Summary
This PR records the production decision for daily digest scheduling under a strict free-tier constraint. It adds a production ADR choosing a protected API job endpoint invoked by Vercel Cron when available, with GitHub Actions scheduled workflow as the free fallback, and updates the milestone task plus deployment docs to match.

## What's Included
- [ ] Product behavior / user workflow changes
- [ ] API, schema, or data model changes
- [ ] Frontend UI / state management changes
- [ ] Tests, fixtures, or CI updates
- [x] Docs updated (README, PRD, ADRs, task docs, testing docs)

## How to Test
1. **Automated**
   ```bash
   git diff --check
   ```

## Screenshots / Logs
No UI changes.

## Checklist
- [ ] Lints pass (`make lint`)
- [ ] Typecheck passes (`make typecheck`)
- [ ] Tests pass (`make test` plus any focused suites listed above)
- [ ] Build passes (`make build`)
- [x] Updated docs where needed
- [x] No secrets committed

## Notes / Follow-ups
Docs-only change. Full lint/typecheck/test/build were not run. The implementation task should now target the protected job endpoint, `DIGEST_JOB_SECRET`, dry-run support, and `EMAIL_DAILY_SEND_LIMIT`.
