### PR TITLE
add email HTTP pack for preference, preview, and manual send verification

### DIFF
--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -7,6 +7,7 @@ const prisma = new PrismaClient();
 async function main() {
   const demoEmail = 'demo@taskforge.dev';
   const demoPassword = process.env.SEED_USER_PASSWORD ?? 'Demo1234!';
+  const digestSmokeTaskId = '00000000-0000-4000-8000-000000000510';
   const saltRounds = Number.parseInt(process.env.BCRYPT_SALT_ROUNDS ?? '', 10);
   const hasher = createPasswordHasher(Number.isFinite(saltRounds) && saltRounds > 0 ? saltRounds : 10);
 
@@ -17,11 +18,13 @@ async function main() {
     update: {
       name: 'Taskforge Demo',
       passwordHash,
+      emailVerified: new Date('2026-05-01T00:00:00.000Z'),
     },
     create: {
       email: demoEmail,
       name: 'Taskforge Demo',
       passwordHash,
+      emailVerified: new Date('2026-05-01T00:00:00.000Z'),
     },
   });
 
@@ -39,6 +42,29 @@ async function main() {
       dailyDigestEnabled: false,
       dailyDigestHourUtc: null,
       dailyDigestTimezone: 'UTC',
+    },
+  });
+
+  await prisma.task.upsert({
+    where: { id: digestSmokeTaskId },
+    update: {
+      userId: demoUser.id,
+      title: 'Email digest HTTP smoke task',
+      description: 'Seeded task used by apps/api/tests/email.http for MailHog verification.',
+      status: 'TODO',
+      priority: 'HIGH',
+      dueDate: new Date('2026-05-26T13:00:00.000Z'),
+      boardOrder: 0,
+    },
+    create: {
+      id: digestSmokeTaskId,
+      userId: demoUser.id,
+      title: 'Email digest HTTP smoke task',
+      description: 'Seeded task used by apps/api/tests/email.http for MailHog verification.',
+      status: 'TODO',
+      priority: 'HIGH',
+      dueDate: new Date('2026-05-26T13:00:00.000Z'),
+      boardOrder: 0,
     },
   });
 }

--- a/apps/api/tests/README.md
+++ b/apps/api/tests/README.md
@@ -48,10 +48,11 @@ pnpm -C apps/api test
 - `auth.http`: register/login/logout/me auth smoke flow.
 - `tasks.http`: task CRUD + filters + board fetch/move requests.
 - `kanban.http`: focused board + tag list/create demo flows for QA and staging walkthroughs.
+- `email.http`: email preference, digest preview, and manual send (MailHog-first) verification flows.
 
 ### Environment variables
 
-All packs support variable-based hosts/tokens (for example `@apiBaseUrl` and `{{accessToken}}`) so you can replay requests without editing hard-coded URLs.
+All packs support variable-based hosts/tokens (for example `@apiBaseUrl` and `{{accessToken}}`) so you can replay requests without editing hard-coded URLs. The email pack also keeps SMTP examples placeholder-only (`SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`, `EMAIL_FROM`) so real Resend credentials stay in local environment variables.
 
 ### Import tips
 

--- a/apps/api/tests/README.md
+++ b/apps/api/tests/README.md
@@ -52,7 +52,18 @@ pnpm -C apps/api test
 
 ### Environment variables
 
-All packs support variable-based hosts/tokens (for example `@apiBaseUrl` and `{{accessToken}}`) so you can replay requests without editing hard-coded URLs. The email pack also keeps SMTP examples placeholder-only (`SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`, `EMAIL_FROM`) so real Resend credentials stay in local environment variables.
+All packs support variable-based hosts/tokens (for example `@apiBaseUrl` and `{{accessToken}}`) so you can replay requests without editing hard-coded URLs.
+
+For `email.http`, start the Docker stack and seed the database first:
+
+```bash
+make up
+make seed
+```
+
+The seed creates a verified `demo@taskforge.dev` user and one deterministic digest task for MailHog verification. Dockerized local SMTP uses `SMTP_HOST=mailhog` and `SMTP_PORT=1025`; if you run the API directly on the host machine while MailHog runs in Docker, use `SMTP_HOST=localhost`.
+
+The email pack keeps production SMTP examples placeholder-only (`SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`, `EMAIL_FROM`) so real Resend credentials stay in local environment variables.
 
 ### Import tips
 

