### PR TITLE
web: add digest preview panel to dashboard

### DIFF
--- a/apps/web/app/(protected)/dashboard/dashboard-content.test.tsx
+++ b/apps/web/app/(protected)/dashboard/dashboard-content.test.tsx
@@ -24,7 +24,19 @@ let emailPreferenceQueryState = {
 let updateEmailPreferenceMutationState = {
   isPending: false,
 };
-let digestPreviewQueryState = {
+
+type DigestPreviewQueryState = {
+  data?: {
+    totalTasksConsidered: number;
+    groups: Array<{ key: string; label: string; total: number; tasks: unknown[] }>;
+  };
+  isLoading: boolean;
+  isFetching: boolean;
+  isError: boolean;
+  refetch: ReturnType<typeof vi.fn>;
+};
+
+let digestPreviewQueryState: DigestPreviewQueryState = {
   data: {
     totalTasksConsidered: 2,
     groups: [
@@ -593,6 +605,7 @@ describe('DashboardContent board drag behavior', () => {
   it('shows disabled digest preview message when preference is off', () => {
     renderDashboard();
     expect(screen.getByText(/Digest is currently disabled\./)).toBeInTheDocument();
+    expect(screen.getByText('Overdue')).toBeInTheDocument();
   });
 
   it('shows digest preview groups and counts from read model', () => {
@@ -601,5 +614,61 @@ describe('DashboardContent board drag behavior', () => {
     expect(screen.getByText('Overdue')).toBeInTheDocument();
     expect(screen.getAllByText('Due today').length).toBeGreaterThan(0);
     expect(screen.getAllByText('1').length).toBeGreaterThan(0);
+  });
+
+  it('shows a loading state while digest preview data is loading', () => {
+    emailPreferenceQueryState.data.dailyDigestEnabled = true;
+    digestPreviewQueryState = {
+      data: undefined,
+      isLoading: true,
+      isFetching: true,
+      isError: false,
+      refetch: vi.fn(),
+    };
+
+    renderDashboard();
+
+    expect(screen.getByRole('status', { name: 'Loading digest preview' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Refresh digest preview' })).toBeDisabled();
+  });
+
+  it('shows an error state when digest preview data cannot load', () => {
+    emailPreferenceQueryState.data.dailyDigestEnabled = true;
+    digestPreviewQueryState = {
+      data: undefined,
+      isLoading: false,
+      isFetching: false,
+      isError: true,
+      refetch: vi.fn(),
+    };
+
+    renderDashboard();
+
+    expect(screen.getByText('Digest preview is unavailable right now.')).toBeInTheDocument();
+  });
+
+  it('shows an empty state when digest preview has no matching tasks', () => {
+    emailPreferenceQueryState.data.dailyDigestEnabled = true;
+    digestPreviewQueryState = {
+      data: {
+        totalTasksConsidered: 0,
+        groups: [
+          { key: 'overdue', label: 'Overdue', total: 0, tasks: [] },
+          { key: 'dueToday', label: 'Due today', total: 0, tasks: [] },
+          { key: 'dueSoon', label: 'Due soon', total: 0, tasks: [] },
+          { key: 'recentlyUpdated', label: 'Recently updated', total: 0, tasks: [] },
+          { key: 'blockedByStatus', label: 'Still todo', total: 0, tasks: [] },
+        ],
+      },
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+      refetch: vi.fn(),
+    };
+
+    renderDashboard();
+
+    expect(screen.getByText('No digest-worthy tasks right now.')).toBeInTheDocument();
+    expect(screen.getByText('Still todo')).toBeInTheDocument();
   });
 });

--- a/apps/web/app/(protected)/dashboard/dashboard-content.test.tsx
+++ b/apps/web/app/(protected)/dashboard/dashboard-content.test.tsx
@@ -24,6 +24,19 @@ let emailPreferenceQueryState = {
 let updateEmailPreferenceMutationState = {
   isPending: false,
 };
+let digestPreviewQueryState = {
+  data: {
+    totalTasksConsidered: 2,
+    groups: [
+      { key: 'overdue', label: 'Overdue', total: 1, tasks: [] },
+      { key: 'dueToday', label: 'Due today', total: 1, tasks: [] },
+    ],
+  },
+  isLoading: false,
+  isFetching: false,
+  isError: false,
+  refetch: vi.fn(),
+};
 
 vi.mock('next/navigation', () => ({
   usePathname: () => '/dashboard',
@@ -396,6 +409,9 @@ vi.mock('@/lib/email-preferences-hooks', () => ({
     ...updateEmailPreferenceMutationState,
   }),
 }));
+vi.mock('@/lib/digest-preview-hooks', () => ({
+  useDigestPreviewQuery: () => digestPreviewQueryState,
+}));
 
 function renderDashboard() {
   return render(
@@ -438,6 +454,19 @@ describe('DashboardContent board drag behavior', () => {
     };
     updateEmailPreferenceMutationState = {
       isPending: false,
+    };
+    digestPreviewQueryState = {
+      data: {
+        totalTasksConsidered: 2,
+        groups: [
+          { key: 'overdue', label: 'Overdue', total: 1, tasks: [] },
+          { key: 'dueToday', label: 'Due today', total: 1, tasks: [] },
+        ],
+      },
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+      refetch: vi.fn(),
     };
     window.localStorage.clear();
   });
@@ -559,5 +588,18 @@ describe('DashboardContent board drag behavior', () => {
     await user.click(toggle);
 
     expect(updateEmailPreferenceMutate).toHaveBeenCalledWith(false);
+  });
+
+  it('shows disabled digest preview message when preference is off', () => {
+    renderDashboard();
+    expect(screen.getByText(/Digest is currently disabled\./)).toBeInTheDocument();
+  });
+
+  it('shows digest preview groups and counts from read model', () => {
+    emailPreferenceQueryState.data.dailyDigestEnabled = true;
+    renderDashboard();
+    expect(screen.getByText('Overdue')).toBeInTheDocument();
+    expect(screen.getAllByText('Due today').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('1').length).toBeGreaterThan(0);
   });
 });

--- a/apps/web/app/(protected)/dashboard/dashboard-content.tsx
+++ b/apps/web/app/(protected)/dashboard/dashboard-content.tsx
@@ -1207,6 +1207,10 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
     !boardQuery.isError &&
     visibleTaskCount === 0;
   const dragActive = Boolean(activeId);
+  const isDigestPreferenceDisabled =
+    !emailPreferenceQuery.isLoading &&
+    !emailPreferenceQuery.isError &&
+    !emailPreferenceQuery.data?.dailyDigestEnabled;
 
   const renderedTaskMap = useMemo(() => {
     const map = new Map<string, TaskListItem>();
@@ -1786,6 +1790,7 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
                       type="button"
                       size="sm"
                       variant="ghost"
+                      aria-label="Refresh digest preview"
                       className="h-7 px-2 text-xs"
                       disabled={digestPreviewQuery.isLoading || digestPreviewQuery.isFetching}
                       onClick={() => void digestPreviewQuery.refetch()}
@@ -1794,12 +1799,13 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
                       Refresh
                     </Button>
                   </div>
-                  {!emailPreferenceQuery.isLoading && !emailPreferenceQuery.isError && !emailPreferenceQuery.data?.dailyDigestEnabled ? (
+                  {isDigestPreferenceDisabled ? (
                     <p className="text-xs text-muted-foreground">
                       Digest is currently disabled. Enable it to keep this preview aligned with your next scheduled send.
                     </p>
-                  ) : digestPreviewQuery.isLoading ? (
-                    <div className="space-y-2">
+                  ) : null}
+                  {digestPreviewQuery.isLoading ? (
+                    <div className="space-y-2" role="status" aria-label="Loading digest preview">
                       <Skeleton className="h-4 w-full" />
                       <Skeleton className="h-4 w-5/6" />
                     </div>

--- a/apps/web/app/(protected)/dashboard/dashboard-content.tsx
+++ b/apps/web/app/(protected)/dashboard/dashboard-content.tsx
@@ -82,6 +82,7 @@ import {
   useEmailPreferenceQuery,
   useUpdateEmailPreferenceMutation,
 } from "@/lib/email-preferences-hooks";
+import { useDigestPreviewQuery } from "@/lib/digest-preview-hooks";
 import { cn } from "@/lib/utils";
 import { sanitizeTags } from "@/lib/task-tags";
 import { TaskTagSelector } from "@/components/tasks/task-tag-selector";
@@ -862,6 +863,7 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
   });
   const emailPreferenceQuery = useEmailPreferenceQuery();
   const updateEmailPreference = useUpdateEmailPreferenceMutation();
+  const digestPreviewQuery = useDigestPreviewQuery();
   const tagsQuery = useTagsQuery();
   const moveTask = useMoveTaskOnBoard();
   const { toast } = useToast();
@@ -1776,6 +1778,48 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
                       "Turn on"
                     )}
                   </Button>
+                </div>
+                <div className="mt-4 border-t border-border/60 pt-3">
+                  <div className="mb-2 flex items-center justify-between gap-2">
+                    <p className="text-xs font-medium text-foreground">Next digest preview</p>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="ghost"
+                      className="h-7 px-2 text-xs"
+                      disabled={digestPreviewQuery.isLoading || digestPreviewQuery.isFetching}
+                      onClick={() => void digestPreviewQuery.refetch()}
+                    >
+                      <RefreshCcw className={cn("h-3.5 w-3.5", digestPreviewQuery.isFetching && "animate-spin")} />
+                      Refresh
+                    </Button>
+                  </div>
+                  {!emailPreferenceQuery.isLoading && !emailPreferenceQuery.isError && !emailPreferenceQuery.data?.dailyDigestEnabled ? (
+                    <p className="text-xs text-muted-foreground">
+                      Digest is currently disabled. Enable it to keep this preview aligned with your next scheduled send.
+                    </p>
+                  ) : digestPreviewQuery.isLoading ? (
+                    <div className="space-y-2">
+                      <Skeleton className="h-4 w-full" />
+                      <Skeleton className="h-4 w-5/6" />
+                    </div>
+                  ) : digestPreviewQuery.isError ? (
+                    <p className="text-xs text-destructive">Digest preview is unavailable right now.</p>
+                  ) : digestPreviewQuery.data ? (
+                    <div className="space-y-2">
+                      {digestPreviewQuery.data.groups.map((group) => (
+                        <div key={group.key} className="flex items-center justify-between text-xs">
+                          <span className="text-muted-foreground">{group.label}</span>
+                          <span className="font-medium text-foreground">{group.total}</span>
+                        </div>
+                      ))}
+                      {digestPreviewQuery.data.totalTasksConsidered === 0 ? (
+                        <p className="text-xs text-muted-foreground">No digest-worthy tasks right now.</p>
+                      ) : null}
+                    </div>
+                  ) : (
+                    <p className="text-xs text-muted-foreground">No preview data yet.</p>
+                  )}
                 </div>
               </div>
             </CardContent>

--- a/apps/web/lib/digest-preview-client.ts
+++ b/apps/web/lib/digest-preview-client.ts
@@ -19,9 +19,17 @@ const DigestGroupSchema = z.object({
   tasks: z.array(DigestTaskSchema),
 });
 
+const DigestPreviewWindowSchema = z.object({
+  startOfTodayUtc: z.string(),
+  startOfTomorrowUtc: z.string(),
+  dueSoonUntilUtc: z.string(),
+  recentlyUpdatedSinceUtc: z.string(),
+});
+
 const DigestPreviewSchema = z.object({
   generatedAt: z.string(),
   timezone: z.string(),
+  window: DigestPreviewWindowSchema,
   totalTasksConsidered: z.number().int().nonnegative(),
   groups: z.array(DigestGroupSchema),
 });

--- a/apps/web/lib/digest-preview-client.ts
+++ b/apps/web/lib/digest-preview-client.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+
+import { requestTaskforgeJson } from './tasks-client';
+
+const DigestTaskSchema = z.object({
+  id: z.string().uuid(),
+  title: z.string(),
+  status: z.enum(['TODO', 'IN_PROGRESS', 'DONE']),
+  priority: z.enum(['LOW', 'MEDIUM', 'HIGH']),
+  dueDate: z.string().optional(),
+  updatedAt: z.string(),
+  tags: z.array(z.string()),
+});
+
+const DigestGroupSchema = z.object({
+  key: z.enum(['overdue', 'dueToday', 'dueSoon', 'recentlyUpdated', 'blockedByStatus']),
+  label: z.string(),
+  total: z.number().int().nonnegative(),
+  tasks: z.array(DigestTaskSchema),
+});
+
+const DigestPreviewSchema = z.object({
+  generatedAt: z.string(),
+  timezone: z.string(),
+  totalTasksConsidered: z.number().int().nonnegative(),
+  groups: z.array(DigestGroupSchema),
+});
+
+export type DigestPreview = z.infer<typeof DigestPreviewSchema>;
+
+export async function getDigestPreview(): Promise<DigestPreview> {
+  return requestTaskforgeJson('v1/email/digest/preview', {
+    method: 'GET',
+    schema: DigestPreviewSchema,
+  });
+}

--- a/apps/web/lib/digest-preview-hooks.ts
+++ b/apps/web/lib/digest-preview-hooks.ts
@@ -5,11 +5,17 @@ import { useQuery } from '@tanstack/react-query';
 import { getDigestPreview } from './digest-preview-client';
 import { useAuth } from './use-auth';
 
+const FALLBACK_USER_KEY = 'anonymous';
+
+export const digestPreviewQueryKeys = {
+  all: (userId: string | null | undefined) => ['email-digest-preview', userId ?? FALLBACK_USER_KEY] as const,
+};
+
 export function useDigestPreviewQuery() {
   const { user, status } = useAuth();
 
   return useQuery({
-    queryKey: ['email-digest-preview', user?.id ?? 'anonymous'],
+    queryKey: digestPreviewQueryKeys.all(user?.id),
     queryFn: getDigestPreview,
     enabled: status === 'authenticated' && Boolean(user?.id),
   });

--- a/apps/web/lib/digest-preview-hooks.ts
+++ b/apps/web/lib/digest-preview-hooks.ts
@@ -1,0 +1,16 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { getDigestPreview } from './digest-preview-client';
+import { useAuth } from './use-auth';
+
+export function useDigestPreviewQuery() {
+  const { user, status } = useAuth();
+
+  return useQuery({
+    queryKey: ['email-digest-preview', user?.id ?? 'anonymous'],
+    queryFn: getDigestPreview,
+    enabled: status === 'authenticated' && Boolean(user?.id),
+  });
+}

--- a/apps/web/lib/tasks-hooks.test.ts
+++ b/apps/web/lib/tasks-hooks.test.ts
@@ -1,5 +1,5 @@
 import { QueryClient } from '@tanstack/react-query';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import type { TaskBoardResponse } from './tasks-client';
 import type { TaskListData, TaskListItem } from './tasks-hooks';
@@ -76,6 +76,17 @@ const board: TaskBoardResponse = {
 };
 
 describe('tasks-hooks board cache helpers', () => {
+  it('invalidates the digest preview cache for task-derived read model changes', () => {
+    const queryClient = new QueryClient();
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+
+    __testing.invalidateDigestPreview(queryClient, 'user-1');
+
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['email-digest-preview', 'user-1'],
+    });
+  });
+
   it('applies task edits to the board cache and recomputes lane metadata', () => {
     const now = new Date('2024-06-15T00:00:00.000Z');
 

--- a/apps/web/lib/tasks-hooks.ts
+++ b/apps/web/lib/tasks-hooks.ts
@@ -25,6 +25,7 @@ import {
   updateTask,
   TaskClientError,
 } from './tasks-client';
+import { digestPreviewQueryKeys } from './digest-preview-hooks';
 import type {
   BoardMoveInput,
   CreateTaskInput,
@@ -963,6 +964,10 @@ function scopedQueryKey(userId?: string | null): string {
   return userId ?? FALLBACK_USER_KEY;
 }
 
+function invalidateDigestPreview(queryClient: QueryClient, userScope: string): void {
+  queryClient.invalidateQueries({ queryKey: digestPreviewQueryKeys.all(userScope) });
+}
+
 function deserializeNormalizedFilters(serialized: string): NormalizedTaskListFilters | undefined {
   if (!serialized || serialized === 'undefined' || serialized === 'null') {
     return undefined;
@@ -1437,6 +1442,7 @@ export function useCreateTask(
     onSettled: (result, error, variables, context, mutationContext) => {
       onSettled?.(result, error, variables, context, mutationContext);
       queryClient.invalidateQueries({ queryKey: taskQueryKeys.all(userScope) });
+      invalidateDigestPreview(queryClient, userScope);
     },
     ...restOptions,
   });
@@ -1605,6 +1611,7 @@ export function useUpdateTask(
     onSettled: (result, error, variables, context, mutationContext) => {
       onSettled?.(result, error, variables, context, mutationContext);
       queryClient.invalidateQueries({ queryKey: taskQueryKeys.all(userScope) });
+      invalidateDigestPreview(queryClient, userScope);
     },
     ...restOptions,
   });
@@ -1750,6 +1757,7 @@ export function useMoveTaskOnBoard<TContext extends object = Record<string, neve
         type: 'active',
       });
       queryClient.invalidateQueries({ queryKey: taskQueryKeys.all(userScope) });
+      invalidateDigestPreview(queryClient, userScope);
     },
     ...restOptions,
   });
@@ -1816,6 +1824,7 @@ export function useDeleteTask(
     onSettled: (result, error, variables, context, mutationContext) => {
       onSettled?.(result, error, variables, context, mutationContext);
       queryClient.invalidateQueries({ queryKey: taskQueryKeys.all(userScope) });
+      invalidateDigestPreview(queryClient, userScope);
     },
     ...restOptions,
   });
@@ -1858,5 +1867,6 @@ export const __testing = {
   removeTaskFromBoard,
   collectBoardQueries,
   restoreBoardSnapshots,
+  invalidateDigestPreview,
   taskQueryKeys,
 };

--- a/docs/tasks/milestone5/08-digest-preview-ui.md
+++ b/docs/tasks/milestone5/08-digest-preview-ui.md
@@ -4,14 +4,20 @@
 - Show users the task groups that would appear in their next digest.
 - Make the preview useful even before email delivery is enabled.
 
-**Status:** New.
+**Status:** Completed.
 
 ## Acceptance Criteria
-- [ ] Dashboard or settings page renders the digest preview from the API read model.
-- [ ] Empty, loading, error, and disabled-preference states are covered.
-- [ ] Preview groups match the email template grouping and counts.
-- [ ] UI does not duplicate task business logic already owned by the API digest service.
+- [x] Dashboard or settings page renders the digest preview from the API read model.
+- [x] Empty, loading, error, and disabled-preference states are covered.
+- [x] Preview groups match the email template grouping and counts.
+- [x] UI does not duplicate task business logic already owned by the API digest service.
 
 ## Notes
 - This should be a compact operational preview, not a marketing page.
 - Keep actions limited to enabling/disabling digest and refreshing preview data.
+
+## Implementation Notes
+- Added a compact dashboard digest preview under the daily digest preference control.
+- Preview data is read from `GET /api/taskforge/v1/email/digest/preview` and renders the API-provided group labels and totals without rebuilding digest business logic in the UI.
+- Disabled preferences now show an explanatory state while still rendering the current preview read model.
+- Task mutations invalidate the digest preview cache so refreshed task lists and preview counts stay aligned.


### PR DESCRIPTION
### Motivation
- Provide users with a compact operational preview of the task groups that would appear in their next daily digest without reimplementing the API digest grouping logic in the frontend.
- Make the preview useful even when email delivery is not configured by handling disabled-preference, loading, error, and empty states.

### Description
- Add a typed digest preview client `getDigestPreview` with Zod validation for the `v1/email/digest/preview` read model (`apps/web/lib/digest-preview-client.ts`).
- Add a React Query hook `useDigestPreviewQuery` keyed by the authenticated user to fetch the preview (`apps/web/lib/digest-preview-hooks.ts`).
- Add a compact “Next digest preview” panel to the Dashboard account snapshot that shows group labels and counts, includes a refresh button, and covers disabled, loading, error, and empty states (`apps/web/app/(protected)/dashboard/dashboard-content.tsx`).
- Extend dashboard unit tests to mock the preview hook and add assertions for disabled-preview messaging and rendered group counts (`apps/web/app/(protected)/dashboard/dashboard-content.test.tsx`).

### Testing
- Ran the dashboard unit test file with Vitest: `pnpm vitest run "app/(protected)/dashboard/dashboard-content.test.tsx"` in `apps/web`, and the test file passed with 9/9 tests succeeding.
- New/modified unit tests cover the preview disabled state, preview rendering of group labels and counts, and continued existing board behaviors; all assertions passed in the final run.

