### PR TITLE
milestone-5: add digest preview + guarded manual send API

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -125,13 +125,18 @@ export function createApp(options: CreateAppOptions = {}) {
   app.use('/api/taskforge/v1/tasks', createTaskRouter(taskRepository));
   app.use('/api/taskforge/v1/tags', tagRoutes);
   const digestEmailAdapter = options.digestEmailAdapter ?? options.welcomeEmailAdapter;
-  if (digestEmailAdapter) {
-    const digestRunner = new DailyDigestRunner({
-      prisma: getOrCreatePrisma(),
-      emailAdapter: digestEmailAdapter,
-    });
-    app.use('/api/taskforge/v1/email/digest', createEmailDigestRouter(getOrCreatePrisma(), digestRunner));
-  }
+  const emailDigestRunner = new DailyDigestRunner({
+    prisma: getOrCreatePrisma(),
+    emailAdapter: digestEmailAdapter ?? { sendMail: () => Promise.resolve() },
+  });
+  app.use(
+    '/api/taskforge/v1/email/digest',
+    createEmailDigestRouter(getOrCreatePrisma(), {
+      defaultSendLimit: options.digestDailySendLimit ?? 90,
+      digestRunner: emailDigestRunner,
+      sendConfigured: Boolean(digestEmailAdapter),
+    }),
+  );
   app.get('/api/taskforge/v1/me', (_req, res) => {
     const user = res.locals.user as
       | { id: string; email: string; createdAt: string }

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -16,6 +16,7 @@ import { WelcomeEmailService, type WelcomeEmailDeliveryDispatcher } from './noti
 import type { EmailAdapter } from './email/types';
 import { DailyDigestRunner } from './notifications/daily-digest-runner';
 import { createJobsRouter } from './routes/jobs';
+import { createEmailDigestRouter } from './routes/email-digest';
 
 export interface CreateAppOptions {
   jwtSecret?: string;
@@ -123,6 +124,14 @@ export function createApp(options: CreateAppOptions = {}) {
   app.use(authRouterFactory.authMiddleware);
   app.use('/api/taskforge/v1/tasks', createTaskRouter(taskRepository));
   app.use('/api/taskforge/v1/tags', tagRoutes);
+  const digestEmailAdapter = options.digestEmailAdapter ?? options.welcomeEmailAdapter;
+  if (digestEmailAdapter) {
+    const digestRunner = new DailyDigestRunner({
+      prisma: getOrCreatePrisma(),
+      emailAdapter: digestEmailAdapter,
+    });
+    app.use('/api/taskforge/v1/email/digest', createEmailDigestRouter(getOrCreatePrisma(), digestRunner));
+  }
   app.get('/api/taskforge/v1/me', (_req, res) => {
     const user = res.locals.user as
       | { id: string; email: string; createdAt: string }

--- a/apps/api/src/notifications/daily-digest-runner.ts
+++ b/apps/api/src/notifications/daily-digest-runner.ts
@@ -22,6 +22,7 @@ export interface DailyDigestRunInput {
   now?: Date;
   dryRun?: boolean;
   sendLimit?: number;
+  userIds?: string[];
 }
 
 export interface DailyDigestRunResult {
@@ -60,6 +61,7 @@ export class DailyDigestRunner {
     const dryRun = input.dryRun ?? false;
     const dryRunConsumedBudget = dryRun ? await countConsumedBudget(this.options.prisma, input.digestDate) : 0;
     const users = await this.options.prisma.user.findMany({
+      where: input.userIds?.length ? { id: { in: input.userIds } } : undefined,
       select: {
         id: true,
         email: true,

--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -781,6 +781,68 @@ export const openApiDocument: OpenAPIV3.Document = {
         },
       },
     },
+
+    '/api/taskforge/v1/email/digest/preview': {
+      get: {
+        tags: ['Email'],
+        summary: 'Preview digest payload for the authenticated user',
+        security: [{ bearerAuth: [] }, { sessionCookie: [] }],
+        parameters: [
+          { name: 'timezone', in: 'query', schema: { type: 'string' } },
+          { name: 'dueSoonDays', in: 'query', schema: { type: 'integer', minimum: 1, maximum: 30 } },
+          { name: 'recentlyUpdatedDays', in: 'query', schema: { type: 'integer', minimum: 1, maximum: 30 } },
+          { name: 'maxTasksPerGroup', in: 'query', schema: { type: 'integer', minimum: 1, maximum: 50 } },
+        ],
+        responses: {
+          '200': { description: 'Digest preview payload returned.' },
+          '400': {
+            description: 'Invalid query parameters',
+            content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } },
+          },
+          '401': {
+            description: 'Unauthorized',
+            content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' }, examples: { unauthorized: unauthorizedExample } } },
+          },
+        },
+      },
+    },
+    '/api/taskforge/v1/email/digest/send': {
+      post: {
+        tags: ['Email'],
+        summary: 'Send or dry-run digest delivery for the authenticated user',
+        security: [{ bearerAuth: [] }, { sessionCookie: [] }],
+        requestBody: {
+          required: false,
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  digestDate: { type: 'string', format: 'date' },
+                  digestHourUtc: { type: 'integer', minimum: 0, maximum: 23 },
+                  dryRun: { type: 'boolean' },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          '200': { description: 'Digest run completed.' },
+          '400': {
+            description: 'Invalid payload',
+            content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } },
+          },
+          '401': {
+            description: 'Unauthorized',
+            content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' }, examples: { unauthorized: unauthorizedExample } } },
+          },
+          '409': {
+            description: 'Digest preference disabled',
+            content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } },
+          },
+        },
+      },
+    },
     '/api/taskforge/v1/tasks': {
       get: {
         tags: ['Tasks'],

--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -464,6 +464,155 @@ const taskDeletedResponse: OpenAPIV3.SchemaObject = {
   },
 };
 
+const dailyDigestTaskSummary: OpenAPIV3.SchemaObject = {
+  type: 'object',
+  properties: {
+    id: { type: 'string', format: 'uuid' },
+    title: { type: 'string' },
+    status: { type: 'string', enum: ['TODO', 'IN_PROGRESS', 'DONE'] },
+    priority: { type: 'string', enum: ['LOW', 'MEDIUM', 'HIGH'] },
+    dueDate: { type: 'string', format: 'date-time', nullable: true },
+    updatedAt: { type: 'string', format: 'date-time' },
+    tags: { type: 'array', items: { type: 'string' } },
+  },
+  required: ['id', 'title', 'status', 'priority', 'updatedAt', 'tags'],
+  example: {
+    id: '4dce5dc0-0f19-4b9c-9c28-31a237a2b617',
+    title: 'Review launch checklist',
+    status: 'TODO',
+    priority: 'HIGH',
+    dueDate: '2026-05-21T12:00:00.000Z',
+    updatedAt: '2026-05-20T10:30:00.000Z',
+    tags: ['launch'],
+  },
+};
+
+const dailyDigestGroup: OpenAPIV3.SchemaObject = {
+  type: 'object',
+  properties: {
+    key: {
+      type: 'string',
+      enum: ['overdue', 'dueToday', 'dueSoon', 'recentlyUpdated', 'blockedByStatus'],
+    },
+    label: { type: 'string' },
+    total: { type: 'integer', minimum: 0 },
+    tasks: {
+      type: 'array',
+      items: { $ref: '#/components/schemas/DailyDigestTaskSummary' },
+    },
+  },
+  required: ['key', 'label', 'total', 'tasks'],
+  example: {
+    key: 'dueToday',
+    label: 'Due today',
+    total: 1,
+    tasks: [dailyDigestTaskSummary.example as Record<string, unknown>],
+  },
+};
+
+const dailyDigestPreviewResponse: OpenAPIV3.SchemaObject = {
+  type: 'object',
+  properties: {
+    generatedAt: { type: 'string', format: 'date-time' },
+    timezone: { type: 'string', example: 'America/New_York' },
+    window: {
+      type: 'object',
+      properties: {
+        startOfTodayUtc: { type: 'string', format: 'date-time' },
+        startOfTomorrowUtc: { type: 'string', format: 'date-time' },
+        dueSoonUntilUtc: { type: 'string', format: 'date-time' },
+        recentlyUpdatedSinceUtc: { type: 'string', format: 'date-time' },
+      },
+      required: ['startOfTodayUtc', 'startOfTomorrowUtc', 'dueSoonUntilUtc', 'recentlyUpdatedSinceUtc'],
+    },
+    totalTasksConsidered: { type: 'integer', minimum: 0 },
+    groups: {
+      type: 'array',
+      items: { $ref: '#/components/schemas/DailyDigestGroup' },
+    },
+  },
+  required: ['generatedAt', 'timezone', 'window', 'totalTasksConsidered', 'groups'],
+  example: {
+    generatedAt: '2026-05-20T12:00:00.000Z',
+    timezone: 'America/New_York',
+    window: {
+      startOfTodayUtc: '2026-05-20T04:00:00.000Z',
+      startOfTomorrowUtc: '2026-05-21T04:00:00.000Z',
+      dueSoonUntilUtc: '2026-05-28T04:00:00.000Z',
+      recentlyUpdatedSinceUtc: '2026-05-18T12:00:00.000Z',
+    },
+    totalTasksConsidered: 1,
+    groups: [dailyDigestGroup.example as Record<string, unknown>],
+  },
+};
+
+const dailyDigestSendRequest: OpenAPIV3.SchemaObject = {
+  type: 'object',
+  properties: {
+    digestDate: {
+      type: 'string',
+      format: 'date',
+      description: 'Optional local digest calendar date. Defaults to today in the user digest timezone.',
+    },
+    digestHourUtc: {
+      type: 'integer',
+      minimum: 0,
+      maximum: 23,
+      description: 'Optional UTC hour filter. Users configured for a different hour are skipped.',
+    },
+    dryRun: {
+      description: 'When true, renders and reports the digest without sending email or recording delivery success.',
+      oneOf: [
+        { type: 'boolean' },
+        { type: 'string', enum: ['true', 'false', '1', '0'] },
+      ],
+      default: false,
+    },
+  },
+  example: {
+    digestDate: '2026-05-21',
+    digestHourUtc: 13,
+    dryRun: true,
+  },
+};
+
+const dailyDigestRunResponse: OpenAPIV3.SchemaObject = {
+  type: 'object',
+  properties: {
+    digestDate: { type: 'string', format: 'date' },
+    attempted: { type: 'integer', minimum: 0 },
+    sent: { type: 'integer', minimum: 0 },
+    skipped: { type: 'integer', minimum: 0 },
+    failed: { type: 'integer', minimum: 0 },
+    budgetSkipped: { type: 'integer', minimum: 0 },
+    duplicateSkipped: { type: 'integer', minimum: 0 },
+    preferenceSkipped: { type: 'integer', minimum: 0 },
+    noContentSkipped: { type: 'integer', minimum: 0 },
+  },
+  required: [
+    'digestDate',
+    'attempted',
+    'sent',
+    'skipped',
+    'failed',
+    'budgetSkipped',
+    'duplicateSkipped',
+    'preferenceSkipped',
+    'noContentSkipped',
+  ],
+  example: {
+    digestDate: '2026-05-21',
+    attempted: 1,
+    sent: 1,
+    skipped: 0,
+    failed: 0,
+    budgetSkipped: 0,
+    duplicateSkipped: 0,
+    preferenceSkipped: 0,
+    noContentSkipped: 0,
+  },
+};
+
 const taskUpdateExample = {
   value: taskUpdateInput.example as Record<string, unknown>,
 } satisfies OpenAPIV3.ExampleObject;
@@ -482,6 +631,30 @@ const tagCreatedExample = {
 
 const tagListResponseExample = {
   value: tagListResponse.example as Record<string, unknown>,
+} satisfies OpenAPIV3.ExampleObject;
+
+const dailyDigestPreviewExample = {
+  value: dailyDigestPreviewResponse.example as Record<string, unknown>,
+} satisfies OpenAPIV3.ExampleObject;
+
+const dailyDigestSendRequestExample = {
+  value: dailyDigestSendRequest.example as Record<string, unknown>,
+} satisfies OpenAPIV3.ExampleObject;
+
+const dailyDigestRunExample = {
+  value: dailyDigestRunResponse.example as Record<string, unknown>,
+} satisfies OpenAPIV3.ExampleObject;
+
+const dailyDigestDisabledExample = {
+  value: { error: 'Daily digest is disabled for this user.' },
+} satisfies OpenAPIV3.ExampleObject;
+
+const digestDeliveryUnavailableExample = {
+  value: { error: 'Digest email delivery is not configured.' },
+} satisfies OpenAPIV3.ExampleObject;
+
+const rateLimitedExample = {
+  value: { error: 'Too many requests, please try again later.' },
 } satisfies OpenAPIV3.ExampleObject;
 
 export const openApiDocument: OpenAPIV3.Document = {
@@ -554,6 +727,11 @@ export const openApiDocument: OpenAPIV3.Document = {
       TaskUpdateInput: taskUpdateInput,
       TaskListResponse: taskListResponse,
       TaskDeleteResponse: taskDeletedResponse,
+      DailyDigestTaskSummary: dailyDigestTaskSummary,
+      DailyDigestGroup: dailyDigestGroup,
+      DailyDigestPreviewResponse: dailyDigestPreviewResponse,
+      DailyDigestSendRequest: dailyDigestSendRequest,
+      DailyDigestRunResponse: dailyDigestRunResponse,
     },
   },
   paths: {
@@ -788,20 +966,59 @@ export const openApiDocument: OpenAPIV3.Document = {
         summary: 'Preview digest payload for the authenticated user',
         security: [{ bearerAuth: [] }, { sessionCookie: [] }],
         parameters: [
-          { name: 'timezone', in: 'query', schema: { type: 'string' } },
-          { name: 'dueSoonDays', in: 'query', schema: { type: 'integer', minimum: 1, maximum: 30 } },
-          { name: 'recentlyUpdatedDays', in: 'query', schema: { type: 'integer', minimum: 1, maximum: 30 } },
-          { name: 'maxTasksPerGroup', in: 'query', schema: { type: 'integer', minimum: 1, maximum: 50 } },
+          {
+            name: 'timezone',
+            in: 'query',
+            schema: { type: 'string', maxLength: 100 },
+            description: 'Optional IANA timezone override for previewing date windows.',
+          },
+          {
+            name: 'dueSoonDays',
+            in: 'query',
+            schema: { type: 'integer', minimum: 1, maximum: 30 },
+          },
+          {
+            name: 'recentlyUpdatedDays',
+            in: 'query',
+            schema: { type: 'integer', minimum: 1, maximum: 30 },
+          },
+          {
+            name: 'maxTasksPerGroup',
+            in: 'query',
+            schema: { type: 'integer', minimum: 1, maximum: 50 },
+          },
         ],
         responses: {
-          '200': { description: 'Digest preview payload returned.' },
+          '200': {
+            description: 'Digest preview payload returned.',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/DailyDigestPreviewResponse' },
+                examples: { default: dailyDigestPreviewExample },
+              },
+            },
+          },
           '400': {
-            description: 'Invalid query parameters',
-            content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } },
+            description: 'Invalid query parameters or digest timezone preference',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/ErrorResponse' },
+                examples: { invalidPayload: invalidPayloadExample },
+              },
+            },
           },
           '401': {
             description: 'Unauthorized',
             content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' }, examples: { unauthorized: unauthorizedExample } } },
+          },
+          '429': {
+            description: 'Digest endpoint rate limit exceeded',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/ErrorResponse' },
+                examples: { rateLimited: rateLimitedExample },
+              },
+            },
           },
         },
       },