--- a/apps/api/tests/auth.http
+++ b/apps/api/tests/auth.http
@@ -1,6 +1,8 @@
+@apiBaseUrl = http://localhost:4000/api/taskforge/v1
+
 ### Register a new user
 # @name register
-POST http://localhost:4000/api/taskforge/v1/auth/register
+POST {{apiBaseUrl}}/auth/register
 Content-Type: application/json
 
 {
@@ -22,7 +24,7 @@ client.test('register returns tokens', () => {
 
 ### Login with existing user
 # @name login
-POST http://localhost:4000/api/taskforge/v1/auth/login
+POST {{apiBaseUrl}}/auth/login
 Content-Type: application/json
 
 {
@@ -41,7 +43,7 @@ client.test('login succeeds and refreshes tokens', () => {
 
 ### Login with wrong password should fail
 # @name loginFailure
-POST http://localhost:4000/api/taskforge/v1/auth/login
+POST {{apiBaseUrl}}/auth/login
 Content-Type: application/json
 
 {
@@ -58,7 +60,7 @@ client.test('login fails with 401', () => {
 
 ### Fetch current user with token
 # @name me
-GET http://localhost:4000/api/taskforge/v1/auth/me
+GET {{apiBaseUrl}}/auth/me
 Authorization: Bearer {{accessToken}}
 
 > {%
@@ -70,7 +72,7 @@ client.test('me endpoint returns authenticated user', () => {
 
 ### Logout (requires token)
 # @name logout
-POST http://localhost:4000/api/taskforge/v1/auth/logout
+POST {{apiBaseUrl}}/auth/logout
 Authorization: Bearer {{accessToken}}
 
 > {%
@@ -84,7 +86,7 @@ client.test('logout clears session cookie', () => {
 
 ### Access protected tasks endpoint with token
 # @name tasks
-GET http://localhost:4000/api/taskforge/v1/tasks
+GET {{apiBaseUrl}}/tasks
 Authorization: Bearer {{accessToken}}
 
 > {%
@@ -96,7 +98,7 @@ client.test('tasks endpoint responds for authenticated user', () => {
 
 ### Access protected tasks endpoint without token should fail
 # @name tasksUnauthorized
-GET http://localhost:4000/api/taskforge/v1/tasks
+GET {{apiBaseUrl}}/tasks
 
 > {%
 client.test('tasks endpoint rejects unauthenticated user', () => {

--- a/apps/api/tests/email.http
+++ b/apps/api/tests/email.http
@@ -1,0 +1,84 @@
+@apiBaseUrl = http://localhost:4000/api/taskforge/v1
+@accessToken = REPLACE_WITH_TF_SESSION_COOKIE_VALUE
+@digestDate = 2026-05-26
+@previewTimezone = America/New_York
+
+# Email HTTP pack (safe by default)
+# 1) Run requests in apps/api/tests/auth.http first and copy tf_session into @accessToken.
+# 2) Local default SMTP should point to MailHog (SMTP_HOST=mailhog, SMTP_PORT=1025).
+# 3) Real Resend sends are opt-in only; keep dryRun=true unless you explicitly load production-like secrets.
+# 4) Verify outbound messages in MailHog UI: http://localhost:8025.
+
+### Me snapshot (auth + current email preference)
+GET {{apiBaseUrl}}/me
+Authorization: Bearer {{accessToken}}
+
+### Enable daily digest preference for this user
+PATCH {{apiBaseUrl}}/me/email-preferences
+Content-Type: application/json
+Authorization: Bearer {{accessToken}}
+
+{
+  "dailyDigestEnabled": true
+}
+
+### Preview digest payload with explicit timezone + tuning controls
+GET {{apiBaseUrl}}/email/digest/preview?timezone={{previewTimezone}}&dueSoonDays=7&recentlyUpdatedDays=2&maxTasksPerGroup=10
+Authorization: Bearer {{accessToken}}
+
+### Preview digest payload using stored preference defaults
+GET {{apiBaseUrl}}/email/digest/preview
+Authorization: Bearer {{accessToken}}
+
+### Manual digest send (safe local dry run)
+# Expected:
+# - HTTP 200 with skipped/sent attempt details for this user.
+# - x-taskforge-idempotency-key response header: digest:<digestDate>:<userId>.
+# - No SMTP delivery attempt because dryRun=true.
+POST {{apiBaseUrl}}/email/digest/send
+Content-Type: application/json
+Authorization: Bearer {{accessToken}}
+
+{
+  "digestDate": "{{digestDate}}",
+  "dryRun": true
+}
+
+### Manual digest send (MailHog delivery; still local-safe)
+# Preconditions:
+# - dailyDigestEnabled=true
+# - Local SMTP is configured for MailHog.
+# Expected MailHog result:
+# - One digest email appears in MailHog inbox for the authenticated user.
+# Idempotency behavior:
+# - Re-running with the same digestDate + user will keep header key stable.
+# - The API should not create duplicate terminal delivery rows for the same digest:user key.
+POST {{apiBaseUrl}}/email/digest/send
+Content-Type: application/json
+Authorization: Bearer {{accessToken}}
+
+{
+  "digestDate": "{{digestDate}}",
+  "dryRun": false
+}
+
+### Optional production-like Resend example (DO NOT RUN by default)
+# Opt-in checklist before sending:
+# - Verified Resend domain exists.
+# - Local env exports production-like secrets.
+# - You intentionally set dryRun=false.
+# Placeholder variable names (no real credentials):
+#   SMTP_HOST=smtp.resend.com
+#   SMTP_PORT=587
+#   SMTP_USER=resend
+#   SMTP_PASS=<RESEND_API_KEY_FROM_ENV>
+#   EMAIL_FROM=TaskForge Notifications <notifications@YOUR_VERIFIED_DOMAIN>
+# Keep this request disabled/commented in shared demos to avoid accidental CI execution.
+# POST {{apiBaseUrl}}/email/digest/send
+# Content-Type: application/json
+# Authorization: Bearer {{accessToken}}
+#
+# {
+#   "digestDate": "{{digestDate}}",
+#   "dryRun": false
+# }

--- a/apps/api/tests/email.http
+++ b/apps/api/tests/email.http
@@ -1,13 +1,36 @@
 @apiBaseUrl = http://localhost:4000/api/taskforge/v1
-@accessToken = REPLACE_WITH_TF_SESSION_COOKIE_VALUE
+@authEmail = demo@taskforge.dev
+@authPassword = Demo1234!
 @digestDate = 2026-05-26
 @previewTimezone = America/New_York
+@mailhogDeliveryDryRun = true
 
 # Email HTTP pack (safe by default)
-# 1) Run requests in apps/api/tests/auth.http first and copy tf_session into @accessToken.
-# 2) Local default SMTP should point to MailHog (SMTP_HOST=mailhog, SMTP_PORT=1025).
-# 3) Real Resend sends are opt-in only; keep dryRun=true unless you explicitly load production-like secrets.
-# 4) Verify outbound messages in MailHog UI: http://localhost:8025.
+# 1) Start local services with `make up`, then run `make seed`.
+# 2) The seed creates a verified demo user plus one deterministic digest task for @digestDate.
+# 3) If SEED_USER_PASSWORD is overridden, update @authPassword before logging in.
+# 4) Dockerized local SMTP uses MailHog (SMTP_HOST=mailhog, SMTP_PORT=1025).
+# 5) If the API runs on the host machine instead of Docker, point SMTP_HOST at localhost.
+# 6) Verify local outbound messages in MailHog UI: http://localhost:8025.
+# 7) Keep @mailhogDeliveryDryRun=true unless you have confirmed this API is local and using MailHog.
+
+### Auth setup - login seeded verified digest user
+# @name emailLogin
+POST {{apiBaseUrl}}/auth/login
+Content-Type: application/json
+
+{
+  "email": "{{authEmail}}",
+  "password": "{{authPassword}}"
+}
+
+> {%
+client.test('login returns an access token for email HTTP pack', () => {
+  client.assert(response.status === 200, 'expected 200 OK');
+  client.assert(response.body.tokens.accessToken, 'access token is present');
+  client.global.set('accessToken', response.body.tokens.accessToken);
+});
+%}
 
 ### Me snapshot (auth + current email preference)
 GET {{apiBaseUrl}}/me
@@ -30,11 +53,11 @@ Authorization: Bearer {{accessToken}}
 GET {{apiBaseUrl}}/email/digest/preview
 Authorization: Bearer {{accessToken}}
 
-### Manual digest send (safe local dry run)
+### Manual digest send (safe dry run)
 # Expected:
-# - HTTP 200 with skipped/sent attempt details for this user.
+# - HTTP 200 with attempted/sent/skipped counters for this user.
 # - x-taskforge-idempotency-key response header: digest:<digestDate>:<userId>.
-# - No SMTP delivery attempt because dryRun=true.
+# - No SMTP delivery attempt and no delivery history row because dryRun=true.
 POST {{apiBaseUrl}}/email/digest/send
 Content-Type: application/json
 Authorization: Bearer {{accessToken}}
@@ -44,36 +67,38 @@ Authorization: Bearer {{accessToken}}
   "dryRun": true
 }
 
-### Manual digest send (MailHog delivery; still local-safe)
-# Preconditions:
-# - dailyDigestEnabled=true
+### Manual digest send (MailHog delivery opt-in)
+# Keep @mailhogDeliveryDryRun=true for shared demos, CI, staging, or any Resend-backed API.
+# Set @mailhogDeliveryDryRun=false only after confirming:
+# - dailyDigestEnabled=true.
+# - This request targets your local API.
 # - Local SMTP is configured for MailHog.
-# Expected MailHog result:
-# - One digest email appears in MailHog inbox for the authenticated user.
-# Idempotency behavior:
-# - Re-running with the same digestDate + user will keep header key stable.
-# - The API should not create duplicate terminal delivery rows for the same digest:user key.
+# Expected MailHog result when @mailhogDeliveryDryRun=false:
+# - One digest email appears in MailHog inbox for {{authEmail}}.
+# Idempotency behavior after one successful real send:
+# - Re-running with the same digestDate + user keeps the header key stable.
+# - The API reports the duplicate skip and does not send a second MailHog email.
 POST {{apiBaseUrl}}/email/digest/send
 Content-Type: application/json
 Authorization: Bearer {{accessToken}}
 
 {
   "digestDate": "{{digestDate}}",
-  "dryRun": false
+  "dryRun": "{{mailhogDeliveryDryRun}}"
 }
 
 ### Optional production-like Resend example (DO NOT RUN by default)
 # Opt-in checklist before sending:
 # - Verified Resend domain exists.
-# - Local env exports production-like secrets.
+# - Production-like secrets are loaded from the local environment, not this file.
 # - You intentionally set dryRun=false.
-# Placeholder variable names (no real credentials):
+# Placeholder variable names only:
 #   SMTP_HOST=smtp.resend.com
 #   SMTP_PORT=587
 #   SMTP_USER=resend
 #   SMTP_PASS=<RESEND_API_KEY_FROM_ENV>
 #   EMAIL_FROM=TaskForge Notifications <notifications@YOUR_VERIFIED_DOMAIN>
-# Keep this request disabled/commented in shared demos to avoid accidental CI execution.
+# Keep this request disabled/commented in shared demos to avoid accidental CI or staging execution.
 # POST {{apiBaseUrl}}/email/digest/send
 # Content-Type: application/json
 # Authorization: Bearer {{accessToken}}

--- a/apps/api/tests/tasks.http
+++ b/apps/api/tests/tasks.http
@@ -1,21 +1,24 @@
-GET http://localhost:4000/api/taskforge/v1/health
+@apiBaseUrl = http://localhost:4000/api/taskforge/v1
+@accessToken = replace-with-access-token
+
+GET {{apiBaseUrl}}/health
 
 ###
 # Replace {{accessToken}} with the tf_session cookie value returned by auth.http flows.
 
-GET http://localhost:4000/api/taskforge/v1/tasks?page=1&pageSize=10
+GET {{apiBaseUrl}}/tasks?page=1&pageSize=10
 Authorization: Bearer {{accessToken}}
 Cookie: tf_session={{accessToken}}
 
 ###
 # Fetch board read model (includes ETag/updatedAt metadata)
-GET http://localhost:4000/api/taskforge/v1/tasks/board
+GET {{apiBaseUrl}}/tasks/board
 Authorization: Bearer {{accessToken}}
 Cookie: tf_session={{accessToken}}
 
 ###
 # Move a task on the board (replace {{taskId}} with the task id)
-PATCH http://localhost:4000/api/taskforge/v1/tasks/board/move
+PATCH {{apiBaseUrl}}/tasks/board/move
 Content-Type: application/json
 Authorization: Bearer {{accessToken}}
 Cookie: tf_session={{accessToken}}
@@ -29,13 +32,13 @@ Cookie: tf_session={{accessToken}}
 ###
 # Filtered search: high priority docs tasks due in Q1
 
-GET http://localhost:4000/api/taskforge/v1/tasks?q=release&status=IN_PROGRESS&priority=HIGH&tag=docs&tag=launch&dueFrom=2024-01-01T00:00:00.000Z&dueTo=2024-03-31T23:59:59.999Z
+GET {{apiBaseUrl}}/tasks?q=release&status=IN_PROGRESS&priority=HIGH&tag=docs&tag=launch&dueFrom=2024-01-01T00:00:00.000Z&dueTo=2024-03-31T23:59:59.999Z
 Authorization: Bearer {{accessToken}}
 Cookie: tf_session={{accessToken}}
 
 ###
 # Create a task with tags + due date
-POST http://localhost:4000/api/taskforge/v1/tasks
+POST {{apiBaseUrl}}/tasks
 Content-Type: application/json
 Authorization: Bearer {{accessToken}}
 Cookie: tf_session={{accessToken}}
@@ -51,7 +54,7 @@ Cookie: tf_session={{accessToken}}
 
 ###
 # Update a task (replace {{taskId}} with the created task id)
-PATCH http://localhost:4000/api/taskforge/v1/tasks/{{taskId}}
+PATCH {{apiBaseUrl}}/tasks/{{taskId}}
 Content-Type: application/json
 Authorization: Bearer {{accessToken}}
 Cookie: tf_session={{accessToken}}
@@ -67,6 +70,6 @@ Cookie: tf_session={{accessToken}}
 
 ###
 # Delete a task
-DELETE http://localhost:4000/api/taskforge/v1/tasks/{{taskId}}
+DELETE {{apiBaseUrl}}/tasks/{{taskId}}
 Authorization: Bearer {{accessToken}}
 Cookie: tf_session={{accessToken}}

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -8,7 +8,7 @@
 - Primary: single user (personal). Future: org workspaces.
 
 ## Success
-- Deployed FE/BE/DB on free tiers. OAuth login, CRUD tasks (tags + due dates), Kanban, filters/search, Swagger at `/api/taskforge/docs`, API and frontend automated tests, `.http` suite, Docker + CI, README + ADRs. Email delivery infrastructure, welcome emails, and the protected digest scheduler are staged; digest user-facing product flows remain planned future scope.
+- Deployed FE/BE/DB on free tiers. OAuth login, CRUD tasks (tags + due dates), Kanban, filters/search, Swagger at `/api/taskforge/docs`, API and frontend automated tests, `.http` suite, Docker + CI, README + ADRs. Email delivery infrastructure, welcome emails, digest preferences, digest preview/manual-send flows, and the protected digest scheduler are staged; production scheduled sends remain gated on Resend verification and rollout checks.
 
 ## Scope
 - Auth: NextAuth (GitHub/Google) backed by Prisma, credential login against the API, and a session bridge that exchanges
@@ -16,7 +16,7 @@
 - Tasks: title, description (MD), status, priority, **tags**, **dueDate**.
 - Kanban: DnD with optimistic UI.
 - Filters/search: tag/status/due range/text.
-- Email: Nodemailer SMTP adapter with MailHog local defaults and Resend production configuration; welcome emails send after first account creation, while daily digest product flows remain planned. The digest scheduler runs through a protected API job endpoint with a Vercel Cron web proxy and GitHub Actions fallback.
+- Email: Nodemailer SMTP adapter with MailHog local defaults and Resend production configuration; welcome emails send after first account creation, and users can manage digest preferences, preview digest payloads, and trigger guarded manual digest sends. The digest scheduler runs through a protected API job endpoint with a Vercel Cron web proxy and GitHub Actions fallback.
 - UI: Next.js, Tailwind, shadcn/ui, Framer Motion, desktop-first dark theme.
 - Docs: Swagger/OpenAPI + ADRs. `.http` pack.
 - Tests: Jest/Supertest for API coverage and Vitest/React Testing Library for frontend coverage.

--- a/docs/prod/resend-email-setup.md
+++ b/docs/prod/resend-email-setup.md
@@ -31,6 +31,7 @@ The production API env example lives at `infra/env/api.prod.env.example`.
 11. Assign a daily human reviewer for the first production rollout.
 12. Confirm the reviewer can access TaskForge logs, delivery history, Resend logs, alert delivery, and quota state.
 13. Run production-like dry runs and manual-only sends against the verified sender before enabling scheduled sends.
+14. If `apps/api/tests/email.http` is used for a production-like smoke, keep the Resend request commented until the verified domain, deployed secrets, target recipient, and `dryRun=false` intent are confirmed in the local operator environment.
 
 The email rollout decisions are documented in `docs/prod/adr/0007-email-observability-rollout-decisions.md`.
 

--- a/docs/tasks/milestone5/10-email-http-pack.md
+++ b/docs/tasks/milestone5/10-email-http-pack.md
@@ -4,14 +4,14 @@
 - Extend the API `.http` collections with email preference, digest preview, and manual send flows.
 - Make local MailHog verification repeatable for reviewers.
 
-**Status:** New.
+**Status:** Completed.
 
 ## Acceptance Criteria
-- [ ] HTTP examples cover auth setup, reading/updating preferences, previewing digest payloads, and dry-run send.
-- [ ] Manual send example documents expected MailHog result and idempotency behavior.
-- [ ] Variables are environment-driven and do not hard-code real SMTP credentials.
-- [ ] Production SMTP examples show Resend variable names and placeholder values only.
-- [ ] HTTP linting includes the new email collection.
+- [x] HTTP examples cover auth setup, reading/updating preferences, previewing digest payloads, and dry-run send.
+- [x] Manual send example documents expected MailHog result and idempotency behavior.
+- [x] Variables are environment-driven and do not hard-code real SMTP credentials.
+- [x] Production SMTP examples show Resend variable names and placeholder values only.
+- [x] HTTP linting includes the new email collection.
 
 ## Manual Setup Required
 - Use MailHog for local HTTP-pack verification by default.
@@ -20,3 +20,9 @@
 
 ## Notes
 - Keep examples safe by default; real send flows should target local MailHog unless explicitly configured.
+
+## Completion Notes
+- Added `apps/api/tests/email.http` with seeded demo auth, preference read/update, digest preview, safe dry-run, guarded MailHog delivery, and disabled production-like Resend examples.
+- Updated `apps/api/prisma/seed.ts` so local reviewers can repeat MailHog verification with a verified `demo@taskforge.dev` user and deterministic digest task.
+- Kept real delivery opt-in with `@mailhogDeliveryDryRun=true` by default; reviewers must flip it to `false` only after confirming the API is local and SMTP points to MailHog.
+- `pnpm -C apps/api run lint:http` validates the new email collection with the existing HTTP linter.

--- a/docs/tasks/milestone5/sequence.md
+++ b/docs/tasks/milestone5/sequence.md
@@ -9,6 +9,6 @@
 7. **07-email-settings-ui.md** - Let users opt in/out of digest emails and choose digest timing from the web app.
 8. **08-digest-preview-ui.md** - Add a dashboard preview surface so users can inspect the digest before enabling it.
 9. **09-email-observability-and-safety.md** - Add structured logging, idempotency, rate limits, and failure handling.
-10. **10-email-http-pack.md** - Extend HTTP collections with email preference, preview, and send flows.
+10. **10-email-http-pack.md** - Completed: HTTP collections now cover seeded email auth, preference reads/updates, digest preview, safe dry-run, and guarded MailHog manual-send verification.
 11. **11-email-docs.md** - Update PRD, README, ADR notes, env docs, testing docs, and Resend setup/runbook notes for email behavior.
 12. **12-email-tests.md** - Cover adapter, scheduler, API, and frontend email flows in automated tests and CI.

--- a/docs/testing/milestone5-automated.md
+++ b/docs/testing/milestone5-automated.md
@@ -6,6 +6,7 @@ Use these checks while implementing email notification tasks.
 
 ```bash
 pnpm -C apps/api lint
+pnpm -C apps/api run lint:http
 pnpm -C apps/api typecheck
 pnpm -C apps/api test
 pnpm -C apps/web lint

--- a/docs/testing/milestone5-manual-checklist.md
+++ b/docs/testing/milestone5-manual-checklist.md
@@ -3,6 +3,7 @@
 Use this checklist before enabling real email sends in any shared environment.
 
 - [ ] MailHog receives local welcome emails.
+- [ ] `apps/api/tests/email.http` runs against the seeded `demo@taskforge.dev` user after `make up` and `make seed`.
 - [ ] Digest dry run reports attempted, sent, skipped, failed, and skip reason counts.
 - [ ] Digest dry run does not create `NotificationDelivery` or `NotificationDeliveryAttempt` records.
 - [ ] Protected API job endpoint rejects missing or incorrect `DIGEST_JOB_SECRET`.
@@ -12,5 +13,6 @@ Use this checklist before enabling real email sends in any shared environment.
 - [ ] Budget exhaustion reports `budgetSkipped`, records `SKIPPED` attempts with `BUDGET_SKIPPED`, and does not exceed the configured send limit.
 - [ ] Provider quota exhaustion stops same-run sends, reports `providerQuotaSkipped`, and records remaining eligible digests as `SKIPPED`.
 - [ ] Delivery logs include notification type, user id, delivery status, provider, provider message id when available, and sanitized provider metadata without rendered email bodies.
-- [ ] Manual digest sends return `x-taskforge-idempotency-key` and repeated sends for the same user/date do not send duplicates after `SENT` or `PENDING` attempts.
+- [ ] Manual digest sends return `x-taskforge-idempotency-key` and repeated sends for the same user/date do not send duplicate MailHog emails after `SENT` or `PENDING` attempts.
+- [ ] Real Resend sends remain disabled/commented in HTTP packs unless the verified domain, production-like secrets, and recipient safety checks are explicitly confirmed.
 - [ ] First production schedule is confirmed with a dry run before real sends are enabled.


### PR DESCRIPTION
### Motivation
- Provide HTTP examples to exercise email preference management, digest preview, and manual send flows so reviewers can verify email behavior end-to-end.
- Make local verification repeatable and safe-by-default by targeting MailHog and documenting explicit opt-in steps for real Resend sends.

### Description
- Add `apps/api/tests/email.http` with authenticated `GET /me`, `PATCH /me/email-preferences`, `GET /email/digest/preview`, and `POST /email/digest/send` examples including a safe `dryRun=true` flow and a MailHog delivery example. 
- Keep production SMTP examples commented and placeholder-only, and require environment-driven variables (`SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`, `EMAIL_FROM`) so no real credentials are hard-coded. 
- Document idempotency expectations (response header `x-taskforge-idempotency-key`) and note MailHog UI at `http://localhost:8025` for local verification. 
- Update `apps/api/tests/README.md` to list the new `email.http` pack and to explain the placeholder SMTP variables for the email pack. 

### Testing
- Ran the HTTP lint script with `pnpm -C apps/api run lint:http`, which validated the HTTP files and reported `Validated 4 HTTP files` and passed without failures.

