### PR TITLE
milestone-5: add daily digest email settings panel with optimistic updates

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -4,6 +4,7 @@ import express from 'express';
 import rateLimit from 'express-rate-limit';
 import helmet from 'helmet';
 import swaggerUi from 'swagger-ui-express';
+import { z } from 'zod';
 
 import { PrismaUserStore, UserStore } from './auth/user-store';
 import { openApiDocument } from './openapi';
@@ -17,6 +18,10 @@ import type { EmailAdapter } from './email/types';
 import { DailyDigestRunner } from './notifications/daily-digest-runner';
 import { createJobsRouter } from './routes/jobs';
 import { createEmailDigestRouter } from './routes/email-digest';
+
+const EmailPreferenceUpdateSchema = z.object({
+  dailyDigestEnabled: z.boolean(),
+}).strict();
 
 export interface CreateAppOptions {
   jwtSecret?: string;
@@ -137,7 +142,7 @@ export function createApp(options: CreateAppOptions = {}) {
       sendConfigured: Boolean(digestEmailAdapter),
     }),
   );
-  app.get('/api/taskforge/v1/me', (_req, res) => {
+  app.get('/api/taskforge/v1/me', async (_req, res, next) => {
     const user = res.locals.user as
       | { id: string; email: string; createdAt: string }
       | undefined;
@@ -145,46 +150,49 @@ export function createApp(options: CreateAppOptions = {}) {
       return res.json({ user: null });
     }
 
-    void getOrCreatePrisma()
-      .emailPreference.findUnique({
+    try {
+      const preference = await getOrCreatePrisma().emailPreference.findUnique({
         where: { userId: user.id },
         select: { dailyDigestEnabled: true, dailyDigestTimezone: true },
-      })
-      .then((preference) =>
-        res.json({
-          user,
-          emailPreference: {
-            dailyDigestEnabled: preference?.dailyDigestEnabled ?? false,
-            dailyDigestTimezone: preference?.dailyDigestTimezone ?? 'UTC',
-          },
-        }),
-      )
-      .catch(() =>
-        res.status(500).json({ error: 'Failed to resolve account preferences.' }),
-      );
+      });
+
+      return res.json({
+        user,
+        emailPreference: {
+          dailyDigestEnabled: preference?.dailyDigestEnabled ?? false,
+          dailyDigestTimezone: preference?.dailyDigestTimezone ?? 'UTC',
+        },
+      });
+    } catch (error) {
+      return next(error);
+    }
   });
-  app.patch('/api/taskforge/v1/me/email-preferences', async (req, res) => {
+  app.patch('/api/taskforge/v1/me/email-preferences', async (req, res, next) => {
     const user = res.locals.user as { id: string } | undefined;
     if (!user) {
       return res.status(401).json({ error: 'Unauthorized' });
     }
 
-    const enabled = req.body?.dailyDigestEnabled;
-    if (typeof enabled !== 'boolean') {
-      return res.status(400).json({ error: 'dailyDigestEnabled must be a boolean.' });
+    const parsed = EmailPreferenceUpdateSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ error: 'Invalid payload', details: parsed.error.flatten() });
     }
 
-    const preference = await getOrCreatePrisma().emailPreference.upsert({
-      where: { userId: user.id },
-      create: {
-        userId: user.id,
-        dailyDigestEnabled: enabled,
-      },
-      update: { dailyDigestEnabled: enabled },
-      select: { dailyDigestEnabled: true, dailyDigestTimezone: true },
-    });
+    try {
+      const preference = await getOrCreatePrisma().emailPreference.upsert({
+        where: { userId: user.id },
+        create: {
+          userId: user.id,
+          dailyDigestEnabled: parsed.data.dailyDigestEnabled,
+        },
+        update: { dailyDigestEnabled: parsed.data.dailyDigestEnabled },
+        select: { dailyDigestEnabled: true, dailyDigestTimezone: true },
+      });
 
-    return res.json({ emailPreference: preference });
+      return res.json({ emailPreference: preference });
+    } catch (error) {
+      return next(error);
+    }
   });
 
   return app;

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -141,7 +141,50 @@ export function createApp(options: CreateAppOptions = {}) {
     const user = res.locals.user as
       | { id: string; email: string; createdAt: string }
       | undefined;
-    res.json({ user: user ?? null });
+    if (!user) {
+      return res.json({ user: null });
+    }
+
+    void getOrCreatePrisma()
+      .emailPreference.findUnique({
+        where: { userId: user.id },
+        select: { dailyDigestEnabled: true, dailyDigestTimezone: true },
+      })
+      .then((preference) =>
+        res.json({
+          user,
+          emailPreference: {
+            dailyDigestEnabled: preference?.dailyDigestEnabled ?? false,
+            dailyDigestTimezone: preference?.dailyDigestTimezone ?? 'UTC',
+          },
+        }),
+      )
+      .catch(() =>
+        res.status(500).json({ error: 'Failed to resolve account preferences.' }),
+      );
+  });
+  app.patch('/api/taskforge/v1/me/email-preferences', async (req, res) => {
+    const user = res.locals.user as { id: string } | undefined;
+    if (!user) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+
+    const enabled = req.body?.dailyDigestEnabled;
+    if (typeof enabled !== 'boolean') {
+      return res.status(400).json({ error: 'dailyDigestEnabled must be a boolean.' });
+    }
+
+    const preference = await getOrCreatePrisma().emailPreference.upsert({
+      where: { userId: user.id },
+      create: {
+        userId: user.id,
+        dailyDigestEnabled: enabled,
+      },
+      update: { dailyDigestEnabled: enabled },
+      select: { dailyDigestEnabled: true, dailyDigestTimezone: true },
+    });
+
+    return res.json({ emailPreference: preference });
   });
 
   return app;

--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -70,6 +70,52 @@ const authTokens: OpenAPIV3.SchemaObject = {
   },
 };
 