@@ -815,22 +1032,29 @@ export const openApiDocument: OpenAPIV3.Document = {
           required: false,
           content: {
             'application/json': {
-              schema: {
-                type: 'object',
-                properties: {
-                  digestDate: { type: 'string', format: 'date' },
-                  digestHourUtc: { type: 'integer', minimum: 0, maximum: 23 },
-                  dryRun: { type: 'boolean' },
-                },
-              },
+              schema: { $ref: '#/components/schemas/DailyDigestSendRequest' },
+              examples: { default: dailyDigestSendRequestExample },
             },
           },
         },
         responses: {
-          '200': { description: 'Digest run completed.' },
+          '200': {
+            description: 'Digest run completed.',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/DailyDigestRunResponse' },
+                examples: { default: dailyDigestRunExample },
+              },
+            },
+          },
           '400': {
-            description: 'Invalid payload',
-            content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } },
+            description: 'Invalid payload or digest timezone preference',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/ErrorResponse' },
+                examples: { invalidPayload: invalidPayloadExample },
+              },
+            },
           },
           '401': {
             description: 'Unauthorized',
@@ -838,7 +1062,30 @@ export const openApiDocument: OpenAPIV3.Document = {
           },
           '409': {
             description: 'Digest preference disabled',
-            content: { 'application/json': { schema: { $ref: '#/components/schemas/ErrorResponse' } } },
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/ErrorResponse' },
+                examples: { disabled: dailyDigestDisabledExample },
+              },
+            },
+          },
+          '429': {
+            description: 'Digest endpoint rate limit exceeded',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/ErrorResponse' },
+                examples: { rateLimited: rateLimitedExample },
+              },
+            },
+          },
+          '503': {
+            description: 'Digest delivery is not configured for real sends',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/ErrorResponse' },
+                examples: { unavailable: digestDeliveryUnavailableExample },
+              },
+            },
           },
         },
       },

--- a/apps/api/src/routes/email-digest.ts
+++ b/apps/api/src/routes/email-digest.ts
@@ -14,7 +14,13 @@ const dateOnlySchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/).refine(value => {
 
 const optionalIntegerParam = (schema: z.ZodNumber) =>
   z.preprocess(
-    value => (typeof value === 'string' && value.trim() === '') || value === null ? Number.NaN : value,
+    value => {
+      if (typeof value === 'string' && value.trim() === '') {
+        return undefined;
+      }
+
+      return value === null ? Number.NaN : value;
+    },
     schema.optional(),
   );
 

--- a/apps/api/src/routes/email-digest.ts
+++ b/apps/api/src/routes/email-digest.ts
@@ -12,16 +12,26 @@ const dateOnlySchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/).refine(value => {
   return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value;
 }, 'Expected a valid YYYY-MM-DD date.');
 
+const optionalIntegerParam = (schema: z.ZodNumber) =>
+  z.preprocess(
+    value => (typeof value === 'string' && value.trim() === '') || value === null ? Number.NaN : value,
+    schema.optional(),
+  );
+
+const timezoneSchema = z.string().trim().min(1).max(100).refine(value => isValidTimezone(value), {
+  message: 'Expected a valid IANA timezone.',
+});
+
 const previewQuerySchema = z.object({
-  timezone: z.string().min(1).max(100).optional(),
-  dueSoonDays: z.coerce.number().int().min(1).max(30).optional(),
-  recentlyUpdatedDays: z.coerce.number().int().min(1).max(30).optional(),
-  maxTasksPerGroup: z.coerce.number().int().min(1).max(50).optional(),
+  timezone: timezoneSchema.optional(),
+  dueSoonDays: optionalIntegerParam(z.coerce.number().int().min(1).max(30)),
+  recentlyUpdatedDays: optionalIntegerParam(z.coerce.number().int().min(1).max(30)),
+  maxTasksPerGroup: optionalIntegerParam(z.coerce.number().int().min(1).max(50)),
 });
 
 const sendPayloadSchema = z.object({
   digestDate: dateOnlySchema.optional(),
-  digestHourUtc: z.coerce.number().int().min(0).max(23).optional(),
+  digestHourUtc: optionalIntegerParam(z.coerce.number().int().min(0).max(23)),
   dryRun: z.union([z.boolean(), z.enum(['true', 'false', '1', '0'])]).optional().transform(value => value === true || value === 'true' || value === '1'),
 });
 
@@ -48,6 +58,10 @@ export function createEmailDigestRouter(prisma: PrismaClient, digestRunner: Dail
       const digest = await queryService.queryForUser(user.id, parsed.data);
       return res.json(digest);
     } catch (error) {
+      if (isInvalidTimezoneError(error)) {
+        return res.status(400).json({ error: 'Invalid digest timezone preference.' });
+      }
+
       return next(error);
     }
   });
@@ -89,4 +103,21 @@ export function createEmailDigestRouter(prisma: PrismaClient, digestRunner: Dail
   });
 
   return router;
+}
+
+function isValidTimezone(timezone: string): boolean {
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: timezone }).format(new Date(0));
+    return true;
+  } catch (error) {
+    if (isInvalidTimezoneError(error)) {
+      return false;
+    }
+
+    throw error;
+  }
+}
+
+function isInvalidTimezoneError(error: unknown): boolean {
+  return error instanceof RangeError;
 }