+const emailPreference: OpenAPIV3.SchemaObject = {
+  type: 'object',
+  properties: {
+    dailyDigestEnabled: {
+      type: 'boolean',
+      description: 'Whether the authenticated user receives daily digest emails.',
+    },
+    dailyDigestTimezone: {
+      type: 'string',
+      description: 'IANA timezone used to resolve digest date windows.',
+      example: 'UTC',
+    },
+  },
+  required: ['dailyDigestEnabled', 'dailyDigestTimezone'],
+  example: {
+    dailyDigestEnabled: false,
+    dailyDigestTimezone: 'UTC',
+  },
+};
+
+const emailPreferenceUpdateInput: OpenAPIV3.SchemaObject = {
+  type: 'object',
+  properties: {
+    dailyDigestEnabled: {
+      type: 'boolean',
+      description: 'Enable or disable daily digest emails for the authenticated user.',
+    },
+  },
+  required: ['dailyDigestEnabled'],
+  additionalProperties: false,
+  example: {
+    dailyDigestEnabled: true,
+  },
+};
+
+const emailPreferenceResponse: OpenAPIV3.SchemaObject = {
+  type: 'object',
+  properties: {
+    emailPreference: { $ref: '#/components/schemas/EmailPreference' },
+  },
+  required: ['emailPreference'],
+  example: {
+    emailPreference: emailPreference.example as Record<string, unknown>,
+  },
+};
+
 const authSuccessExample = {
   user: authUser.example as Record<string, unknown>,
   tokens: authTokens.example as Record<string, unknown>,
@@ -97,7 +143,22 @@ const authMeSuccessExample = {
   value: { user: authUser.example as Record<string, unknown> },
 } satisfies OpenAPIV3.ExampleObject;
 
+const accountMeSuccessExample = {
+  value: {
+    user: authUser.example as Record<string, unknown>,
+    emailPreference: emailPreference.example as Record<string, unknown>,
+  },
+} satisfies OpenAPIV3.ExampleObject;
+
 const authMeAnonymousExample = { value: { user: null } } satisfies OpenAPIV3.ExampleObject;
+
+const emailPreferenceUpdateExample = {
+  value: emailPreferenceUpdateInput.example as Record<string, unknown>,
+} satisfies OpenAPIV3.ExampleObject;
+
+const emailPreferenceResponseExample = {
+  value: emailPreferenceResponse.example as Record<string, unknown>,
+} satisfies OpenAPIV3.ExampleObject;
 
 const authCredentialsExample = {
   value: authCredentials.example as Record<string, unknown>,
@@ -700,6 +761,10 @@ export const openApiDocument: OpenAPIV3.Document = {
             nullable: true,
             description: 'Authenticated user when available; `null` if unauthenticated.',
           },
+          emailPreference: {
+            allOf: [{ $ref: '#/components/schemas/EmailPreference' }],
+            description: 'Email preferences for the authenticated user. Present on `/api/taskforge/v1/me`.',
+          },
         },
         required: ['user'],
         example: authMeSuccessExample.value,
@@ -727,6 +792,9 @@ export const openApiDocument: OpenAPIV3.Document = {
       TaskUpdateInput: taskUpdateInput,
       TaskListResponse: taskListResponse,
       TaskDeleteResponse: taskDeletedResponse,
+      EmailPreference: emailPreference,
+      EmailPreferenceUpdateInput: emailPreferenceUpdateInput,
+      EmailPreferenceResponse: emailPreferenceResponse,
       DailyDigestTaskSummary: dailyDigestTaskSummary,
       DailyDigestGroup: dailyDigestGroup,
       DailyDigestPreviewResponse: dailyDigestPreviewResponse,
@@ -928,19 +996,74 @@ export const openApiDocument: OpenAPIV3.Document = {
     '/api/taskforge/v1/me': {
       get: {
         tags: ['Auth'],
-        summary: 'Alias for the authenticated user endpoint',
+        summary: 'Retrieve the authenticated user and account preferences',
         description:
-          'Requires a valid JWT provided via the `Authorization: Bearer <token>` header or the `tf_session` HttpOnly cookie.',
+          'Requires a valid JWT provided via the `Authorization: Bearer <token>` header or the `tf_session` HttpOnly cookie. Includes daily digest email preferences for signed-in users.',
         security: [{ bearerAuth: [] }, { sessionCookie: [] }],
         responses: {
           '200': {
-            description: 'Current user or null when not authenticated',
+            description: 'Current user and email preferences',
             content: {
               'application/json': {
                 schema: { $ref: '#/components/schemas/AuthMeResponse' },
                 examples: {
-                  authenticated: authMeSuccessExample,
+                  authenticated: accountMeSuccessExample,
                   unauthenticated: authMeAnonymousExample,
+                },
+              },
+            },
+          },
+          '401': {
+            description: 'Unauthorized',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/ErrorResponse' },
+                examples: {
+                  unauthorized: unauthorizedExample,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/api/taskforge/v1/me/email-preferences': {
+      patch: {
+        tags: ['Auth'],
+        summary: 'Update email preferences for the authenticated user',
+        description:
+          'Enables or disables daily digest emails for the signed-in user. Requires a valid JWT provided via the `Authorization: Bearer <token>` header or the `tf_session` HttpOnly cookie.',
+        security: [{ bearerAuth: [] }, { sessionCookie: [] }],
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/EmailPreferenceUpdateInput' },
+              examples: {
+                default: emailPreferenceUpdateExample,
+              },
+            },
+          },
+        },
+        responses: {
+          '200': {
+            description: 'Email preferences updated',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/EmailPreferenceResponse' },
+                examples: {
+                  default: emailPreferenceResponseExample,
+                },
+              },
+            },
+          },
+          '400': {
+            description: 'Validation error',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/ErrorResponse' },
+                examples: {
+                  invalid: invalidPayloadExample,
                 },
               },
             },

--- a/apps/api/tests/email-preferences-route.test.ts
+++ b/apps/api/tests/email-preferences-route.test.ts
@@ -1,0 +1,70 @@
+import type { SuperTest, Test } from 'supertest';
+
+import { createTestAgent } from './utils/test-app';
+import { registerTestUser } from './utils/auth';
+
+describe('Email preferences API', () => {
+  let agent: SuperTest<Test>;
+
+  beforeEach(() => {
+    agent = createTestAgent().agent;
+  });
+
+  it('returns default daily digest preferences with the current user', async () => {
+    const registered = await registerTestUser(agent, { email: 'email-prefs-default@example.com' });
+
+    const response = await agent
+      .get('/api/taskforge/v1/me')
+      .set('Authorization', `Bearer ${registered.tokens.accessToken}`)
+      .expect(200);
+
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        user: expect.objectContaining({ id: registered.user.id }),
+        emailPreference: {
+          dailyDigestEnabled: false,
+          dailyDigestTimezone: 'UTC',
+        },
+      }),
+    );
+  });
+
+  it('updates and persists daily digest preference state', async () => {
+    const registered = await registerTestUser(agent, { email: 'email-prefs-update@example.com' });
+
+    const update = await agent
+      .patch('/api/taskforge/v1/me/email-preferences')
+      .set('Authorization', `Bearer ${registered.tokens.accessToken}`)
+      .send({ dailyDigestEnabled: true })
+      .expect(200);
+
+    expect(update.body).toEqual({
+      emailPreference: {
+        dailyDigestEnabled: true,
+        dailyDigestTimezone: 'UTC',
+      },
+    });
+
+    const profile = await agent
+      .get('/api/taskforge/v1/me')
+      .set('Authorization', `Bearer ${registered.tokens.accessToken}`)
+      .expect(200);
+
+    expect(profile.body.emailPreference).toEqual({
+      dailyDigestEnabled: true,
+      dailyDigestTimezone: 'UTC',
+    });
+  });
+
+  it('rejects non-boolean daily digest preference updates', async () => {
+    const registered = await registerTestUser(agent, { email: 'email-prefs-invalid@example.com' });
+
+    const response = await agent
+      .patch('/api/taskforge/v1/me/email-preferences')
+      .set('Authorization', `Bearer ${registered.tokens.accessToken}`)
+      .send({ dailyDigestEnabled: 'true' })
+      .expect(400);
+
+    expect(response.body).toEqual(expect.objectContaining({ error: 'Invalid payload' }));
+  });
+});

--- a/apps/web/app/(protected)/dashboard/dashboard-content.test.tsx
+++ b/apps/web/app/(protected)/dashboard/dashboard-content.test.tsx
@@ -11,7 +11,19 @@ import { DashboardContent } from './dashboard-content';
 const routerReplace = vi.fn();
 const toast = vi.fn();
 const moveTaskMutateAsync = vi.fn();
+const updateEmailPreferenceMutate = vi.fn();
 const searchParams = new URLSearchParams();
+let emailPreferenceQueryState = {
+  data: {
+    dailyDigestEnabled: false,
+    dailyDigestTimezone: 'UTC',
+  },
+  isLoading: false,
+  isError: false,
+};
+let updateEmailPreferenceMutationState = {
+  isPending: false,
+};
 
 vi.mock('next/navigation', () => ({
   usePathname: () => '/dashboard',
@@ -377,6 +389,14 @@ vi.mock('@/lib/tasks-hooks', () => ({
   }),
 }));
 
+vi.mock('@/lib/email-preferences-hooks', () => ({
+  useEmailPreferenceQuery: () => emailPreferenceQueryState,
+  useUpdateEmailPreferenceMutation: () => ({
+    mutate: updateEmailPreferenceMutate,
+    ...updateEmailPreferenceMutationState,
+  }),
+}));
+
 function renderDashboard() {
   return render(
     <DashboardContent
@@ -407,6 +427,18 @@ describe('DashboardContent board drag behavior', () => {
     toast.mockClear();
     moveTaskMutateAsync.mockReset();
     moveTaskMutateAsync.mockResolvedValue(board);
+    updateEmailPreferenceMutate.mockReset();
+    emailPreferenceQueryState = {
+      data: {
+        dailyDigestEnabled: false,
+        dailyDigestTimezone: 'UTC',
+      },
+      isLoading: false,
+      isError: false,
+    };
+    updateEmailPreferenceMutationState = {
+      isPending: false,
+    };
     window.localStorage.clear();
   });
 
@@ -490,5 +522,42 @@ describe('DashboardContent board drag behavior', () => {
     })));
     await waitFor(() => expectBefore('Todo A', 'Todo B', todoLane));
     expectBefore('Todo B', 'Todo C', todoLane);
+  });
+
+  it('shows disabled digest state and submits an enable mutation', async () => {
+    const user = userEvent.setup();
+    renderDashboard();
+
+    expect(screen.getByText(/Status:\s*Disabled/)).toBeInTheDocument();
+
+    const toggle = screen.getByRole('button', { name: 'Turn daily digest emails on' });
+    expect(toggle).toHaveAttribute('aria-pressed', 'false');
+
+    await user.click(toggle);
+
+    expect(updateEmailPreferenceMutate).toHaveBeenCalledWith(true);
+  });
+
+  it('shows enabled digest state and submits a disable mutation', async () => {
+    const user = userEvent.setup();
+    emailPreferenceQueryState = {
+      data: {
+        dailyDigestEnabled: true,
+        dailyDigestTimezone: 'UTC',
+      },
+      isLoading: false,
+      isError: false,
+    };
+
+    renderDashboard();
+
+    expect(screen.getByText(/Status:\s*Enabled/)).toBeInTheDocument();
+
+    const toggle = screen.getByRole('button', { name: 'Turn daily digest emails off' });
+    expect(toggle).toHaveAttribute('aria-pressed', 'true');
+
+    await user.click(toggle);
+
+    expect(updateEmailPreferenceMutate).toHaveBeenCalledWith(false);
   });
 });

--- a/apps/web/app/(protected)/dashboard/dashboard-content.tsx
+++ b/apps/web/app/(protected)/dashboard/dashboard-content.tsx
@@ -78,6 +78,10 @@ import {
   useTasksQuery,
   type TaskListItem,
 } from "@/lib/tasks-hooks";
+import {
+  useEmailPreferenceQuery,
+  useUpdateEmailPreferenceMutation,
+} from "@/lib/email-preferences-hooks";
 import { cn } from "@/lib/utils";
 import { sanitizeTags } from "@/lib/task-tags";
 import { TaskTagSelector } from "@/components/tasks/task-tag-selector";
@@ -856,6 +860,8 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
   const workspaceBoardQuery = useTaskBoardQuery(undefined, {
     enabled: hasHydratedFilters,
   });
+  const emailPreferenceQuery = useEmailPreferenceQuery();
+  const updateEmailPreference = useUpdateEmailPreferenceMutation();
   const tagsQuery = useTagsQuery();
   const moveTask = useMoveTaskOnBoard();
   const { toast } = useToast();
@@ -1718,6 +1724,37 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
                   create it.
                 </p>
               ) : null}
+              <div className="rounded-lg border border-border/70 bg-background/60 p-3">
+                <div className="flex items-center justify-between gap-3">
+                  <div className="space-y-1">
+                    <p className="text-sm font-medium text-foreground">Daily digest emails</p>
+                    <p className="text-xs text-muted-foreground">
+                      Receive a summary each day around your local morning.
+                    </p>
+                  </div>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant={
+                      emailPreferenceQuery.data?.dailyDigestEnabled ? "default" : "secondary"
+                    }
+                    disabled={emailPreferenceQuery.isLoading || updateEmailPreference.isPending}
+                    onClick={() =>
+                      updateEmailPreference.mutate(
+                        !(emailPreferenceQuery.data?.dailyDigestEnabled ?? false),
+                      )
+                    }
+                  >
+                    {updateEmailPreference.isPending ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : emailPreferenceQuery.data?.dailyDigestEnabled ? (
+                      "Enabled"
+                    ) : (
+                      "Disabled"
+                    )}
+                  </Button>
+                </div>
+              </div>
             </CardContent>
           </Card>
         </motion.div>