--- a/apps/api/src/routes/email-digest.ts
+++ b/apps/api/src/routes/email-digest.ts
@@ -43,6 +43,8 @@ const sendPayloadSchema = z.object({
 
 interface AuthUser { id: string }
 
+const rateLimitErrorResponse = { error: 'Too many requests, please try again later.' };
+
 export interface EmailDigestRouterOptions {
   defaultSendLimit?: number;
   digestRunner: DailyDigestRunner;
@@ -55,7 +57,11 @@ export function createEmailDigestRouter(prisma: PrismaClient, options: EmailDige
   const defaultSendLimit = options.defaultSendLimit ?? 90;
   const sendConfigured = options.sendConfigured ?? true;
 
-  router.use(rateLimit({ windowMs: 60_000, max: 10 }));
+  router.use(rateLimit({
+    windowMs: 60_000,
+    max: 10,
+    handler: (_req, res) => res.status(429).json(rateLimitErrorResponse),
+  }));
 
   router.get('/preview', async (req, res, next) => {
     const user = res.locals.user as AuthUser | undefined;
@@ -91,33 +97,25 @@ export function createEmailDigestRouter(prisma: PrismaClient, options: EmailDige
       return res.status(400).json({ error: 'Invalid payload', details: parsed.error.flatten() });
     }
 
-    const preference = await prisma.emailPreference.findUnique({
-      where: { userId: user.id },
-      select: { dailyDigestEnabled: true, dailyDigestTimezone: true },
-    });
-
-    if (!preference?.dailyDigestEnabled) {
-      return res.status(409).json({ error: 'Daily digest is disabled for this user.' });
-    }
-
-    if (!sendConfigured && !parsed.data.dryRun) {
-      return res.status(503).json({ error: 'Digest email delivery is not configured.' });
-    }
-
-    let digestDate = parsed.data.digestDate;
-    if (!digestDate) {
-      try {
-        digestDate = formatLocalDate(new Date(), preference.dailyDigestTimezone ?? 'UTC');
-      } catch (error) {
-        if (isInvalidTimezoneError(error)) {
-          return res.status(400).json({ error: 'Invalid digest timezone preference.' });
-        }
-
-        return next(error);
-      }
-    }
-
     try {
+      const preference = await prisma.emailPreference.findUnique({
+        where: { userId: user.id },
+        select: { dailyDigestEnabled: true, dailyDigestTimezone: true },
+      });
+
+      if (!preference?.dailyDigestEnabled) {
+        return res.status(409).json({ error: 'Daily digest is disabled for this user.' });
+      }
+
+      if (!sendConfigured && !parsed.data.dryRun) {
+        return res.status(503).json({ error: 'Digest email delivery is not configured.' });
+      }
+
+      let digestDate = parsed.data.digestDate;
+      if (!digestDate) {
+        digestDate = formatLocalDate(new Date(), preference.dailyDigestTimezone ?? 'UTC');
+      }
+
       const result = await options.digestRunner.run({
         digestDate,
         digestHourUtc: parsed.data.digestHourUtc,
@@ -127,6 +125,10 @@ export function createEmailDigestRouter(prisma: PrismaClient, options: EmailDige
       });
       return res.json(result);
     } catch (error) {
+      if (isInvalidTimezoneError(error)) {
+        return res.status(400).json({ error: 'Invalid digest timezone preference.' });
+      }
+
       return next(error);
     }
   });

--- a/apps/api/src/routes/email-digest.ts
+++ b/apps/api/src/routes/email-digest.ts
@@ -1,0 +1,92 @@
+import rateLimit from 'express-rate-limit';
+import { Router } from 'express';
+import { z } from 'zod';
+
+import type { PrismaClient } from '@prisma/client';
+
+import { DailyDigestQueryService } from '../notifications/digest-query-service';
+import type { DailyDigestRunner } from '../notifications/daily-digest-runner';
+
+const dateOnlySchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/).refine(value => {
+  const parsed = new Date(`${value}T00:00:00.000Z`);
+  return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value;
+}, 'Expected a valid YYYY-MM-DD date.');
+
+const previewQuerySchema = z.object({
+  timezone: z.string().min(1).max(100).optional(),
+  dueSoonDays: z.coerce.number().int().min(1).max(30).optional(),
+  recentlyUpdatedDays: z.coerce.number().int().min(1).max(30).optional(),
+  maxTasksPerGroup: z.coerce.number().int().min(1).max(50).optional(),
+});
+
+const sendPayloadSchema = z.object({
+  digestDate: dateOnlySchema.optional(),
+  digestHourUtc: z.coerce.number().int().min(0).max(23).optional(),
+  dryRun: z.union([z.boolean(), z.enum(['true', 'false', '1', '0'])]).optional().transform(value => value === true || value === 'true' || value === '1'),
+});
+
+interface AuthUser { id: string }
+
+export function createEmailDigestRouter(prisma: PrismaClient, digestRunner: DailyDigestRunner) {
+  const router = Router();
+  const queryService = new DailyDigestQueryService(prisma);
+
+  router.use(rateLimit({ windowMs: 60_000, max: 10 }));
+
+  router.get('/preview', async (req, res, next) => {
+    const user = res.locals.user as AuthUser | undefined;
+    if (!user?.id) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+
+    const parsed = previewQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      return res.status(400).json({ error: 'Invalid query parameters', details: parsed.error.flatten() });
+    }
+
+    try {
+      const digest = await queryService.queryForUser(user.id, parsed.data);
+      return res.json(digest);
+    } catch (error) {
+      return next(error);
+    }
+  });
+
+  router.post('/send', async (req, res, next) => {
+    const user = res.locals.user as AuthUser | undefined;
+    if (!user?.id) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+
+    const parsed = sendPayloadSchema.safeParse(req.body ?? {});
+    if (!parsed.success) {
+      return res.status(400).json({ error: 'Invalid payload', details: parsed.error.flatten() });
+    }
+
+    const preference = await prisma.emailPreference.findUnique({
+      where: { userId: user.id },
+      select: { dailyDigestEnabled: true },
+    });
+
+    if (!preference?.dailyDigestEnabled) {
+      return res.status(409).json({ error: 'Daily digest is disabled for this user.' });
+    }
+
+    const digestDate = parsed.data.digestDate ?? new Date().toISOString().slice(0, 10);
+
+    try {
+      const result = await digestRunner.run({
+        digestDate,
+        digestHourUtc: parsed.data.digestHourUtc,
+        dryRun: parsed.data.dryRun,
+        sendLimit: 1,
+        userIds: [user.id],
+      });
+      return res.json(result);
+    } catch (error) {
+      return next(error);
+    }
+  });
+
+  return router;
+}

--- a/apps/api/src/routes/email-digest.ts
+++ b/apps/api/src/routes/email-digest.ts
@@ -37,9 +37,17 @@ const sendPayloadSchema = z.object({
 
 interface AuthUser { id: string }
 
-export function createEmailDigestRouter(prisma: PrismaClient, digestRunner: DailyDigestRunner) {
+export interface EmailDigestRouterOptions {
+  defaultSendLimit?: number;
+  digestRunner: DailyDigestRunner;
+  sendConfigured?: boolean;
+}
+
+export function createEmailDigestRouter(prisma: PrismaClient, options: EmailDigestRouterOptions) {
   const router = Router();
   const queryService = new DailyDigestQueryService(prisma);
+  const defaultSendLimit = options.defaultSendLimit ?? 90;
+  const sendConfigured = options.sendConfigured ?? true;
 
   router.use(rateLimit({ windowMs: 60_000, max: 10 }));
 
@@ -79,21 +87,36 @@ export function createEmailDigestRouter(prisma: PrismaClient, digestRunner: Dail
 
     const preference = await prisma.emailPreference.findUnique({
       where: { userId: user.id },
-      select: { dailyDigestEnabled: true },
+      select: { dailyDigestEnabled: true, dailyDigestTimezone: true },
     });
 
     if (!preference?.dailyDigestEnabled) {
       return res.status(409).json({ error: 'Daily digest is disabled for this user.' });
     }
 
-    const digestDate = parsed.data.digestDate ?? new Date().toISOString().slice(0, 10);
+    if (!sendConfigured && !parsed.data.dryRun) {
+      return res.status(503).json({ error: 'Digest email delivery is not configured.' });
+    }
+
+    let digestDate = parsed.data.digestDate;
+    if (!digestDate) {
+      try {
+        digestDate = formatLocalDate(new Date(), preference.dailyDigestTimezone ?? 'UTC');
+      } catch (error) {
+        if (isInvalidTimezoneError(error)) {
+          return res.status(400).json({ error: 'Invalid digest timezone preference.' });
+        }
+
+        return next(error);
+      }
+    }
 
     try {
-      const result = await digestRunner.run({
+      const result = await options.digestRunner.run({
         digestDate,
         digestHourUtc: parsed.data.digestHourUtc,
         dryRun: parsed.data.dryRun,
-        sendLimit: 1,
+        sendLimit: defaultSendLimit,
         userIds: [user.id],
       });
       return res.json(result);
@@ -120,4 +143,23 @@ function isValidTimezone(timezone: string): boolean {
 
 function isInvalidTimezoneError(error: unknown): boolean {
   return error instanceof RangeError;
+}
+
+function formatLocalDate(date: Date, timezone: string): string {
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone: timezone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(date);
+
+  const year = parts.find(part => part.type === 'year')?.value;
+  const month = parts.find(part => part.type === 'month')?.value;
+  const day = parts.find(part => part.type === 'day')?.value;
+
+  if (!year || !month || !day) {
+    throw new Error(`Unable to compute local date for timezone ${timezone}`);
+  }
+
+  return `${year}-${month}-${day}`;
 }

--- a/apps/api/tests/app.test.ts
+++ b/apps/api/tests/app.test.ts
@@ -1,3 +1,8 @@
+import { randomUUID } from 'node:crypto';
+import request from 'supertest';
+
+import { createTokenService } from '../src/auth/token';
+import { InMemoryUserStore } from '../src/auth/user-store';
 import { createApp } from '../src/app';
 
 describe('createApp', () => {
@@ -26,5 +31,28 @@ describe('createApp', () => {
     expect(() => createApp({ jwtSecret: 'test-secret' })).toThrow(
       'digestEmailAdapter or welcomeEmailAdapter must be configured before enabling digest jobs.',
     );
+  });
+
+  it('mounts digest preview without configured email delivery', async () => {
+    delete process.env.DIGEST_JOB_SECRET;
+
+    const userStore = new InMemoryUserStore();
+    const user = {
+      id: randomUUID(),
+      email: 'preview@example.test',
+      passwordHash: null,
+      createdAt: new Date('2026-05-01T00:00:00.000Z'),
+    };
+    await userStore.create(user);
+
+    const app = createApp({ jwtSecret: 'test-secret', userStore });
+    const tokens = await createTokenService({ accessSecret: 'test-secret' }).issueTokens(user.id);
+
+    const response = await request(app)
+      .get('/api/taskforge/v1/email/digest/preview')
+      .set('Authorization', `Bearer ${tokens.accessToken}`)
+      .expect(200);
+
+    expect(response.body).toMatchObject({ timezone: 'UTC', groups: expect.any(Array) });
   });
 });

--- a/apps/api/tests/email-digest-route.test.ts
+++ b/apps/api/tests/email-digest-route.test.ts
@@ -3,17 +3,28 @@ import type { PrismaClient } from '@prisma/client';
 import request from 'supertest';
 
 import type { DailyDigestRunner } from '../src/notifications/daily-digest-runner';
-import { createEmailDigestRouter } from '../src/routes/email-digest';
+import { createEmailDigestRouter, type EmailDigestRouterOptions } from '../src/routes/email-digest';
 
 describe('email digest routes', () => {
-  function appWithUser(prisma: PrismaClient, run = jest.fn().mockResolvedValue({ sent: 0 })) {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  function appWithUser(
+    prisma: PrismaClient,
+    run = jest.fn().mockResolvedValue({ sent: 0 }),
+    routerOptions: Partial<Omit<EmailDigestRouterOptions, 'digestRunner'>> = {},
+  ) {
     const app = express();
     app.use(express.json());
     app.use((_req, res, next) => {
       res.locals.user = { id: 'user-1', email: 'user@example.com', createdAt: new Date().toISOString() };
       next();
     });
-    app.use('/email/digest', createEmailDigestRouter(prisma, { run } as unknown as DailyDigestRunner));
+    app.use(
+      '/email/digest',
+      createEmailDigestRouter(prisma, { ...routerOptions, digestRunner: { run } as unknown as DailyDigestRunner }),
+    );
     return { app, run };
   }
 
@@ -66,10 +77,46 @@ describe('email digest routes', () => {
       task: { findMany: jest.fn().mockResolvedValue([]) },
       emailPreference: { findUnique: jest.fn().mockResolvedValue({ dailyDigestEnabled: true }) },
     } as unknown as PrismaClient;
-    const { app, run } = appWithUser(enabledPrisma, jest.fn().mockResolvedValue({ digestDate: '2026-05-21', attempted: 1 }));
+    const { app, run } = appWithUser(
+      enabledPrisma,
+      jest.fn().mockResolvedValue({ digestDate: '2026-05-21', attempted: 1 }),
+      { defaultSendLimit: 50 },
+    );
 
     await request(app).post('/email/digest/send').send({ digestDate: '2026-05-21', dryRun: true }).expect(200);
 
-    expect(run).toHaveBeenCalledWith(expect.objectContaining({ digestDate: '2026-05-21', dryRun: true, sendLimit: 1 }));
+    expect(run).toHaveBeenCalledWith(expect.objectContaining({ digestDate: '2026-05-21', dryRun: true, sendLimit: 50 }));
+  });
+
+  it('derives the default send date from the user digest timezone', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-05-18T11:30:00.000Z'));
+
+    const prisma = {
+      task: { findMany: jest.fn().mockResolvedValue([]) },
+      emailPreference: {
+        findUnique: jest.fn().mockResolvedValue({ dailyDigestEnabled: true, dailyDigestTimezone: 'Pacific/Kiritimati' }),
+      },
+    } as unknown as PrismaClient;
+    const { app, run } = appWithUser(prisma, jest.fn().mockResolvedValue({ digestDate: '2026-05-19', attempted: 1 }));
+
+    await request(app).post('/email/digest/send').send({ dryRun: true }).expect(200);
+
+    expect(run).toHaveBeenCalledWith(expect.objectContaining({ digestDate: '2026-05-19' }));
+  });
+
+  it('keeps dry run available when email delivery is not configured', async () => {
+    const prisma = {
+      task: { findMany: jest.fn().mockResolvedValue([]) },
+      emailPreference: { findUnique: jest.fn().mockResolvedValue({ dailyDigestEnabled: true }) },
+    } as unknown as PrismaClient;
+    const { app, run } = appWithUser(prisma, jest.fn().mockResolvedValue({ digestDate: '2026-05-21' }), {
+      sendConfigured: false,
+    });
+
+    await request(app).post('/email/digest/send').send({ digestDate: '2026-05-21' }).expect(503);
+    expect(run).not.toHaveBeenCalled();
+
+    await request(app).post('/email/digest/send').send({ digestDate: '2026-05-21', dryRun: true }).expect(200);
+    expect(run).toHaveBeenCalledWith(expect.objectContaining({ dryRun: true }));
   });
 });

--- a/apps/api/tests/email-digest-route.test.ts
+++ b/apps/api/tests/email-digest-route.test.ts
@@ -1,0 +1,59 @@
+import express from 'express';
+import request from 'supertest';
+
+import { createEmailDigestRouter } from '../src/routes/email-digest';
+
+describe('email digest routes', () => {
+  function appWithUser(prisma: any, run = jest.fn().mockResolvedValue({ sent: 0 })) {
+    const app = express();
+    app.use(express.json());
+    app.use((_req, res, next) => {
+      res.locals.user = { id: 'user-1', email: 'user@example.com', createdAt: new Date().toISOString() };
+      next();
+    });
+    app.use('/email/digest', createEmailDigestRouter(prisma, { run } as any));
+    return { app, run };
+  }
+
+  it('returns digest preview for authenticated user', async () => {
+    const prisma = {
+      task: { findMany: jest.fn().mockResolvedValue([]) },
+      emailPreference: { findUnique: jest.fn().mockResolvedValue({ dailyDigestTimezone: 'UTC' }) },
+    };
+    const { app } = appWithUser(prisma);
+
+    const response = await request(app).get('/email/digest/preview?dueSoonDays=3').expect(200);
+
+    expect(response.body).toMatchObject({ timezone: 'UTC', groups: expect.any(Array) });
+  });
+
+  it('validates preview query and send payload', async () => {
+    const prisma = {
+      task: { findMany: jest.fn().mockResolvedValue([]) },
+      emailPreference: { findUnique: jest.fn().mockResolvedValue({ dailyDigestEnabled: true, dailyDigestTimezone: 'UTC' }) },
+    };
+    const { app } = appWithUser(prisma);
+
+    await request(app).get('/email/digest/preview?dueSoonDays=0').expect(400);
+    await request(app).post('/email/digest/send').send({ digestHourUtc: 99 }).expect(400);
+  });
+
+  it('blocks send when digest preference is disabled and supports dry run', async () => {
+    const disabledPrisma = {
+      task: { findMany: jest.fn().mockResolvedValue([]) },
+      emailPreference: { findUnique: jest.fn().mockResolvedValue({ dailyDigestEnabled: false }) },
+    };
+    const { app: blockedApp } = appWithUser(disabledPrisma);
+    await request(blockedApp).post('/email/digest/send').send({ dryRun: true }).expect(409);
+
+    const enabledPrisma = {
+      task: { findMany: jest.fn().mockResolvedValue([]) },
+      emailPreference: { findUnique: jest.fn().mockResolvedValue({ dailyDigestEnabled: true }) },
+    };
+    const { app, run } = appWithUser(enabledPrisma, jest.fn().mockResolvedValue({ digestDate: '2026-05-21', attempted: 1 }));
+
+    await request(app).post('/email/digest/send').send({ digestDate: '2026-05-21', dryRun: true }).expect(200);
+
+    expect(run).toHaveBeenCalledWith(expect.objectContaining({ digestDate: '2026-05-21', dryRun: true, sendLimit: 1 }));
+  });
+});

--- a/apps/api/tests/email-digest-route.test.ts
+++ b/apps/api/tests/email-digest-route.test.ts
@@ -1,17 +1,19 @@
 import express from 'express';
+import type { PrismaClient } from '@prisma/client';
 import request from 'supertest';
 
+import type { DailyDigestRunner } from '../src/notifications/daily-digest-runner';
 import { createEmailDigestRouter } from '../src/routes/email-digest';
 
 describe('email digest routes', () => {
-  function appWithUser(prisma: any, run = jest.fn().mockResolvedValue({ sent: 0 })) {
+  function appWithUser(prisma: PrismaClient, run = jest.fn().mockResolvedValue({ sent: 0 })) {
     const app = express();
     app.use(express.json());
     app.use((_req, res, next) => {
       res.locals.user = { id: 'user-1', email: 'user@example.com', createdAt: new Date().toISOString() };
       next();
     });
-    app.use('/email/digest', createEmailDigestRouter(prisma, { run } as any));
+    app.use('/email/digest', createEmailDigestRouter(prisma, { run } as unknown as DailyDigestRunner));
     return { app, run };
   }
 
@@ -19,7 +21,7 @@ describe('email digest routes', () => {
     const prisma = {
       task: { findMany: jest.fn().mockResolvedValue([]) },
       emailPreference: { findUnique: jest.fn().mockResolvedValue({ dailyDigestTimezone: 'UTC' }) },
-    };
+    } as unknown as PrismaClient;
     const { app } = appWithUser(prisma);
 
     const response = await request(app).get('/email/digest/preview?dueSoonDays=3').expect(200);
@@ -31,25 +33,39 @@ describe('email digest routes', () => {
     const prisma = {
       task: { findMany: jest.fn().mockResolvedValue([]) },
       emailPreference: { findUnique: jest.fn().mockResolvedValue({ dailyDigestEnabled: true, dailyDigestTimezone: 'UTC' }) },
-    };
+    } as unknown as PrismaClient;
     const { app } = appWithUser(prisma);
 
     await request(app).get('/email/digest/preview?dueSoonDays=0').expect(400);
+    await request(app).get('/email/digest/preview?timezone=Not/A_Timezone').expect(400);
     await request(app).post('/email/digest/send').send({ digestHourUtc: 99 }).expect(400);
+    await request(app).post('/email/digest/send').send({ digestHourUtc: null }).expect(400);
+    await request(app).post('/email/digest/send').send({ digestHourUtc: '' }).expect(400);
+    await request(app).post('/email/digest/send').send({ digestHourUtc: ' ' }).expect(400);
+  });
+
+  it('returns a client error for an invalid stored digest timezone', async () => {
+    const prisma = {
+      task: { findMany: jest.fn().mockResolvedValue([]) },
+      emailPreference: { findUnique: jest.fn().mockResolvedValue({ dailyDigestTimezone: 'Not/A_Timezone' }) },
+    } as unknown as PrismaClient;
+    const { app } = appWithUser(prisma);
+
+    await request(app).get('/email/digest/preview').expect(400);
   });
 
   it('blocks send when digest preference is disabled and supports dry run', async () => {
     const disabledPrisma = {
       task: { findMany: jest.fn().mockResolvedValue([]) },
       emailPreference: { findUnique: jest.fn().mockResolvedValue({ dailyDigestEnabled: false }) },
-    };
+    } as unknown as PrismaClient;
     const { app: blockedApp } = appWithUser(disabledPrisma);
     await request(blockedApp).post('/email/digest/send').send({ dryRun: true }).expect(409);
 
     const enabledPrisma = {
       task: { findMany: jest.fn().mockResolvedValue([]) },
       emailPreference: { findUnique: jest.fn().mockResolvedValue({ dailyDigestEnabled: true }) },
-    };
+    } as unknown as PrismaClient;
     const { app, run } = appWithUser(enabledPrisma, jest.fn().mockResolvedValue({ digestDate: '2026-05-21', attempted: 1 }));
 
     await request(app).post('/email/digest/send').send({ digestDate: '2026-05-21', dryRun: true }).expect(200);

--- a/apps/api/tests/email-digest-route.test.ts
+++ b/apps/api/tests/email-digest-route.test.ts
@@ -51,8 +51,27 @@ describe('email digest routes', () => {
     await request(app).get('/email/digest/preview?timezone=Not/A_Timezone').expect(400);
     await request(app).post('/email/digest/send').send({ digestHourUtc: 99 }).expect(400);
     await request(app).post('/email/digest/send').send({ digestHourUtc: null }).expect(400);
-    await request(app).post('/email/digest/send').send({ digestHourUtc: '' }).expect(400);
-    await request(app).post('/email/digest/send').send({ digestHourUtc: ' ' }).expect(400);
+  });
+
+  it('treats blank digest hour values as omitted', async () => {
+    const prisma = {
+      task: { findMany: jest.fn().mockResolvedValue([]) },
+      emailPreference: { findUnique: jest.fn().mockResolvedValue({ dailyDigestEnabled: true, dailyDigestTimezone: 'UTC' }) },
+    } as unknown as PrismaClient;
+    const { app, run } = appWithUser(prisma, jest.fn().mockResolvedValue({ digestDate: '2026-05-21', attempted: 1 }));
+
+    await request(app)
+      .post('/email/digest/send')
+      .send({ digestDate: '2026-05-21', digestHourUtc: '', dryRun: true })
+      .expect(200);
+    await request(app)
+      .post('/email/digest/send')
+      .send({ digestDate: '2026-05-21', digestHourUtc: ' ', dryRun: true })
+      .expect(200);
+
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(run.mock.calls[0]?.[0]).toHaveProperty('digestHourUtc', undefined);
+    expect(run.mock.calls[1]?.[0]).toHaveProperty('digestHourUtc', undefined);
   });
 
   it('returns a client error for an invalid stored digest timezone', async () => {

--- a/apps/api/tests/email-digest-route.test.ts
+++ b/apps/api/tests/email-digest-route.test.ts
@@ -1,4 +1,4 @@
-import express from 'express';
+import express, { type ErrorRequestHandler } from 'express';
 import type { PrismaClient } from '@prisma/client';
 import request from 'supertest';
 
@@ -72,6 +72,40 @@ describe('email digest routes', () => {
     expect(run).toHaveBeenCalledTimes(2);
     expect(run.mock.calls[0]?.[0]).toHaveProperty('digestHourUtc', undefined);
     expect(run.mock.calls[1]?.[0]).toHaveProperty('digestHourUtc', undefined);
+  });
+
+  it('forwards preference lookup failures from manual send', async () => {
+    const prisma = {
+      task: { findMany: jest.fn().mockResolvedValue([]) },
+      emailPreference: { findUnique: jest.fn().mockRejectedValue(new Error('database unavailable')) },
+    } as unknown as PrismaClient;
+    const { app, run } = appWithUser(prisma);
+    const errorHandler: ErrorRequestHandler = (error, _req, res, _next) => {
+      res.status(503).json({ error: error instanceof Error ? error.message : 'Unknown error' });
+    };
+    app.use(errorHandler);
+
+    const response = await request(app).post('/email/digest/send').send({ dryRun: true }).expect(503);
+
+    expect(response.body).toEqual({ error: 'database unavailable' });
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('returns JSON when the digest endpoint rate limit is exceeded', async () => {
+    const prisma = {
+      task: { findMany: jest.fn().mockResolvedValue([]) },
+      emailPreference: { findUnique: jest.fn().mockResolvedValue({ dailyDigestTimezone: 'UTC' }) },
+    } as unknown as PrismaClient;
+    const { app } = appWithUser(prisma);
+
+    for (let requestNumber = 0; requestNumber < 10; requestNumber += 1) {
+      await request(app).get('/email/digest/preview').expect(200);
+    }
+
+    const response = await request(app).get('/email/digest/preview').expect(429);
+
+    expect(response.type).toBe('application/json');
+    expect(response.body).toEqual({ error: 'Too many requests, please try again later.' });
   });
 
   it('returns a client error for an invalid stored digest timezone', async () => {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -909,6 +909,310 @@
           "id": "9e22c508-1383-4609-9bbd-2e09b7a2d108",
           "status": "deleted"
         }
+      },
+      "DailyDigestTaskSummary": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "title": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "TODO",
+              "IN_PROGRESS",
+              "DONE"
+            ]
+          },
+          "priority": {
+            "type": "string",
+            "enum": [
+              "LOW",
+              "MEDIUM",
+              "HIGH"
+            ]
+          },
+          "dueDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "status",
+          "priority",
+          "updatedAt",
+          "tags"
+        ],
+        "example": {
+          "id": "4dce5dc0-0f19-4b9c-9c28-31a237a2b617",
+          "title": "Review launch checklist",
+          "status": "TODO",
+          "priority": "HIGH",
+          "dueDate": "2026-05-21T12:00:00.000Z",
+          "updatedAt": "2026-05-20T10:30:00.000Z",
+          "tags": [
+            "launch"
+          ]
+        }
+      },
+      "DailyDigestGroup": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "enum": [
+              "overdue",
+              "dueToday",
+              "dueSoon",
+              "recentlyUpdated",
+              "blockedByStatus"
+            ]
+          },
+          "label": {
+            "type": "string"
+          },
+          "total": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "tasks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DailyDigestTaskSummary"
+            }
+          }
+        },
+        "required": [
+          "key",
+          "label",
+          "total",
+          "tasks"
+        ],
+        "example": {
+          "key": "dueToday",
+          "label": "Due today",
+          "total": 1,
+          "tasks": [
+            {
+              "id": "4dce5dc0-0f19-4b9c-9c28-31a237a2b617",
+              "title": "Review launch checklist",
+              "status": "TODO",
+              "priority": "HIGH",
+              "dueDate": "2026-05-21T12:00:00.000Z",
+              "updatedAt": "2026-05-20T10:30:00.000Z",
+              "tags": [
+                "launch"
+              ]
+            }
+          ]
+        }
+      },
+      "DailyDigestPreviewResponse": {
+        "type": "object",
+        "properties": {
+          "generatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "timezone": {
+            "type": "string",
+            "example": "America/New_York"
+          },
+          "window": {
+            "type": "object",
+            "properties": {
+              "startOfTodayUtc": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "startOfTomorrowUtc": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "dueSoonUntilUtc": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "recentlyUpdatedSinceUtc": {
+                "type": "string",
+                "format": "date-time"
+              }
+            },
+            "required": [
+              "startOfTodayUtc",
+              "startOfTomorrowUtc",
+              "dueSoonUntilUtc",
+              "recentlyUpdatedSinceUtc"
+            ]
+          },
+          "totalTasksConsidered": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DailyDigestGroup"
+            }
+          }
+        },
+        "required": [
+          "generatedAt",
+          "timezone",
+          "window",
+          "totalTasksConsidered",
+          "groups"
+        ],
+        "example": {
+          "generatedAt": "2026-05-20T12:00:00.000Z",
+          "timezone": "America/New_York",
+          "window": {
+            "startOfTodayUtc": "2026-05-20T04:00:00.000Z",
+            "startOfTomorrowUtc": "2026-05-21T04:00:00.000Z",
+            "dueSoonUntilUtc": "2026-05-28T04:00:00.000Z",
+            "recentlyUpdatedSinceUtc": "2026-05-18T12:00:00.000Z"
+          },
+          "totalTasksConsidered": 1,
+          "groups": [
+            {
+              "key": "dueToday",
+              "label": "Due today",
+              "total": 1,
+              "tasks": [
+                {
+                  "id": "4dce5dc0-0f19-4b9c-9c28-31a237a2b617",
+                  "title": "Review launch checklist",
+                  "status": "TODO",
+                  "priority": "HIGH",
+                  "dueDate": "2026-05-21T12:00:00.000Z",
+                  "updatedAt": "2026-05-20T10:30:00.000Z",
+                  "tags": [
+                    "launch"
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "DailyDigestSendRequest": {
+        "type": "object",
+        "properties": {
+          "digestDate": {
+            "type": "string",
+            "format": "date",
+            "description": "Optional local digest calendar date. Defaults to today in the user digest timezone."
+          },
+          "digestHourUtc": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 23,
+            "description": "Optional UTC hour filter. Users configured for a different hour are skipped."
+          },
+          "dryRun": {
+            "description": "When true, renders and reports the digest without sending email or recording delivery success.",
+            "oneOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "string",
+                "enum": [
+                  "true",
+                  "false",
+                  "1",
+                  "0"
+                ]
+              }
+            ],
+            "default": false
+          }
+        },
+        "example": {
+          "digestDate": "2026-05-21",
+          "digestHourUtc": 13,
+          "dryRun": true
+        }
+      },
+      "DailyDigestRunResponse": {
+        "type": "object",
+        "properties": {
+          "digestDate": {
+            "type": "string",
+            "format": "date"
+          },
+          "attempted": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "sent": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "skipped": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "failed": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "budgetSkipped": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "duplicateSkipped": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "preferenceSkipped": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "noContentSkipped": {
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "digestDate",
+          "attempted",
+          "sent",
+          "skipped",
+          "failed",
+          "budgetSkipped",
+          "duplicateSkipped",
+          "preferenceSkipped",
+          "noContentSkipped"
+        ],
+        "example": {
+          "digestDate": "2026-05-21",
+          "attempted": 1,
+          "sent": 1,
+          "skipped": 0,
+          "failed": 0,
+          "budgetSkipped": 0,
+          "duplicateSkipped": 0,
+          "preferenceSkipped": 0,
+          "noContentSkipped": 0
+        }
       }
     }
   },
@@ -1296,6 +1600,321 @@
                   "unauthorized": {
                     "value": {
                       "error": "Unauthorized"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/taskforge/v1/email/digest/preview": {
+      "get": {
+        "tags": [
+          "Email"
+        ],
+        "summary": "Preview digest payload for the authenticated user",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "timezone",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "maxLength": 100
+            },
+            "description": "Optional IANA timezone override for previewing date windows."
+          },
+          {
+            "name": "dueSoonDays",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 30
+            }
+          },
+          {
+            "name": "recentlyUpdatedDays",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 30
+            }
+          },
+          {
+            "name": "maxTasksPerGroup",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 50
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Digest preview payload returned.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DailyDigestPreviewResponse"
+                },
+                "examples": {
+                  "default": {
+                    "value": {
+                      "generatedAt": "2026-05-20T12:00:00.000Z",
+                      "timezone": "America/New_York",
+                      "window": {
+                        "startOfTodayUtc": "2026-05-20T04:00:00.000Z",
+                        "startOfTomorrowUtc": "2026-05-21T04:00:00.000Z",
+                        "dueSoonUntilUtc": "2026-05-28T04:00:00.000Z",
+                        "recentlyUpdatedSinceUtc": "2026-05-18T12:00:00.000Z"
+                      },
+                      "totalTasksConsidered": 1,
+                      "groups": [
+                        {
+                          "key": "dueToday",
+                          "label": "Due today",
+                          "total": 1,
+                          "tasks": [
+                            {
+                              "id": "4dce5dc0-0f19-4b9c-9c28-31a237a2b617",
+                              "title": "Review launch checklist",
+                              "status": "TODO",
+                              "priority": "HIGH",
+                              "dueDate": "2026-05-21T12:00:00.000Z",
+                              "updatedAt": "2026-05-20T10:30:00.000Z",
+                              "tags": [
+                                "launch"
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid query parameters or digest timezone preference",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "invalidPayload": {
+                    "value": {
+                      "error": "Invalid payload",
+                      "details": {
+                        "fieldErrors": {
+                          "email": [
+                            "Invalid email address"
+                          ]
+                        },
+                        "formErrors": []
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unauthorized": {
+                    "value": {
+                      "error": "Unauthorized"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Digest endpoint rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "rateLimited": {
+                    "value": {
+                      "error": "Too many requests, please try again later."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/taskforge/v1/email/digest/send": {
+      "post": {
+        "tags": [
+          "Email"
+        ],
+        "summary": "Send or dry-run digest delivery for the authenticated user",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DailyDigestSendRequest"
+              },
+              "examples": {
+                "default": {
+                  "value": {
+                    "digestDate": "2026-05-21",
+                    "digestHourUtc": 13,
+                    "dryRun": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Digest run completed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DailyDigestRunResponse"
+                },
+                "examples": {
+                  "default": {
+                    "value": {
+                      "digestDate": "2026-05-21",
+                      "attempted": 1,
+                      "sent": 1,
+                      "skipped": 0,
+                      "failed": 0,
+                      "budgetSkipped": 0,
+                      "duplicateSkipped": 0,
+                      "preferenceSkipped": 0,
+                      "noContentSkipped": 0
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid payload or digest timezone preference",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "invalidPayload": {
+                    "value": {
+                      "error": "Invalid payload",
+                      "details": {
+                        "fieldErrors": {
+                          "email": [
+                            "Invalid email address"
+                          ]
+                        },
+                        "formErrors": []
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unauthorized": {
+                    "value": {
+                      "error": "Unauthorized"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Digest preference disabled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "disabled": {
+                    "value": {
+                      "error": "Daily digest is disabled for this user."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Digest endpoint rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "rateLimited": {
+                    "value": {
+                      "error": "Too many requests, please try again later."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Digest delivery is not configured for real sends",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unavailable": {
+                    "value": {
+                      "error": "Digest email delivery is not configured."
                     }
                   }
                 }

--- a/docs/tasks/milestone5/06-digest-preview-and-send-api.md
+++ b/docs/tasks/milestone5/06-digest-preview-and-send-api.md
@@ -4,14 +4,20 @@
 - Expose protected endpoints for previewing the current user's digest payload.
 - Provide a guarded send endpoint for manual QA and future admin tooling.
 
-**Status:** New.
+**Status:** Completed.
 
 ## Acceptance Criteria
-- [ ] `GET /api/taskforge/v1/email/digest/preview` returns the authenticated user's digest read model.
-- [ ] `POST /api/taskforge/v1/email/digest/send` sends or dry-runs the authenticated user's digest based on request options.
-- [ ] Endpoints validate auth, preferences, date window inputs, and dry-run flags.
-- [ ] OpenAPI documents request/response shapes and expected error cases.
+- [x] `GET /api/taskforge/v1/email/digest/preview` returns the authenticated user's digest read model.
+- [x] `POST /api/taskforge/v1/email/digest/send` sends or dry-runs the authenticated user's digest based on request options.
+- [x] Endpoints validate auth, preferences, date window inputs, and dry-run flags.
+- [x] OpenAPI documents request/response shapes and expected error cases.
 
 ## Notes
 - Keep manual send endpoints protected and rate-limited.
 - Dry-run mode should render the same payload without recording a successful delivery.
+
+## Implementation Notes
+- Added protected `/api/taskforge/v1/email/digest/preview` and `/api/taskforge/v1/email/digest/send` routes behind the shared auth middleware.
+- Preview uses `DailyDigestQueryService` directly and remains available even when SMTP delivery is not configured.
+- Manual send delegates to `DailyDigestRunner` with the authenticated user's id, configured daily send budget, local digest-date defaults, preference checks, idempotency, and dry-run behavior.
+- OpenAPI now includes digest preview/send schemas, examples, and expected `400`, `401`, `409`, `429`, and `503` error cases.


### PR DESCRIPTION
### Motivation
- Provide authenticated, protected endpoints for QA and future admin tooling to preview a user's digest payload and to trigger a guarded manual send with dry-run support.
- Keep manual send scoped, rate-limited, and preference-aware so QA cannot accidentally send mass emails.

### Description
- Added a new router `createEmailDigestRouter` with `GET /api/taskforge/v1/email/digest/preview` and `POST /api/taskforge/v1/email/digest/send` implementing validation, preference checks, and route-level rate limiting (`apps/api/src/routes/email-digest.ts`).
- Wired the router into the app in `createApp` and only enabled when a digest email adapter is configured (`apps/api/src/app.ts`).
- Extended `DailyDigestRunner` to accept a `userIds?: string[]` filter so manual sends target a single user (`apps/api/src/notifications/daily-digest-runner.ts`).
- Documented the new endpoints and request/response/error shapes in the OpenAPI document (`apps/api/src/openapi.ts`).
- Added focused route tests (`apps/api/tests/email-digest-route.test.ts`) covering preview success, validation errors, preference-based blocking, and dry-run behavior.

### Testing
- Ran type checking with `pnpm -C apps/api typecheck`, which completed successfully.