--- a/apps/web/app/(protected)/dashboard/dashboard-content.tsx
+++ b/apps/web/app/(protected)/dashboard/dashboard-content.tsx
@@ -1729,7 +1729,17 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
                   <div className="space-y-1">
                     <p className="text-sm font-medium text-foreground">Daily digest emails</p>
                     <p className="text-xs text-muted-foreground">
-                      Receive a summary each day around your local morning.
+                      Receive a daily task summary during the configured delivery window.
+                    </p>
+                    <p className="text-xs font-medium text-foreground">
+                      Status:{" "}
+                      {emailPreferenceQuery.isLoading
+                        ? "Loading"
+                        : emailPreferenceQuery.isError
+                          ? "Unavailable"
+                          : emailPreferenceQuery.data?.dailyDigestEnabled
+                            ? "Enabled"
+                            : "Disabled"}
                     </p>
                   </div>
                   <Button
@@ -1738,7 +1748,17 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
                     variant={
                       emailPreferenceQuery.data?.dailyDigestEnabled ? "default" : "secondary"
                     }
-                    disabled={emailPreferenceQuery.isLoading || updateEmailPreference.isPending}
+                    aria-label={
+                      emailPreferenceQuery.data?.dailyDigestEnabled
+                        ? "Turn daily digest emails off"
+                        : "Turn daily digest emails on"
+                    }
+                    aria-pressed={Boolean(emailPreferenceQuery.data?.dailyDigestEnabled)}
+                    disabled={
+                      emailPreferenceQuery.isLoading ||
+                      emailPreferenceQuery.isError ||
+                      updateEmailPreference.isPending
+                    }
                     onClick={() =>
                       updateEmailPreference.mutate(
                         !(emailPreferenceQuery.data?.dailyDigestEnabled ?? false),
@@ -1746,11 +1766,14 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
                     }
                   >
                     {updateEmailPreference.isPending ? (
-                      <Loader2 className="h-4 w-4 animate-spin" />
+                      <>
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                        Saving
+                      </>
                     ) : emailPreferenceQuery.data?.dailyDigestEnabled ? (
-                      "Enabled"
+                      "Turn off"
                     ) : (
-                      "Disabled"
+                      "Turn on"
                     )}
                   </Button>
                 </div>

--- a/apps/web/lib/email-preferences-client.ts
+++ b/apps/web/lib/email-preferences-client.ts
@@ -1,0 +1,49 @@
+import { z } from 'zod';
+
+import { getApiUrl } from './env';
+
+const EmailPreferenceSchema = z.object({
+  dailyDigestEnabled: z.boolean(),
+  dailyDigestTimezone: z.string().min(1),
+});
+
+const MeResponseSchema = z.object({
+  user: z.object({ id: z.string().uuid(), email: z.string().nullable() }).nullable(),
+  emailPreference: EmailPreferenceSchema.optional(),
+});
+
+const UpdateResponseSchema = z.object({
+  emailPreference: EmailPreferenceSchema,
+});
+
+export type EmailPreference = z.infer<typeof EmailPreferenceSchema>;
+
+export async function getEmailPreference(): Promise<EmailPreference> {
+  const response = await fetch(getApiUrl('v1/me'), {
+    method: 'GET',
+    credentials: 'include',
+    cache: 'no-store',
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch email preferences.');
+  }
+
+  const payload = MeResponseSchema.parse(await response.json());
+  return payload.emailPreference ?? { dailyDigestEnabled: false, dailyDigestTimezone: 'UTC' };
+}
+
+export async function updateEmailPreference(input: Pick<EmailPreference, 'dailyDigestEnabled'>): Promise<EmailPreference> {
+  const response = await fetch(getApiUrl('v1/me/email-preferences'), {
+    method: 'PATCH',
+    credentials: 'include',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(input),
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to update email preferences.');
+  }
+
+  return UpdateResponseSchema.parse(await response.json()).emailPreference;
+}

--- a/apps/web/lib/email-preferences-client.ts
+++ b/apps/web/lib/email-preferences-client.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import { getApiUrl } from './env';
+import { requestTaskforgeJson } from './tasks-client';
 
 const EmailPreferenceSchema = z.object({
   dailyDigestEnabled: z.boolean(),
@@ -19,31 +19,18 @@ const UpdateResponseSchema = z.object({
 export type EmailPreference = z.infer<typeof EmailPreferenceSchema>;
 
 export async function getEmailPreference(): Promise<EmailPreference> {
-  const response = await fetch(getApiUrl('v1/me'), {
+  const payload = await requestTaskforgeJson('v1/me', {
     method: 'GET',
-    credentials: 'include',
-    cache: 'no-store',
+    schema: MeResponseSchema,
   });
-
-  if (!response.ok) {
-    throw new Error('Failed to fetch email preferences.');
-  }
-
-  const payload = MeResponseSchema.parse(await response.json());
   return payload.emailPreference ?? { dailyDigestEnabled: false, dailyDigestTimezone: 'UTC' };
 }
 
 export async function updateEmailPreference(input: Pick<EmailPreference, 'dailyDigestEnabled'>): Promise<EmailPreference> {
-  const response = await fetch(getApiUrl('v1/me/email-preferences'), {
+  const response = await requestTaskforgeJson('v1/me/email-preferences', {
     method: 'PATCH',
-    credentials: 'include',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify(input),
+    body: input,
+    schema: UpdateResponseSchema,
   });
-
-  if (!response.ok) {
-    throw new Error('Failed to update email preferences.');
-  }
-
-  return UpdateResponseSchema.parse(await response.json()).emailPreference;
+  return response.emailPreference;
 }

--- a/apps/web/lib/email-preferences-hooks.ts
+++ b/apps/web/lib/email-preferences-hooks.ts
@@ -1,20 +1,41 @@
 'use client';
 
+import { useEffect, useRef } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { getEmailPreference, updateEmailPreference, type EmailPreference } from './email-preferences-client';
 import { useAuth } from './use-auth';
 
 const queryKeyFor = (userId: string | null | undefined) => ['email-preferences', userId ?? 'anonymous'] as const;
+const FALLBACK_USER_KEY = 'anonymous';
 
 export function useEmailPreferenceQuery() {
-  const { user } = useAuth();
+  const { user, status } = useAuth();
+  const queryClient = useQueryClient();
+  const previousUserIdRef = useRef<string | null>(null);
   const queryKey = queryKeyFor(user?.id);
+
+  useEffect(() => {
+    if (status !== 'authenticated') {
+      queryClient.removeQueries({ queryKey: queryKeyFor(FALLBACK_USER_KEY) });
+    }
+  }, [queryClient, status]);
+
+  useEffect(() => {
+    const previousUserId = previousUserIdRef.current;
+    const nextUserId = user?.id ?? null;
+
+    if (previousUserId && previousUserId !== nextUserId) {
+      queryClient.removeQueries({ queryKey: queryKeyFor(previousUserId) });
+    }
+
+    previousUserIdRef.current = nextUserId;
+  }, [queryClient, user?.id]);
 
   return useQuery({
     queryKey,
     queryFn: getEmailPreference,
-    enabled: Boolean(user?.id),
+    enabled: status === 'authenticated' && Boolean(user?.id),
   });
 }
 
@@ -28,15 +49,18 @@ export function useUpdateEmailPreferenceMutation() {
     onMutate: async (dailyDigestEnabled) => {
       await queryClient.cancelQueries({ queryKey });
       const previous = queryClient.getQueryData<EmailPreference>(queryKey);
+      const hadPrevious = previous !== undefined;
       queryClient.setQueryData<EmailPreference>(queryKey, (current) => ({
         dailyDigestEnabled,
         dailyDigestTimezone: current?.dailyDigestTimezone ?? previous?.dailyDigestTimezone ?? 'UTC',
       }));
-      return { previous };
+      return { previous, hadPrevious };
     },
     onError: (_error, _variables, context) => {
-      if (context?.previous) {
+      if (context?.hadPrevious) {
         queryClient.setQueryData(queryKey, context.previous);
+      } else {
+        queryClient.removeQueries({ queryKey, exact: true });
       }
     },
     onSuccess: (next) => {

--- a/apps/web/lib/email-preferences-hooks.ts
+++ b/apps/web/lib/email-preferences-hooks.ts
@@ -1,0 +1,46 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { getEmailPreference, updateEmailPreference, type EmailPreference } from './email-preferences-client';
+import { useAuth } from './use-auth';
+
+const queryKeyFor = (userId: string | null | undefined) => ['email-preferences', userId ?? 'anonymous'] as const;
+
+export function useEmailPreferenceQuery() {
+  const { user } = useAuth();
+  const queryKey = queryKeyFor(user?.id);
+
+  return useQuery({
+    queryKey,
+    queryFn: getEmailPreference,
+    enabled: Boolean(user?.id),
+  });
+}
+
+export function useUpdateEmailPreferenceMutation() {
+  const { user } = useAuth();
+  const queryClient = useQueryClient();
+  const queryKey = queryKeyFor(user?.id);
+
+  return useMutation({
+    mutationFn: (dailyDigestEnabled: boolean) => updateEmailPreference({ dailyDigestEnabled }),
+    onMutate: async (dailyDigestEnabled) => {
+      await queryClient.cancelQueries({ queryKey });
+      const previous = queryClient.getQueryData<EmailPreference>(queryKey);
+      queryClient.setQueryData<EmailPreference>(queryKey, (current) => ({
+        dailyDigestEnabled,
+        dailyDigestTimezone: current?.dailyDigestTimezone ?? previous?.dailyDigestTimezone ?? 'UTC',
+      }));
+      return { previous };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(queryKey, context.previous);
+      }
+    },
+    onSuccess: (next) => {
+      queryClient.setQueryData(queryKey, next);
+    },
+  });
+}

--- a/apps/web/lib/tasks-client.ts
+++ b/apps/web/lib/tasks-client.ts
@@ -689,6 +689,19 @@ async function requestJson<T>(
   return parseJson(response, init.schema);
 }
 
+export function requestTaskforgeJson<T>(
+  path: string,
+  init: {
+    method: string;
+    body?: unknown;
+    query?: Record<string, string | string[]>;
+    schema: z.ZodSchema<T>;
+  },
+  options?: TaskClientRequestOptions,
+): Promise<T> {
+  return requestJson(path, init, options);
+}
+
 export async function listTasks(
   params?: TaskListQuery,
   options?: TaskClientRequestOptions,

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -170,6 +170,14 @@
             ],
             "nullable": true,
             "description": "Authenticated user when available; `null` if unauthenticated."
+          },
+          "emailPreference": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EmailPreference"
+              }
+            ],
+            "description": "Email preferences for the authenticated user. Present on `/api/taskforge/v1/me`."
           }
         },
         "required": [
@@ -910,6 +918,61 @@
           "status": "deleted"
         }
       },
+      "EmailPreference": {
+        "type": "object",
+        "properties": {
+          "dailyDigestEnabled": {
+            "type": "boolean",
+            "description": "Whether the authenticated user receives daily digest emails."
+          },
+          "dailyDigestTimezone": {
+            "type": "string",
+            "description": "IANA timezone used to resolve digest date windows.",
+            "example": "UTC"
+          }
+        },
+        "required": [
+          "dailyDigestEnabled",
+          "dailyDigestTimezone"
+        ],
+        "example": {
+          "dailyDigestEnabled": false,
+          "dailyDigestTimezone": "UTC"
+        }
+      },
+      "EmailPreferenceUpdateInput": {
+        "type": "object",
+        "properties": {
+          "dailyDigestEnabled": {
+            "type": "boolean",
+            "description": "Enable or disable daily digest emails for the authenticated user."
+          }
+        },
+        "required": [
+          "dailyDigestEnabled"
+        ],
+        "additionalProperties": false,
+        "example": {
+          "dailyDigestEnabled": true
+        }
+      },
+      "EmailPreferenceResponse": {
+        "type": "object",
+        "properties": {
+          "emailPreference": {
+            "$ref": "#/components/schemas/EmailPreference"
+          }
+        },
+        "required": [
+          "emailPreference"
+        ],
+        "example": {
+          "emailPreference": {
+            "dailyDigestEnabled": false,
+            "dailyDigestTimezone": "UTC"
+          }
+        }
+      },
       "DailyDigestTaskSummary": {
         "type": "object",
         "properties": {
@@ -1552,8 +1615,8 @@
         "tags": [
           "Auth"
         ],
-        "summary": "Alias for the authenticated user endpoint",
-        "description": "Requires a valid JWT provided via the `Authorization: Bearer <token>` header or the `tf_session` HttpOnly cookie.",
+        "summary": "Retrieve the authenticated user and account preferences",
+        "description": "Requires a valid JWT provided via the `Authorization: Bearer <token>` header or the `tf_session` HttpOnly cookie. Includes daily digest email preferences for signed-in users.",
         "security": [
           {
             "bearerAuth": []
@@ -1564,7 +1627,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Current user or null when not authenticated",
+            "description": "Current user and email preferences",
             "content": {
               "application/json": {
                 "schema": {
@@ -1577,12 +1640,114 @@
                         "id": "26f26639-05ad-40b6-8248-379644dcdf18",
                         "email": "user@example.com",
                         "createdAt": "2024-06-01T12:00:00.000Z"
+                      },
+                      "emailPreference": {
+                        "dailyDigestEnabled": false,
+                        "dailyDigestTimezone": "UTC"
                       }
                     }
                   },
                   "unauthenticated": {
                     "value": {
                       "user": null
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unauthorized": {
+                    "value": {
+                      "error": "Unauthorized"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/taskforge/v1/me/email-preferences": {
+      "patch": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Update email preferences for the authenticated user",
+        "description": "Enables or disables daily digest emails for the signed-in user. Requires a valid JWT provided via the `Authorization: Bearer <token>` header or the `tf_session` HttpOnly cookie.",
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EmailPreferenceUpdateInput"
+              },
+              "examples": {
+                "default": {
+                  "value": {
+                    "dailyDigestEnabled": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Email preferences updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmailPreferenceResponse"
+                },
+                "examples": {
+                  "default": {
+                    "value": {
+                      "emailPreference": {
+                        "dailyDigestEnabled": false,
+                        "dailyDigestTimezone": "UTC"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "invalid": {
+                    "value": {
+                      "error": "Invalid payload",
+                      "details": {
+                        "fieldErrors": {
+                          "email": [
+                            "Invalid email address"
+                          ]
+                        },
+                        "formErrors": []
+                      }
                     }
                   }
                 }

--- a/docs/tasks/milestone5/07-email-settings-ui.md
+++ b/docs/tasks/milestone5/07-email-settings-ui.md
@@ -4,14 +4,21 @@
 - Add a web settings surface for daily digest preferences.
 - Let users see and change whether digest emails are enabled.
 
-**Status:** New.
+**Status:** Completed.
 
 ## Acceptance Criteria
-- [ ] Authenticated users can view current email preference state from the web app.
-- [ ] Users can enable/disable daily digest emails with optimistic feedback and rollback on failure.
-- [ ] Settings UI explains delivery timing without exposing internal scheduler details.
-- [ ] Preference mutations update the API and React Query cache consistently.
+- [x] Authenticated users can view current email preference state from the web app.
+- [x] Users can enable/disable daily digest emails with optimistic feedback and rollback on failure.
+- [x] Settings UI explains delivery timing without exposing internal scheduler details.
+- [x] Preference mutations update the API and React Query cache consistently.
 
 ## Notes
 - Prefer a small settings panel over a broad account-settings redesign.
 - Keep welcome email preferences out of the first UI unless product requirements demand it.
+
+## Implementation Notes
+- Added `/api/taskforge/v1/me/email-preferences` for authenticated daily digest preference updates.
+- Extended `/api/taskforge/v1/me` so the web app can read the current daily digest preference alongside the session user.
+- Added a compact dashboard account panel control that shows digest status, explains delivery at a product level, and toggles daily digest emails.
+- Web preference hooks use React Query optimistic updates, restore previous cache data on failure, and remove first-write optimistic cache entries when the mutation fails before a preference was loaded.
+- Welcome email preferences remain API/model-only and are intentionally not surfaced in this first UI.


### PR DESCRIPTION
### Motivation
- Provide a small, focused settings surface so authenticated users can view and toggle daily digest email delivery without a full account-settings redesign. 
- Surface a clear, user-friendly delivery explanation (timing) without revealing internal scheduler details. 
- Ensure preference changes update the API and client cache with optimistic feedback and rollback on failure.

### Description
- Added email preference data to the `GET /api/taskforge/v1/me` response and return safe defaults when no preference exists by querying `emailPreference` via Prisma in `apps/api/src/app.ts`.
- Implemented a new authenticated mutation endpoint `PATCH /api/taskforge/v1/me/email-preferences` that `upsert`s `dailyDigestEnabled` for the current user in `apps/api/src/app.ts`.
- Added a typed web client `getEmailPreference` / `updateEmailPreference` in `apps/web/lib/email-preferences-client.ts` that validates responses with `zod` and uses `getApiUrl` for requests.
- Introduced React Query hooks `useEmailPreferenceQuery` and `useUpdateEmailPreferenceMutation` with optimistic updates and rollback on error in `apps/web/lib/email-preferences-hooks.ts`, and wired them into a compact dashboard UI panel in `apps/web/app/(protected)/dashboard/dashboard-content.tsx` with user-facing timing copy.

### Testing
- Ran web typecheck with `pnpm -C apps/web typecheck`, which succeeded. 