### PR TITLE
Verify rate limits and abuse controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Keep `.env` files aligned with the templates in `infra/env/`. The table below su
 | `DATABASE_URL` | both | `postgresql://postgres:postgres@db:5432/taskforge?schema=public` | For local dev outside Docker switch the host from `db` to `localhost`. Production values should come from your managed Postgres provider. |
 | `CORS_ALLOWED_ORIGINS` | `apps/api/.env` | `http://localhost:3000,http://127.0.0.1:3000` | Comma-separated browser origins allowed to call the API with credentials. Entries must be exact origins without paths, query strings, or fragments. Production fails closed when unset, so set every deployed web origin explicitly. |
 | `TRUST_PROXY` | `apps/api/.env` | _(unset)_ | Express trusted-proxy setting used for `req.ip` and IP-based rate limits behind platform proxies. Leave unset locally; in production match the actual proxy chain and avoid trusting arbitrary `X-Forwarded-*` headers. Prefer a hop count such as `1` only when exactly one trusted proxy scrubs forwarded headers. |
+| `API_JSON_BODY_LIMIT` | `apps/api/.env` | `64kb` | Explicit JSON request-body cap for the API. Keep this low for early deployment; task titles, descriptions, tags, filters, digest preview windows, and job parameters also have schema-level bounds. |
 | `API_BASE_URL` | `apps/web/.env` | `http://api:4000/api/taskforge` | Server-side (Next.js) requests to the Express API. Include the `/api/taskforge` prefix so callers can append `/v1/*` paths consistently. |
 | `NEXT_PUBLIC_API_BASE_URL` | `apps/web/.env` | `http://localhost:4000/api/taskforge` | Browser fetches to the Express API. Match the API origin plus `/api/taskforge` to mirror the Docker defaults. |
 | `GITHUB_ID` / `GITHUB_SECRET` | `apps/web/.env` | _(blank)_ | Populate when enabling GitHub OAuth. Leave blank to hide the provider in development. |
@@ -240,6 +241,13 @@ Also configure:
 - API: `DIGEST_JOB_SECRET`
 - Web: `CRON_SECRET`
 - Web: `DIGEST_JOB_SECRET` (must match API value)
+
+### Rate limits and abuse controls
+- The API uses in-process Express rate limiters: a general `120 requests/minute` limiter, auth attempt limiting of `5 requests/15 minutes` per `req.ip`, email digest limiting of `10 requests/minute`, manual digest send limiting of `3 requests/minute` per authenticated user, and protected digest job limiting of `5 requests/minute`. All limiter responses use JSON `429` envelopes with rate-limit headers where configured.
+- The v1 production assumption is one API instance. If the API is horizontally scaled, add a shared `express-rate-limit` store such as Redis before increasing instance count; otherwise each instance keeps its own counters and effective limits reset per instance.
+- IP-based buckets depend on Express `req.ip`. Keep `TRUST_PROXY` unset unless the deployment has a known trusted proxy chain that scrubs forwarded headers; incorrect broad trust lets clients pick their own `X-Forwarded-For` bucket.
+- Rate limits are guardrails, not authentication. Protected job routes still require `DIGEST_JOB_SECRET` through `Authorization: Bearer <secret>` or `x-job-secret`, and error bodies/logs must never include submitted secret values.
+- `TF_DEV_BYPASS_AUTH=true` is ignored outside `development` and `test` in both API and web helpers; do not set bypass secrets in production.
 
 ### Digest behavior summary
 - Daily digest execution is explicit (`/api/taskforge/v1/jobs/digest`) and can run as dry run or real send.

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ Also configure:
 - The API uses in-process Express rate limiters: a general `120 requests/minute` limiter, credential and refresh auth attempt limiting of `5 requests/15 minutes` per `req.ip`, server-side session bridge limiting of `120 requests/minute` per `req.ip`, email digest limiting of `10 requests/minute`, manual digest send limiting of `3 requests/minute` per authenticated user, and protected digest job limiting of `5 requests/minute`. All limiter responses use JSON `429` envelopes with rate-limit headers where configured.
 - The v1 production assumption is one API instance. If the API is horizontally scaled, add a shared `express-rate-limit` store such as Redis before increasing instance count; otherwise each instance keeps its own counters and effective limits reset per instance.
 - IP-based buckets depend on Express `req.ip`. Keep `TRUST_PROXY` unset unless the deployment has a known trusted proxy chain that scrubs forwarded headers; incorrect broad trust lets clients pick their own `X-Forwarded-For` bucket.
-- Rate limits are guardrails, not authentication. Protected job routes still require `DIGEST_JOB_SECRET` through `Authorization: Bearer <secret>` or `x-job-secret`, and error bodies/logs must never include submitted secret values.
+- Rate limits are guardrails, not authentication. Protected job routes still require `DIGEST_JOB_SECRET` through `Authorization: Bearer <secret>` or `x-job-secret`; missing or incorrect job secrets are throttled without spending the valid scheduler bucket, and error bodies/logs must never include submitted secret values.
 - `TF_DEV_BYPASS_AUTH=true` is ignored outside `development` and `test` in both API and web helpers; do not set bypass secrets in production.
 
 ### Digest behavior summary

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Also configure:
 - Web: `DIGEST_JOB_SECRET` (must match API value)
 
 ### Rate limits and abuse controls
-- The API uses in-process Express rate limiters: a general `120 requests/minute` limiter, auth attempt limiting of `5 requests/15 minutes` per `req.ip`, email digest limiting of `10 requests/minute`, manual digest send limiting of `3 requests/minute` per authenticated user, and protected digest job limiting of `5 requests/minute`. All limiter responses use JSON `429` envelopes with rate-limit headers where configured.
+- The API uses in-process Express rate limiters: a general `120 requests/minute` limiter, credential and refresh auth attempt limiting of `5 requests/15 minutes` per `req.ip`, server-side session bridge limiting of `120 requests/minute` per `req.ip`, email digest limiting of `10 requests/minute`, manual digest send limiting of `3 requests/minute` per authenticated user, and protected digest job limiting of `5 requests/minute`. All limiter responses use JSON `429` envelopes with rate-limit headers where configured.
 - The v1 production assumption is one API instance. If the API is horizontally scaled, add a shared `express-rate-limit` store such as Redis before increasing instance count; otherwise each instance keeps its own counters and effective limits reset per instance.
 - IP-based buckets depend on Express `req.ip`. Keep `TRUST_PROXY` unset unless the deployment has a known trusted proxy chain that scrubs forwarded headers; incorrect broad trust lets clients pick their own `X-Forwarded-For` bucket.
 - Rate limits are guardrails, not authentication. Protected job routes still require `DIGEST_JOB_SECRET` through `Authorization: Bearer <secret>` or `x-job-secret`, and error bodies/logs must never include submitted secret values.

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -85,6 +85,7 @@ export interface CreateAppOptions {
   digestJobSecret?: string;
   digestDailySendLimit?: number;
   authRateLimit?: AuthRateLimitOptions | false;
+  sessionBridgeRateLimit?: AuthRateLimitOptions | false;
 }
 
 export function createApp(options: CreateAppOptions = {}) {
@@ -154,6 +155,7 @@ export function createApp(options: CreateAppOptions = {}) {
     devBypassClientSecret: options.devBypassClientSecret,
     welcomeEmailService,
     authRateLimit: options.authRateLimit,
+    sessionBridgeRateLimit: options.sessionBridgeRateLimit,
   });
   app.use('/api/taskforge/v1/auth', authRouterFactory.router);
 

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -8,7 +8,7 @@ import { z } from 'zod';
 
 import { PrismaUserStore, UserStore } from './auth/user-store';
 import { openApiDocument } from './openapi';
-import { createAuthRouter } from './routes/auth';
+import { createAuthRouter, type AuthRateLimitOptions } from './routes/auth';
 import { getPrismaClient } from './prisma';
 import { router as tagRoutes } from './routes/tags';
 import { createTaskRouter } from './routes/tasks';
@@ -84,6 +84,7 @@ export interface CreateAppOptions {
   digestEmailAdapter?: EmailAdapter;
   digestJobSecret?: string;
   digestDailySendLimit?: number;
+  authRateLimit?: AuthRateLimitOptions | false;
 }
 
 export function createApp(options: CreateAppOptions = {}) {
@@ -94,7 +95,7 @@ export function createApp(options: CreateAppOptions = {}) {
   }
   const allowedCorsOrigins = httpConfig.corsAllowedOrigins;
 
-  app.use(express.json());
+  app.use(express.json({ limit: httpConfig.jsonBodyLimit }));
   app.use(cookieParser());
   app.use(helmet());
   // Configure CORS to allow credentials with explicit origins
@@ -152,6 +153,7 @@ export function createApp(options: CreateAppOptions = {}) {
     devBypassEnabled: options.devBypassEnabled,
     devBypassClientSecret: options.devBypassClientSecret,
     welcomeEmailService,
+    authRateLimit: options.authRateLimit,
   });
   app.use('/api/taskforge/v1/auth', authRouterFactory.router);
 

--- a/apps/api/src/config/http.ts
+++ b/apps/api/src/config/http.ts
@@ -3,11 +3,13 @@ export type TrustProxySetting = boolean | number | string | string[];
 export interface HttpServerConfig {
   trustProxy?: TrustProxySetting;
   corsAllowedOrigins: string[];
+  jsonBodyLimit: string;
 }
 
 const TRUE_VALUES = new Set(['true', 'yes', 'on']);
 const FALSE_VALUES = new Set(['false', 'no', 'off']);
 const DEFAULT_LOCAL_CORS_ORIGINS = ['http://localhost:3000', 'http://127.0.0.1:3000'];
+export const DEFAULT_JSON_BODY_LIMIT = '64kb';
 
 export function parseTrustProxySetting(rawValue: string | undefined): TrustProxySetting | undefined {
   const value = rawValue?.trim();
@@ -76,6 +78,19 @@ export function parseCorsAllowedOrigins(rawValue: string | undefined): string[] 
   });
 }
 
+export function parseJsonBodyLimit(rawValue: string | undefined): string {
+  const value = rawValue?.trim();
+  if (!value) {
+    return DEFAULT_JSON_BODY_LIMIT;
+  }
+
+  if (!/^\d+(?:b|kb|mb)$/i.test(value)) {
+    throw new Error(`API_JSON_BODY_LIMIT must be a size such as 64kb, 1mb, or 1024b. Received: ${rawValue}`);
+  }
+
+  return value.toLowerCase();
+}
+
 export function getHttpServerConfig(env: NodeJS.ProcessEnv = process.env): HttpServerConfig {
   const configuredCorsOrigins = parseCorsAllowedOrigins(env.CORS_ALLOWED_ORIGINS);
   const fallbackCorsOrigins = env.NODE_ENV === 'production'
@@ -85,5 +100,6 @@ export function getHttpServerConfig(env: NodeJS.ProcessEnv = process.env): HttpS
   return {
     trustProxy: parseTrustProxySetting(env.TRUST_PROXY),
     corsAllowedOrigins: configuredCorsOrigins.length > 0 ? configuredCorsOrigins : fallbackCorsOrigins,
+    jsonBodyLimit: parseJsonBodyLimit(env.API_JSON_BODY_LIMIT),
   };
 }

--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -3,7 +3,6 @@ import type { OpenAPIV3 } from 'openapi-types';
 import { TAG_LABEL_MAX_LENGTH } from '@taskforge/shared';
 
 import {
-  TASK_BOARD_TARGET_INDEX_MAX,
   TASK_DESCRIPTION_MAX_LENGTH,
   TASK_QUERY_MAX_LENGTH,
   TASK_TAGS_MAX_LENGTH,
@@ -428,7 +427,11 @@ const boardMoveRequest: OpenAPIV3.SchemaObject = {
   properties: {
     taskId: { type: 'string', format: 'uuid' },
     targetStatus: { type: 'string', enum: ['TODO', 'IN_PROGRESS', 'DONE'] },
-    targetIndex: { type: 'integer', minimum: 0, maximum: TASK_BOARD_TARGET_INDEX_MAX },
+    targetIndex: {
+      type: 'integer',
+      minimum: 0,
+      description: 'Zero-based destination index in the target lane. The repository validates this against the lane length.',
+    },
   },
   required: ['taskId', 'targetStatus', 'targetIndex'],
   additionalProperties: false,

--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -1516,7 +1516,7 @@ export const openApiDocument: OpenAPIV3.Document = {
         tags: ['Jobs'],
         summary: 'Run the protected daily digest job',
         description:
-          'Protected scheduler endpoint. Requires `DIGEST_JOB_SECRET` via `Authorization: Bearer <secret>` or `x-job-secret`; invalid secrets return `401` before the job rate limiter is evaluated.',
+          'Protected scheduler endpoint. Requires `DIGEST_JOB_SECRET` via `Authorization: Bearer <secret>` or `x-job-secret`; missing or incorrect secrets are throttled separately from valid scheduler invocations.',
         security: [{ jobSecretBearer: [] }, { jobSecretHeader: [] }],
         parameters: [
           {
@@ -1579,7 +1579,7 @@ export const openApiDocument: OpenAPIV3.Document = {
         tags: ['Jobs'],
         summary: 'Run the protected daily digest job',
         description:
-          'Protected scheduler endpoint. Requires `DIGEST_JOB_SECRET` via `Authorization: Bearer <secret>` or `x-job-secret`; invalid secrets return `401` before the job rate limiter is evaluated.',
+          'Protected scheduler endpoint. Requires `DIGEST_JOB_SECRET` via `Authorization: Bearer <secret>` or `x-job-secret`; missing or incorrect secrets are throttled separately from valid scheduler invocations.',
         security: [{ jobSecretBearer: [] }, { jobSecretHeader: [] }],
         requestBody: {
           required: false,

--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -1,5 +1,7 @@
 import type { OpenAPIV3 } from 'openapi-types';
 
+import { TAG_LABEL_MAX_LENGTH } from '@taskforge/shared';
+
 import {
   TASK_BOARD_TARGET_INDEX_MAX,
   TASK_DESCRIPTION_MAX_LENGTH,
@@ -41,6 +43,32 @@ const authCredentials: OpenAPIV3.SchemaObject = {
   example: {
     email: 'user@example.com',
     password: 'StrongPassword123',
+  },
+};
+
+const authRefreshRequest: OpenAPIV3.SchemaObject = {
+  type: 'object',
+  properties: {
+    refreshToken: { type: 'string', minLength: 1 },
+  },
+  required: ['refreshToken'],
+  additionalProperties: false,
+  example: {
+    refreshToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.refresh-token',
+  },
+};
+
+const sessionBridgeRequest: OpenAPIV3.SchemaObject = {
+  type: 'object',
+  properties: {
+    userId: { type: 'string', minLength: 1 },
+    email: { type: 'string', format: 'email' },
+  },
+  required: ['userId'],
+  additionalProperties: false,
+  example: {
+    userId: '26f26639-05ad-40b6-8248-379644dcdf18',
+    email: 'user@example.com',
   },
 };
 
@@ -133,6 +161,8 @@ const unauthorizedExample = { value: { error: 'Unauthorized' } } satisfies OpenA
 
 const invalidCredentialsExample = { value: { error: 'Invalid credentials' } } satisfies OpenAPIV3.ExampleObject;
 
+const invalidRefreshTokenExample = { value: { error: 'Invalid refresh token' } } satisfies OpenAPIV3.ExampleObject;
+
 const conflictExample = { value: { error: 'User already exists' } } satisfies OpenAPIV3.ExampleObject;
 
 const invalidPayloadExample = {
@@ -170,6 +200,14 @@ const emailPreferenceResponseExample = {
 
 const authCredentialsExample = {
   value: authCredentials.example as Record<string, unknown>,
+} satisfies OpenAPIV3.ExampleObject;
+
+const authRefreshRequestExample = {
+  value: authRefreshRequest.example as Record<string, unknown>,
+} satisfies OpenAPIV3.ExampleObject;
+
+const sessionBridgeRequestExample = {
+  value: sessionBridgeRequest.example as Record<string, unknown>,
 } satisfies OpenAPIV3.ExampleObject;
 
 const authSuccessResponseExample = {
@@ -234,7 +272,7 @@ const tagSummary: OpenAPIV3.SchemaObject = {
     label: {
       type: 'string',
       minLength: 1,
-      maxLength: 64,
+      maxLength: TAG_LABEL_MAX_LENGTH,
       description: 'Canonical lowercase tag label. Length limit applies after normalization.',
     },
     count: { type: 'integer', minimum: 0 },
@@ -253,7 +291,7 @@ const tagRecord: OpenAPIV3.SchemaObject = {
     label: {
       type: 'string',
       minLength: 1,
-      maxLength: 64,
+      maxLength: TAG_LABEL_MAX_LENGTH,
       description: 'Canonical lowercase tag label. Length limit applies after normalization.',
     },
   },
@@ -270,7 +308,7 @@ const tagCreateInput: OpenAPIV3.SchemaObject = {
     label: {
       type: 'string',
       minLength: 1,
-      maxLength: 64,
+      maxLength: TAG_LABEL_MAX_LENGTH,
       description: 'Tag label to create. Length limit applies after lowercase normalization.',
     },
   },
@@ -415,7 +453,7 @@ const taskCreateInput: OpenAPIV3.SchemaObject = {
       items: {
         type: 'string',
         minLength: 1,
-        maxLength: 64,
+        maxLength: TAG_LABEL_MAX_LENGTH,
         description: 'Tag label. Length limit applies after lowercase normalization.',
       },
     },
@@ -446,7 +484,7 @@ const taskUpdateInput: OpenAPIV3.SchemaObject = {
       items: {
         type: 'string',
         minLength: 1,
-        maxLength: 64,
+        maxLength: TAG_LABEL_MAX_LENGTH,
         description: 'Tag label. Length limit applies after lowercase normalization.',
       },
     },
@@ -650,6 +688,44 @@ const dailyDigestSendRequest: OpenAPIV3.SchemaObject = {
   },
 };
 
+const dailyDigestJobRunRequest: OpenAPIV3.SchemaObject = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    digestDate: {
+      type: 'string',
+      format: 'date',
+      description: 'Optional local digest calendar date. When omitted, the job derives local dates per user.',
+    },
+    digestHourUtc: {
+      type: 'integer',
+      minimum: 0,
+      maximum: 23,
+      description: 'Optional UTC hour filter. Users configured for a different hour are skipped.',
+    },
+    dryRun: {
+      description: 'When true, reports the digest run without sending email or recording delivery success.',
+      oneOf: [
+        { type: 'boolean' },
+        { type: 'string', enum: ['true', 'false', '1', '0'] },
+      ],
+      default: false,
+    },
+    sendLimit: {
+      type: 'integer',
+      minimum: 0,
+      maximum: 500,
+      description: 'Optional per-run send cap. Defaults to the configured job send limit.',
+    },
+  },
+  example: {
+    digestDate: '2026-05-21',
+    digestHourUtc: 13,
+    dryRun: true,
+    sendLimit: 5,
+  },
+};
+
 const dailyDigestRunResponse: OpenAPIV3.SchemaObject = {
   type: 'object',
   properties: {
@@ -730,6 +806,10 @@ const dailyDigestSendRequestExample = {
   value: dailyDigestSendRequest.example as Record<string, unknown>,
 } satisfies OpenAPIV3.ExampleObject;
 
+const dailyDigestJobRunRequestExample = {
+  value: dailyDigestJobRunRequest.example as Record<string, unknown>,
+} satisfies OpenAPIV3.ExampleObject;
+
 const dailyDigestRunExample = {
   value: dailyDigestRunResponse.example as Record<string, unknown>,
 } satisfies OpenAPIV3.ExampleObject;
@@ -745,6 +825,30 @@ const digestDeliveryUnavailableExample = {
 const rateLimitedExample = {
   value: { error: 'Too many requests, please try again later.' },
 } satisfies OpenAPIV3.ExampleObject;
+
+const authRateLimitedExample = {
+  value: { error: 'Too many authentication attempts. Please try again later.' },
+} satisfies OpenAPIV3.ExampleObject;
+
+const authRateLimitResponse: OpenAPIV3.ResponseObject = {
+  description: 'Authentication rate limit exceeded',
+  content: {
+    'application/json': {
+      schema: { $ref: '#/components/schemas/ErrorResponse' },
+      examples: { rateLimited: authRateLimitedExample },
+    },
+  },
+};
+
+const rateLimitResponse: OpenAPIV3.ResponseObject = {
+  description: 'Rate limit exceeded',
+  content: {
+    'application/json': {
+      schema: { $ref: '#/components/schemas/ErrorResponse' },
+      examples: { rateLimited: rateLimitedExample },
+    },
+  },
+};
 
 export const openApiDocument: OpenAPIV3.Document = {
   openapi: '3.0.3',
@@ -768,9 +872,31 @@ export const openApiDocument: OpenAPIV3.Document = {
         description:
           'HttpOnly session cookie issued by the auth routes. The cookie carries the same JWT used for bearer authentication.',
       },
+      sessionBridgeSecret: {
+        type: 'apiKey',
+        in: 'header',
+        name: 'x-session-bridge-secret',
+        description:
+          'Shared server-side secret used by the web app to exchange a NextAuth session for API JWTs.',
+      },
+      jobSecretHeader: {
+        type: 'apiKey',
+        in: 'header',
+        name: 'x-job-secret',
+        description: 'Shared secret required by protected background job routes.',
+      },
+      jobSecretBearer: {
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'shared-secret',
+        description:
+          'Alternative protected job authentication using `Authorization: Bearer <DIGEST_JOB_SECRET>`.',
+      },
     },
     schemas: {
       AuthCredentials: authCredentials,
+      AuthRefreshRequest: authRefreshRequest,
+      SessionBridgeRequest: sessionBridgeRequest,
       AuthTokens: authTokens,
       AuthSuccessResponse: {
         type: 'object',
@@ -827,6 +953,7 @@ export const openApiDocument: OpenAPIV3.Document = {
       DailyDigestGroup: dailyDigestGroup,
       DailyDigestPreviewResponse: dailyDigestPreviewResponse,
       DailyDigestSendRequest: dailyDigestSendRequest,
+      DailyDigestJobRunRequest: dailyDigestJobRunRequest,
       DailyDigestRunResponse: dailyDigestRunResponse,
     },
   },
@@ -902,6 +1029,7 @@ export const openApiDocument: OpenAPIV3.Document = {
               },
             },
           },
+          '429': authRateLimitResponse,
         },
       },
     },
@@ -954,6 +1082,139 @@ export const openApiDocument: OpenAPIV3.Document = {
               },
             },
           },
+          '429': authRateLimitResponse,
+        },
+      },
+    },
+    '/api/taskforge/v1/auth/session-bridge': {
+      post: {
+        tags: ['Auth'],
+        summary: 'Exchange a web session for API JWTs',
+        description:
+          'Server-to-server endpoint used by the web app after OAuth sign-in. Requires `x-session-bridge-secret` and returns the same auth token envelope as credential login.',
+        security: [{ sessionBridgeSecret: [] }],
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/SessionBridgeRequest' },
+              examples: {
+                default: sessionBridgeRequestExample,
+              },
+            },
+          },
+        },
+        responses: {
+          '200': {
+            description: 'Session exchanged successfully',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/AuthSuccessResponse' },
+                examples: {
+                  success: authSuccessResponseExample,
+                },
+              },
+            },
+          },
+          '400': {
+            description: 'Invalid payload',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/ErrorResponse' },
+                examples: {
+                  invalidPayload: invalidPayloadExample,
+                },
+              },
+            },
+          },
+          '401': {
+            description: 'Missing or incorrect session bridge secret',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/ErrorResponse' },
+                examples: {
+                  unauthorized: unauthorizedExample,
+                },
+              },
+            },
+          },
+          '404': {
+            description: 'User not found',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/ErrorResponse' },
+                examples: {
+                  notFound: { value: { error: 'User not found' } },
+                },
+              },
+            },
+          },
+          '409': {
+            description: 'User email mismatch',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/ErrorResponse' },
+                examples: {
+                  conflict: { value: { error: 'User email mismatch' } },
+                },
+              },
+            },
+          },
+          '429': authRateLimitResponse,
+        },
+      },
+    },
+    '/api/taskforge/v1/auth/refresh': {
+      post: {
+        tags: ['Auth'],
+        summary: 'Refresh API JWTs',
+        description: 'Exchanges a valid refresh token for a new auth token pair.',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/AuthRefreshRequest' },
+              examples: {
+                default: authRefreshRequestExample,
+              },
+            },
+          },
+        },
+        responses: {
+          '200': {
+            description: 'Token pair refreshed successfully',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/AuthSuccessResponse' },
+                examples: {
+                  success: authSuccessResponseExample,
+                },
+              },
+            },
+          },
+          '400': {
+            description: 'Invalid payload',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/ErrorResponse' },
+                examples: {
+                  invalidPayload: invalidPayloadExample,
+                },
+              },
+            },
+          },
+          '401': {
+            description: 'Invalid refresh token',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/ErrorResponse' },
+                examples: {
+                  invalidRefreshToken: invalidRefreshTokenExample,
+                },
+              },
+            },
+          },
+          '429': authRateLimitResponse,
         },
       },
     },
@@ -1247,6 +1508,117 @@ export const openApiDocument: OpenAPIV3.Document = {
         },
       },
     },
+    '/api/taskforge/v1/jobs/digest': {
+      get: {
+        tags: ['Jobs'],
+        summary: 'Run the protected daily digest job',
+        description:
+          'Protected scheduler endpoint. Requires `DIGEST_JOB_SECRET` via `Authorization: Bearer <secret>` or `x-job-secret`; invalid secrets return `401` before the job rate limiter is evaluated.',
+        security: [{ jobSecretBearer: [] }, { jobSecretHeader: [] }],
+        parameters: [
+          {
+            name: 'digestDate',
+            in: 'query',
+            schema: { type: 'string', format: 'date' },
+            description: 'Optional local digest calendar date.',
+          },
+          {
+            name: 'digestHourUtc',
+            in: 'query',
+            schema: { type: 'integer', minimum: 0, maximum: 23 },
+            description: 'Optional UTC hour filter.',
+          },
+          {
+            name: 'dryRun',
+            in: 'query',
+            schema: { type: 'string', enum: ['true', 'false', '1', '0'] },
+            description: 'When true or 1, reports the run without sending email.',
+          },
+          {
+            name: 'sendLimit',
+            in: 'query',
+            schema: { type: 'integer', minimum: 0, maximum: 500 },
+            description: 'Optional per-run send cap.',
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'Digest job run completed.',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/DailyDigestRunResponse' },
+                examples: { default: dailyDigestRunExample },
+              },
+            },
+          },
+          '400': {
+            description: 'Invalid query parameters',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/ErrorResponse' },
+                examples: { invalidPayload: invalidPayloadExample },
+              },
+            },
+          },
+          '401': {
+            description: 'Missing or incorrect job secret',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/ErrorResponse' },
+                examples: { unauthorized: unauthorizedExample },
+              },
+            },
+          },
+          '429': rateLimitResponse,
+        },
+      },
+      post: {
+        tags: ['Jobs'],
+        summary: 'Run the protected daily digest job',
+        description:
+          'Protected scheduler endpoint. Requires `DIGEST_JOB_SECRET` via `Authorization: Bearer <secret>` or `x-job-secret`; invalid secrets return `401` before the job rate limiter is evaluated.',
+        security: [{ jobSecretBearer: [] }, { jobSecretHeader: [] }],
+        requestBody: {
+          required: false,
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/DailyDigestJobRunRequest' },
+              examples: { default: dailyDigestJobRunRequestExample },
+            },
+          },
+        },
+        responses: {
+          '200': {
+            description: 'Digest job run completed.',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/DailyDigestRunResponse' },
+                examples: { default: dailyDigestRunExample },
+              },
+            },
+          },
+          '400': {
+            description: 'Invalid payload',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/ErrorResponse' },
+                examples: { invalidPayload: invalidPayloadExample },
+              },
+            },
+          },
+          '401': {
+            description: 'Missing or incorrect job secret',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/ErrorResponse' },
+                examples: { unauthorized: unauthorizedExample },
+              },
+            },
+          },
+          '429': rateLimitResponse,
+        },
+      },
+    },
     '/api/taskforge/v1/tasks': {
       get: {
         tags: ['Tasks'],
@@ -1284,7 +1656,11 @@ export const openApiDocument: OpenAPIV3.Document = {
             in: 'query',
             style: 'form',
             explode: true,
-            schema: { type: 'array', maxItems: TASK_TAGS_MAX_LENGTH, items: { type: 'string' } },
+            schema: {
+              type: 'array',
+              maxItems: TASK_TAGS_MAX_LENGTH,
+              items: { type: 'string', minLength: 1, maxLength: TAG_LABEL_MAX_LENGTH },
+            },
             description:
               'Filter tasks that include the specified tag(s). Repeat the parameter to require multiple tags.',
           },
@@ -1422,7 +1798,11 @@ export const openApiDocument: OpenAPIV3.Document = {
             in: 'query',
             style: 'form',
             explode: true,
-            schema: { type: 'array', maxItems: TASK_TAGS_MAX_LENGTH, items: { type: 'string' } },
+            schema: {
+              type: 'array',
+              maxItems: TASK_TAGS_MAX_LENGTH,
+              items: { type: 'string', minLength: 1, maxLength: TAG_LABEL_MAX_LENGTH },
+            },
             description: 'Filter board tasks that include the specified tag(s). Repeat the parameter to require multiple tags.',
           },
           {

--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -1,5 +1,13 @@
 import type { OpenAPIV3 } from 'openapi-types';
 
+import {
+  TASK_BOARD_TARGET_INDEX_MAX,
+  TASK_DESCRIPTION_MAX_LENGTH,
+  TASK_QUERY_MAX_LENGTH,
+  TASK_TAGS_MAX_LENGTH,
+  TASK_TITLE_MAX_LENGTH,
+} from './schemas/task';
+
 const errorResponse: OpenAPIV3.SchemaObject = {
   type: 'object',
   properties: {
@@ -382,9 +390,10 @@ const boardMoveRequest: OpenAPIV3.SchemaObject = {
   properties: {
     taskId: { type: 'string', format: 'uuid' },
     targetStatus: { type: 'string', enum: ['TODO', 'IN_PROGRESS', 'DONE'] },
-    targetIndex: { type: 'integer', minimum: 0 },
+    targetIndex: { type: 'integer', minimum: 0, maximum: TASK_BOARD_TARGET_INDEX_MAX },
   },
   required: ['taskId', 'targetStatus', 'targetIndex'],
+  additionalProperties: false,
   example: {
     taskId: '9e22c508-1383-4609-9bbd-2e09b7a2d108',
     targetStatus: 'DONE',
@@ -395,13 +404,14 @@ const boardMoveRequest: OpenAPIV3.SchemaObject = {
 const taskCreateInput: OpenAPIV3.SchemaObject = {
   type: 'object',
   properties: {
-    title: { type: 'string', minLength: 1 },
-    description: { type: 'string', minLength: 1 },
+    title: { type: 'string', minLength: 1, maxLength: TASK_TITLE_MAX_LENGTH },
+    description: { type: 'string', minLength: 1, maxLength: TASK_DESCRIPTION_MAX_LENGTH },
     status: { type: 'string', enum: ['TODO', 'IN_PROGRESS', 'DONE'] },
     priority: { type: 'string', enum: ['LOW', 'MEDIUM', 'HIGH'] },
     dueDate: { type: 'string', format: 'date-time' },
     tags: {
       type: 'array',
+      maxItems: TASK_TAGS_MAX_LENGTH,
       items: {
         type: 'string',
         minLength: 1,
@@ -411,6 +421,7 @@ const taskCreateInput: OpenAPIV3.SchemaObject = {
     },
   },
   required: ['title'],
+  additionalProperties: false,
   example: {
     title: 'Book product sync',
     description: 'Coordinate roadmap review with stakeholders',
@@ -424,13 +435,14 @@ const taskCreateInput: OpenAPIV3.SchemaObject = {
 const taskUpdateInput: OpenAPIV3.SchemaObject = {
   type: 'object',
   properties: {
-    title: { type: 'string', minLength: 1 },
-    description: { type: 'string', minLength: 1 },
+    title: { type: 'string', minLength: 1, maxLength: TASK_TITLE_MAX_LENGTH },
+    description: { type: 'string', minLength: 1, maxLength: TASK_DESCRIPTION_MAX_LENGTH },
     status: { type: 'string', enum: ['TODO', 'IN_PROGRESS', 'DONE'] },
     priority: { type: 'string', enum: ['LOW', 'MEDIUM', 'HIGH'] },
     dueDate: { type: 'string', format: 'date-time' },
     tags: {
       type: 'array',
+      maxItems: TASK_TAGS_MAX_LENGTH,
       items: {
         type: 'string',
         minLength: 1,
@@ -1272,14 +1284,14 @@ export const openApiDocument: OpenAPIV3.Document = {
             in: 'query',
             style: 'form',
             explode: true,
-            schema: { type: 'array', items: { type: 'string' } },
+            schema: { type: 'array', maxItems: TASK_TAGS_MAX_LENGTH, items: { type: 'string' } },
             description:
               'Filter tasks that include the specified tag(s). Repeat the parameter to require multiple tags.',
           },
           {
             name: 'q',
             in: 'query',
-            schema: { type: 'string', minLength: 1 },
+            schema: { type: 'string', minLength: 1, maxLength: TASK_QUERY_MAX_LENGTH },
             description: 'Case-insensitive search over the title and description.',
           },
           {
@@ -1410,13 +1422,13 @@ export const openApiDocument: OpenAPIV3.Document = {
             in: 'query',
             style: 'form',
             explode: true,
-            schema: { type: 'array', items: { type: 'string' } },
+            schema: { type: 'array', maxItems: TASK_TAGS_MAX_LENGTH, items: { type: 'string' } },
             description: 'Filter board tasks that include the specified tag(s). Repeat the parameter to require multiple tags.',
           },
           {
             name: 'q',
             in: 'query',
-            schema: { type: 'string', minLength: 1 },
+            schema: { type: 'string', minLength: 1, maxLength: TASK_QUERY_MAX_LENGTH },
             description: 'Case-insensitive search over the title and description.',
           },
           {

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -41,26 +41,35 @@ function getCookieOptions() {
 
 const SESSION_COOKIE_NAME = getSessionCookieName();
 
+export interface AuthRateLimitOptions {
+  windowMs?: number;
+  max?: number;
+  skipInTest?: boolean;
+}
+
 const noopLimiter: RequestHandler = (_req, _res, next) => next();
+const AUTH_RATE_LIMIT_RESPONSE = { error: 'Too many authentication attempts. Please try again later.' };
+
+export function createAuthAttemptLimiter(options: AuthRateLimitOptions = {}): RequestHandler {
+  if ((options.skipInTest ?? true) && process.env.NODE_ENV === 'test') {
+    return noopLimiter;
+  }
+
+  return rateLimit({
+    windowMs: options.windowMs ?? 15 * 60 * 1000,
+    max: options.max ?? 5,
+    standardHeaders: true,
+    legacyHeaders: false,
+    keyGenerator: req => req.ip ?? req.socket.remoteAddress ?? 'global',
+    handler: (_req, res) => {
+      res.status(429).json(AUTH_RATE_LIMIT_RESPONSE);
+    },
+  });
+}
+
 const asyncRoute = (handler: RequestHandler): RequestHandler => (req, res, next) => {
   void Promise.resolve(handler(req, res, next)).catch(next);
 };
-const authAttemptLimiter: RequestHandler =
-  process.env.NODE_ENV === 'test'
-    ? noopLimiter
-    : rateLimit({
-        windowMs: 15 * 60 * 1000,
-        max: 5,
-        standardHeaders: true,
-        legacyHeaders: false,
-        keyGenerator: req => req.ip ?? req.socket.remoteAddress ?? 'global',
-        handler: (_req, res) => {
-          res
-            .status(429)
-            .json({ error: 'Too many authentication attempts. Please try again later.' });
-        },
-      });
-
 export interface AuthRouterOptions {
   userStore?: UserStore;
   passwordHasher?: PasswordHasher;
@@ -74,9 +83,10 @@ export interface AuthRouterOptions {
   accessTokenExpiresIn?: string | number;
   refreshTokenExpiresIn?: string | number;
   welcomeEmailService?: WelcomeEmailService;
+  authRateLimit?: AuthRateLimitOptions | false;
 }
 
-function isDevBypassEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+export function isDevBypassEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
   return (
     (env.NODE_ENV === 'development' || env.NODE_ENV === 'test') &&
     env.TF_DEV_BYPASS_AUTH === 'true'
@@ -148,6 +158,9 @@ export function createAuthRouter(options: AuthRouterOptions = {}) {
   });
 
   const router = Router();
+  const authAttemptLimiter = options.authRateLimit === false
+    ? noopLimiter
+    : createAuthAttemptLimiter(options.authRateLimit);
 
   router.post('/register', authAttemptLimiter, asyncRoute(async (req, res) => {
     const parse = registerSchema.safeParse(req.body);

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -67,6 +67,23 @@ export function createAuthAttemptLimiter(options: AuthRateLimitOptions = {}): Re
   });
 }
 
+export function createSessionBridgeLimiter(options: AuthRateLimitOptions = {}): RequestHandler {
+  if ((options.skipInTest ?? true) && process.env.NODE_ENV === 'test') {
+    return noopLimiter;
+  }
+
+  return rateLimit({
+    windowMs: options.windowMs ?? 60_000,
+    max: options.max ?? 120,
+    standardHeaders: true,
+    legacyHeaders: false,
+    keyGenerator: req => req.ip ?? req.socket.remoteAddress ?? 'global',
+    handler: (_req, res) => {
+      res.status(429).json(AUTH_RATE_LIMIT_RESPONSE);
+    },
+  });
+}
+
 const asyncRoute = (handler: RequestHandler): RequestHandler => (req, res, next) => {
   void Promise.resolve(handler(req, res, next)).catch(next);
 };
@@ -84,6 +101,7 @@ export interface AuthRouterOptions {
   refreshTokenExpiresIn?: string | number;
   welcomeEmailService?: WelcomeEmailService;
   authRateLimit?: AuthRateLimitOptions | false;
+  sessionBridgeRateLimit?: AuthRateLimitOptions | false;
 }
 
 export function isDevBypassEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
@@ -161,6 +179,9 @@ export function createAuthRouter(options: AuthRouterOptions = {}) {
   const authAttemptLimiter = options.authRateLimit === false
     ? noopLimiter
     : createAuthAttemptLimiter(options.authRateLimit);
+  const sessionBridgeLimiter = options.sessionBridgeRateLimit === false
+    ? noopLimiter
+    : createSessionBridgeLimiter(options.sessionBridgeRateLimit);
 
   router.post('/register', authAttemptLimiter, asyncRoute(async (req, res) => {
     const parse = registerSchema.safeParse(req.body);
@@ -284,7 +305,7 @@ export function createAuthRouter(options: AuthRouterOptions = {}) {
       return res.status(202).json(result);
     }));
 
-    router.post('/session-bridge', authAttemptLimiter, asyncRoute(async (req, res) => {
+    router.post('/session-bridge', sessionBridgeLimiter, asyncRoute(async (req, res) => {
       const providedSecret = req.get('x-session-bridge-secret');
 
       if (!providedSecret || providedSecret !== bridgeSecret) {

--- a/apps/api/src/routes/email-digest.ts
+++ b/apps/api/src/routes/email-digest.ts
@@ -33,7 +33,7 @@ const previewQuerySchema = z.object({
   dueSoonDays: optionalIntegerParam(z.coerce.number().int().min(1).max(30)),
   recentlyUpdatedDays: optionalIntegerParam(z.coerce.number().int().min(1).max(30)),
   maxTasksPerGroup: optionalIntegerParam(z.coerce.number().int().min(1).max(50)),
-});
+}).strict();
 
 const sendPayloadSchema = z.object({
   digestDate: dateOnlySchema.optional(),
@@ -60,11 +60,15 @@ export function createEmailDigestRouter(prisma: PrismaClient, options: EmailDige
   router.use(rateLimit({
     windowMs: 60_000,
     max: 10,
+    standardHeaders: true,
+    legacyHeaders: false,
     handler: (_req, res) => res.status(429).json(rateLimitErrorResponse),
   }));
   const manualSendRateLimit = rateLimit({
     windowMs: 60_000,
     max: 3,
+    standardHeaders: true,
+    legacyHeaders: false,
     keyGenerator: (req, res) => {
       const user = res.locals.user as AuthUser | undefined;
       return user?.id ? `manual-digest-send:${user.id}` : req.ip ?? req.socket.remoteAddress ?? 'unknown';

--- a/apps/api/src/routes/jobs.ts
+++ b/apps/api/src/routes/jobs.ts
@@ -49,6 +49,17 @@ export function createJobsRouter(runner: DailyDigestRunner, options: JobsRouterO
     },
   });
 
+  const unauthorizedJobAttemptRateLimit = rateLimit({
+    windowMs: 60_000,
+    max: 5,
+    standardHeaders: true,
+    legacyHeaders: false,
+    skip: req => isAuthorized(req, options.secret),
+    handler: (_req, res) => {
+      res.status(429).json({ error: 'Too many requests, please try again later.' });
+    },
+  });
+
   const requireJobSecret: RequestHandler = (req, res, next) => {
     if (!isAuthorized(req, options.secret)) {
       return res.status(401).json({ error: 'Unauthorized' });
@@ -78,8 +89,8 @@ export function createJobsRouter(runner: DailyDigestRunner, options: JobsRouterO
     }
   };
 
-  router.get('/digest', requireJobSecret, jobRateLimit, handleDigestRun);
-  router.post('/digest', requireJobSecret, jobRateLimit, handleDigestRun);
+  router.get('/digest', unauthorizedJobAttemptRateLimit, requireJobSecret, jobRateLimit, handleDigestRun);
+  router.post('/digest', unauthorizedJobAttemptRateLimit, requireJobSecret, jobRateLimit, handleDigestRun);
 
   return router;
 }

--- a/apps/api/src/routes/jobs.ts
+++ b/apps/api/src/routes/jobs.ts
@@ -49,13 +49,15 @@ export function createJobsRouter(runner: DailyDigestRunner, options: JobsRouterO
     },
   });
 
-  router.use(jobRateLimit);
-
-  const handleDigestRun: RequestHandler = async (req, res, next) => {
+  const requireJobSecret: RequestHandler = (req, res, next) => {
     if (!isAuthorized(req, options.secret)) {
       return res.status(401).json({ error: 'Unauthorized' });
     }
 
+    return next();
+  };
+
+  const handleDigestRun: RequestHandler = async (req, res, next) => {
     const payload: unknown = req.method === 'GET' ? req.query : req.body;
     const parsed = runDigestSchema.safeParse(payload);
     if (!parsed.success) {
@@ -76,8 +78,8 @@ export function createJobsRouter(runner: DailyDigestRunner, options: JobsRouterO
     }
   };
 
-  router.get('/digest', handleDigestRun);
-  router.post('/digest', handleDigestRun);
+  router.get('/digest', requireJobSecret, jobRateLimit, handleDigestRun);
+  router.post('/digest', requireJobSecret, jobRateLimit, handleDigestRun);
 
   return router;
 }

--- a/apps/api/src/routes/jobs.ts
+++ b/apps/api/src/routes/jobs.ts
@@ -1,4 +1,5 @@
 import { Router, type Request, type RequestHandler } from 'express';
+import rateLimit from 'express-rate-limit';
 import { z } from 'zod';
 
 import type { DailyDigestRunner } from '../notifications/daily-digest-runner';
@@ -26,8 +27,8 @@ const runDigestSchema = z.object({
     .union([z.boolean(), z.enum(['true', 'false', '1', '0'])])
     .optional()
     .transform(value => value === true || value === 'true' || value === '1'),
-  sendLimit: optionalIntegerParam(z.coerce.number().int().min(0).safe()),
-});
+  sendLimit: optionalIntegerParam(z.coerce.number().int().min(0).max(500)),
+}).strict();
 
 function isAuthorized(req: Request, secret: string): boolean {
   const jobSecret = req.get('x-job-secret');
@@ -37,6 +38,18 @@ function isAuthorized(req: Request, secret: string): boolean {
 
 export function createJobsRouter(runner: DailyDigestRunner, options: JobsRouterOptions) {
   const router = Router();
+
+  const jobRateLimit = rateLimit({
+    windowMs: 60_000,
+    max: 5,
+    standardHeaders: true,
+    legacyHeaders: false,
+    handler: (_req, res) => {
+      res.status(429).json({ error: 'Too many requests, please try again later.' });
+    },
+  });
+
+  router.use(jobRateLimit);
 
   const handleDigestRun: RequestHandler = async (req, res, next) => {
     if (!isAuthorized(req, options.secret)) {

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -9,6 +9,7 @@ import {
   TaskCreateSchema,
   TaskUpdateSchema,
 } from '../schemas/task';
+import { TagLabelSchema } from '../schemas/tag';
 import {
   createTaskRepository,
   type TaskCreateInput,
@@ -18,6 +19,10 @@ import {
 import { normalizeTagLabels } from '../repositories/task-mapper';
 
 const Rfc3339DateTimeSchema = z.string().datetime({ offset: true });
+const TaskTagFilterSchema = z.union([
+  TagLabelSchema,
+  z.array(TagLabelSchema).max(TASK_TAGS_MAX_LENGTH),
+]);
 
 const TaskListQuerySchema = z
   .object({
@@ -25,7 +30,7 @@ const TaskListQuerySchema = z
     pageSize: z.coerce.number().int().positive().max(100).default(20),
     status: z.enum(['TODO', 'IN_PROGRESS', 'DONE']).optional(),
     priority: z.enum(['LOW', 'MEDIUM', 'HIGH']).optional(),
-    tag: z.union([z.string().trim().min(1), z.array(z.string().trim().min(1)).max(TASK_TAGS_MAX_LENGTH)]).optional(),
+    tag: TaskTagFilterSchema.optional(),
     q: z.string().trim().min(1).max(TASK_QUERY_MAX_LENGTH).optional(),
     dueFrom: Rfc3339DateTimeSchema.optional(),
     dueTo: Rfc3339DateTimeSchema.optional(),
@@ -49,7 +54,7 @@ const TaskBoardQuerySchema = z
   .object({
     status: z.enum(['TODO', 'IN_PROGRESS', 'DONE']).optional(),
     priority: z.enum(['LOW', 'MEDIUM', 'HIGH']).optional(),
-    tag: z.union([z.string().trim().min(1), z.array(z.string().trim().min(1)).max(TASK_TAGS_MAX_LENGTH)]).optional(),
+    tag: TaskTagFilterSchema.optional(),
     q: z.string().trim().min(1).max(TASK_QUERY_MAX_LENGTH).optional(),
     dueFrom: Rfc3339DateTimeSchema.optional(),
     dueTo: Rfc3339DateTimeSchema.optional(),

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -2,7 +2,13 @@ import { Router } from 'express';
 import { z } from 'zod';
 
 import { getPrismaClient } from '../prisma';
-import { TaskBoardMoveSchema, TaskCreateSchema, TaskUpdateSchema } from '../schemas/task';
+import {
+  TASK_QUERY_MAX_LENGTH,
+  TASK_TAGS_MAX_LENGTH,
+  TaskBoardMoveSchema,
+  TaskCreateSchema,
+  TaskUpdateSchema,
+} from '../schemas/task';
 import {
   createTaskRepository,
   type TaskCreateInput,
@@ -19,12 +25,12 @@ const TaskListQuerySchema = z
     pageSize: z.coerce.number().int().positive().max(100).default(20),
     status: z.enum(['TODO', 'IN_PROGRESS', 'DONE']).optional(),
     priority: z.enum(['LOW', 'MEDIUM', 'HIGH']).optional(),
-    tag: z.union([z.string().trim().min(1), z.array(z.string().trim().min(1))]).optional(),
-    q: z.string().trim().min(1).optional(),
+    tag: z.union([z.string().trim().min(1), z.array(z.string().trim().min(1)).max(TASK_TAGS_MAX_LENGTH)]).optional(),
+    q: z.string().trim().min(1).max(TASK_QUERY_MAX_LENGTH).optional(),
     dueFrom: Rfc3339DateTimeSchema.optional(),
     dueTo: Rfc3339DateTimeSchema.optional(),
   })
-  .passthrough()
+  .strict()
   .superRefine((data, ctx) => {
     if (data.dueFrom && data.dueTo) {
       const from = new Date(data.dueFrom);
@@ -43,12 +49,12 @@ const TaskBoardQuerySchema = z
   .object({
     status: z.enum(['TODO', 'IN_PROGRESS', 'DONE']).optional(),
     priority: z.enum(['LOW', 'MEDIUM', 'HIGH']).optional(),
-    tag: z.union([z.string().trim().min(1), z.array(z.string().trim().min(1))]).optional(),
-    q: z.string().trim().min(1).optional(),
+    tag: z.union([z.string().trim().min(1), z.array(z.string().trim().min(1)).max(TASK_TAGS_MAX_LENGTH)]).optional(),
+    q: z.string().trim().min(1).max(TASK_QUERY_MAX_LENGTH).optional(),
     dueFrom: Rfc3339DateTimeSchema.optional(),
     dueTo: Rfc3339DateTimeSchema.optional(),
   })
-  .passthrough()
+  .strict()
   .superRefine((data, ctx) => {
     if (data.dueFrom && data.dueTo) {
       const from = new Date(data.dueFrom);

--- a/apps/api/src/schemas/tag.ts
+++ b/apps/api/src/schemas/tag.ts
@@ -11,4 +11,4 @@ export const TagLabelSchema = z
 
 export const CreateTagSchema = z.object({
   label: TagLabelSchema,
-});
+}).strict();

--- a/apps/api/src/schemas/task.ts
+++ b/apps/api/src/schemas/task.ts
@@ -2,23 +2,34 @@ import { z } from 'zod';
 
 import { TagLabelSchema } from './tag';
 
+export const TASK_TITLE_MAX_LENGTH = 160;
+export const TASK_DESCRIPTION_MAX_LENGTH = 5_000;
+export const TASK_TAGS_MAX_LENGTH = 10;
+export const TASK_QUERY_MAX_LENGTH = 200;
+export const TASK_BOARD_TARGET_INDEX_MAX = 1_000;
+
+export const TaskTagsSchema = z.array(TagLabelSchema).max(TASK_TAGS_MAX_LENGTH);
+
+export const TaskTitleSchema = z.string().trim().min(1).max(TASK_TITLE_MAX_LENGTH);
+export const TaskDescriptionSchema = z.string().trim().min(1).max(TASK_DESCRIPTION_MAX_LENGTH);
+
 export const TaskCreateSchema = z.object({
-  title: z.string().trim().min(1),
-  description: z.string().trim().min(1).optional(),
+  title: TaskTitleSchema,
+  description: TaskDescriptionSchema.optional(),
   status: z.enum(['TODO', 'IN_PROGRESS', 'DONE']).optional(),
   priority: z.enum(['LOW', 'MEDIUM', 'HIGH']).optional(),
   dueDate: z.string().datetime().optional(),
-  tags: z.array(TagLabelSchema).optional(),
-});
+  tags: TaskTagsSchema.optional(),
+}).strict();
 
 export const TaskUpdateSchema = z.object({
-  title: z.string().trim().min(1).optional(),
-  description: z.union([z.string().trim().min(1), z.null()]).optional(),
+  title: TaskTitleSchema.optional(),
+  description: z.union([TaskDescriptionSchema, z.null()]).optional(),
   status: z.enum(['TODO', 'IN_PROGRESS', 'DONE']).optional(),
   priority: z.enum(['LOW', 'MEDIUM', 'HIGH']).optional(),
   dueDate: z.union([z.string().datetime(), z.null()]).optional(),
-  tags: z.array(TagLabelSchema).optional(),
-});
+  tags: TaskTagsSchema.optional(),
+}).strict();
 
 export const TaskBoardMoveSchema = z.object({
   taskId: z
@@ -26,5 +37,5 @@ export const TaskBoardMoveSchema = z.object({
     .trim()
     .uuid({ message: 'Invalid identifier' }),
   targetStatus: z.enum(['TODO', 'IN_PROGRESS', 'DONE']),
-  targetIndex: z.number().int().min(0),
-});
+  targetIndex: z.number().int().min(0).max(TASK_BOARD_TARGET_INDEX_MAX),
+}).strict();

--- a/apps/api/src/schemas/task.ts
+++ b/apps/api/src/schemas/task.ts
@@ -6,7 +6,6 @@ export const TASK_TITLE_MAX_LENGTH = 160;
 export const TASK_DESCRIPTION_MAX_LENGTH = 5_000;
 export const TASK_TAGS_MAX_LENGTH = 10;
 export const TASK_QUERY_MAX_LENGTH = 200;
-export const TASK_BOARD_TARGET_INDEX_MAX = 1_000;
 
 export const TaskTagsSchema = z.array(TagLabelSchema).max(TASK_TAGS_MAX_LENGTH);
 
@@ -37,5 +36,5 @@ export const TaskBoardMoveSchema = z.object({
     .trim()
     .uuid({ message: 'Invalid identifier' }),
   targetStatus: z.enum(['TODO', 'IN_PROGRESS', 'DONE']),
-  targetIndex: z.number().int().min(0).max(TASK_BOARD_TARGET_INDEX_MAX),
+  targetIndex: z.number().int().min(0),
 }).strict();

--- a/apps/api/tests/abuse-controls.test.ts
+++ b/apps/api/tests/abuse-controls.test.ts
@@ -1,0 +1,149 @@
+import express from 'express';
+import request from 'supertest';
+
+import { createApp } from '../src/app';
+import { createAuthAttemptLimiter, isDevBypassEnabled } from '../src/routes/auth';
+import { createTestAgent } from './utils/test-app';
+import { registerTestUser } from './utils/auth';
+
+function createLimitedProbeApp(trustProxy?: boolean | number) {
+  const app = express();
+  if (trustProxy !== undefined) {
+    app.set('trust proxy', trustProxy);
+  }
+  app.post(
+    '/limited',
+    createAuthAttemptLimiter({ max: 1, windowMs: 60_000, skipInTest: false }),
+    (_req, res) => res.status(400).json({ error: 'probe' }),
+  );
+  return app;
+}
+
+describe('abuse controls', () => {
+  const originalJsonBodyLimit = process.env.API_JSON_BODY_LIMIT;
+  const originalTrustProxy = process.env.TRUST_PROXY;
+
+  afterEach(() => {
+    if (originalJsonBodyLimit === undefined) {
+      delete process.env.API_JSON_BODY_LIMIT;
+    } else {
+      process.env.API_JSON_BODY_LIMIT = originalJsonBodyLimit;
+    }
+
+    if (originalTrustProxy === undefined) {
+      delete process.env.TRUST_PROXY;
+    } else {
+      process.env.TRUST_PROXY = originalTrustProxy;
+    }
+  });
+
+  it('returns consistent 429 responses and rate limit headers for auth attempts', async () => {
+    const { agent } = createTestAgent({ authRateLimit: { max: 2, windowMs: 60_000, skipInTest: false } });
+
+    await agent.post('/api/taskforge/v1/auth/login').send({ email: 'nobody@example.com', password: 'Password123!' }).expect(401);
+    await agent.post('/api/taskforge/v1/auth/login').send({ email: 'nobody@example.com', password: 'Password123!' }).expect(401);
+
+    const limited = await agent
+      .post('/api/taskforge/v1/auth/login')
+      .send({ email: 'nobody@example.com', password: 'Password123!' })
+      .expect(429);
+
+    expect(limited.body).toEqual({ error: 'Too many authentication attempts. Please try again later.' });
+    expect(limited.headers['ratelimit-limit']).toBe('2');
+  });
+
+  it('does not let untrusted X-Forwarded-For values create new rate-limit buckets when trust proxy is disabled', async () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const app = createLimitedProbeApp(false);
+
+    await request(app).post('/limited').set('X-Forwarded-For', '203.0.113.10').expect(400);
+    const response = await request(app)
+      .post('/limited')
+      .set('X-Forwarded-For', '203.0.113.11')
+      .expect(429);
+
+    expect(response.body).toEqual({ error: 'Too many authentication attempts. Please try again later.' });
+    consoleError.mockRestore();
+  });
+
+  it('uses forwarded client addresses only when a trusted proxy is configured', async () => {
+    const app = createLimitedProbeApp(1);
+
+    await request(app).post('/limited').set('X-Forwarded-For', '203.0.113.20').expect(400);
+    await request(app).post('/limited').set('X-Forwarded-For', '203.0.113.21').expect(400);
+    await request(app).post('/limited').set('X-Forwarded-For', '203.0.113.20').expect(429);
+  });
+
+  it('enforces the explicit JSON body size limit configured for the API app', async () => {
+    process.env.API_JSON_BODY_LIMIT = '1kb';
+    const app = createApp({ jwtSecret: 'test-secret', authRateLimit: false });
+
+    const response = await request(app)
+      .post('/api/taskforge/v1/auth/register')
+      .send({ email: 'large-body@example.com', password: 'Password123!', filler: 'x'.repeat(2_000) })
+      .expect(413);
+
+    expect(response.body.error).toEqual(expect.stringContaining('too large'));
+  });
+
+  it('keeps the dev auth bypass disabled in production even when the flag is true', () => {
+    expect(isDevBypassEnabled({ NODE_ENV: 'production', TF_DEV_BYPASS_AUTH: 'true' })).toBe(false);
+    expect(isDevBypassEnabled({ NODE_ENV: 'development', TF_DEV_BYPASS_AUTH: 'true' })).toBe(true);
+  });
+
+  it('rejects oversized task and tag inputs, unknown fields, and unbounded parameters', async () => {
+    const { agent } = createTestAgent();
+    const auth = await registerTestUser(agent, { email: 'abuse-inputs@example.com' });
+    const bearer = `Bearer ${auth.tokens.accessToken}`;
+
+    await agent
+      .post('/api/taskforge/v1/tasks')
+      .set('Authorization', bearer)
+      .send({ title: 'x'.repeat(161) })
+      .expect(400);
+    await agent
+      .post('/api/taskforge/v1/tasks')
+      .set('Authorization', bearer)
+      .send({ title: 'Valid', description: 'x'.repeat(5_001) })
+      .expect(400);
+    await agent
+      .post('/api/taskforge/v1/tasks')
+      .set('Authorization', bearer)
+      .send({ title: 'Valid', tags: Array.from({ length: 11 }, (_, index) => `tag-${index}`) })
+      .expect(400);
+    await agent
+      .post('/api/taskforge/v1/tasks')
+      .set('Authorization', bearer)
+      .send({ title: 'Valid', unexpected: true })
+      .expect(400);
+    await agent
+      .get(`/api/taskforge/v1/tasks?pageSize=101&q=${'x'.repeat(201)}`)
+      .set('Authorization', bearer)
+      .expect(400);
+    await agent
+      .patch('/api/taskforge/v1/tasks/board/move')
+      .set('Authorization', bearer)
+      .send({
+        taskId: '9e22c508-1383-4609-9bbd-2e09b7a2d108',
+        targetStatus: 'DONE',
+        targetIndex: 1_001,
+      })
+      .expect(400);
+    await agent
+      .post('/api/taskforge/v1/tags')
+      .set('Authorization', bearer)
+      .send({ label: 'x'.repeat(65) })
+      .expect(400);
+  });
+
+  it('rejects unknown email preference fields', async () => {
+    const { agent } = createTestAgent();
+    const auth = await registerTestUser(agent, { email: 'abuse-prefs@example.com' });
+
+    await agent
+      .patch('/api/taskforge/v1/me/email-preferences')
+      .set('Authorization', `Bearer ${auth.tokens.accessToken}`)
+      .send({ dailyDigestEnabled: true, unknown: 'field' })
+      .expect(400);
+  });
+});

--- a/apps/api/tests/abuse-controls.test.ts
+++ b/apps/api/tests/abuse-controls.test.ts
@@ -162,6 +162,14 @@ describe('abuse controls', () => {
       .set('Authorization', bearer)
       .expect(400);
     await agent
+      .get(`/api/taskforge/v1/tasks?tag=${'x'.repeat(65)}`)
+      .set('Authorization', bearer)
+      .expect(400);
+    await agent
+      .get(`/api/taskforge/v1/tasks/board?tag=${'x'.repeat(65)}`)
+      .set('Authorization', bearer)
+      .expect(400);
+    await agent
       .patch('/api/taskforge/v1/tasks/board/move')
       .set('Authorization', bearer)
       .send({

--- a/apps/api/tests/abuse-controls.test.ts
+++ b/apps/api/tests/abuse-controls.test.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto';
+
 import express from 'express';
 import request from 'supertest';
 
@@ -46,6 +48,45 @@ describe('abuse controls', () => {
     const limited = await agent
       .post('/api/taskforge/v1/auth/login')
       .send({ email: 'nobody@example.com', password: 'Password123!' })
+      .expect(429);
+
+    expect(limited.body).toEqual({ error: 'Too many authentication attempts. Please try again later.' });
+    expect(limited.headers['ratelimit-limit']).toBe('2');
+  });
+
+  it('keeps the server-side session bridge on a separate auth limiter bucket', async () => {
+    const sessionBridgeSecret = 'test-bridge-secret';
+    const { agent, userStore } = createTestAgent({
+      sessionBridgeSecret,
+      authRateLimit: { max: 1, windowMs: 60_000, skipInTest: false },
+      sessionBridgeRateLimit: { max: 2, windowMs: 60_000, skipInTest: false },
+    });
+    const user = {
+      id: randomUUID(),
+      email: 'bridge-bucket@example.com',
+      passwordHash: null,
+      createdAt: new Date(),
+    };
+    await userStore.create(user);
+
+    await agent.post('/api/taskforge/v1/auth/login').send({ email: 'nobody@example.com', password: 'Password123!' }).expect(401);
+    await agent.post('/api/taskforge/v1/auth/login').send({ email: 'nobody@example.com', password: 'Password123!' }).expect(429);
+
+    const bridgePayload = { userId: user.id, email: user.email };
+    await agent
+      .post('/api/taskforge/v1/auth/session-bridge')
+      .set('x-session-bridge-secret', sessionBridgeSecret)
+      .send(bridgePayload)
+      .expect(200);
+    await agent
+      .post('/api/taskforge/v1/auth/session-bridge')
+      .set('x-session-bridge-secret', sessionBridgeSecret)
+      .send(bridgePayload)
+      .expect(200);
+    const limited = await agent
+      .post('/api/taskforge/v1/auth/session-bridge')
+      .set('x-session-bridge-secret', sessionBridgeSecret)
+      .send(bridgePayload)
       .expect(429);
 
     expect(limited.body).toEqual({ error: 'Too many authentication attempts. Please try again later.' });

--- a/apps/api/tests/abuse-controls.test.ts
+++ b/apps/api/tests/abuse-controls.test.ts
@@ -2,9 +2,11 @@ import { randomUUID } from 'node:crypto';
 
 import express from 'express';
 import request from 'supertest';
+import type { BoardReadModelDTO } from '@taskforge/shared';
 
 import { createApp } from '../src/app';
 import { createAuthAttemptLimiter, isDevBypassEnabled } from '../src/routes/auth';
+import type { TaskRepository } from '../src/repositories/task-repository';
 import { createTestAgent } from './utils/test-app';
 import { registerTestUser } from './utils/auth';
 
@@ -20,6 +22,18 @@ function createLimitedProbeApp(trustProxy?: boolean | number) {
   );
   return app;
 }
+
+const emptyBoard: BoardReadModelDTO = {
+  columns: [],
+  summary: {
+    totalsByStatus: { TODO: 0, IN_PROGRESS: 0, DONE: 0 },
+    overdueByStatus: { TODO: 0, IN_PROGRESS: 0, DONE: 0 },
+    totalTasks: 0,
+    totalOverdue: 0,
+  },
+  updatedAt: '2026-06-01T00:00:00.000Z',
+  generatedAt: '2026-06-01T00:00:00.000Z',
+};
 
 describe('abuse controls', () => {
   const originalJsonBodyLimit = process.env.API_JSON_BODY_LIMIT;
@@ -175,7 +189,7 @@ describe('abuse controls', () => {
       .send({
         taskId: '9e22c508-1383-4609-9bbd-2e09b7a2d108',
         targetStatus: 'DONE',
-        targetIndex: 1_001,
+        targetIndex: -1,
       })
       .expect(400);
     await agent
@@ -183,6 +197,34 @@ describe('abuse controls', () => {
       .set('Authorization', bearer)
       .send({ label: 'x'.repeat(65) })
       .expect(400);
+  });
+
+  it('allows large board target indexes through schema validation for lane-length checks', async () => {
+    const moveTaskOnBoard = jest.fn().mockResolvedValue({ status: 'ok', board: emptyBoard });
+    const taskRepository = {
+      listTasks: jest.fn(),
+      getTask: jest.fn(),
+      getTaskBoard: jest.fn(),
+      moveTaskOnBoard,
+      createTask: jest.fn(),
+      updateTask: jest.fn(),
+      deleteTask: jest.fn(),
+    } as unknown as TaskRepository;
+    const { agent } = createTestAgent({ taskRepository });
+    const auth = await registerTestUser(agent, { email: 'large-board-index@example.com' });
+    const payload = {
+      taskId: '9e22c508-1383-4609-9bbd-2e09b7a2d108',
+      targetStatus: 'DONE',
+      targetIndex: 1_001,
+    };
+
+    await agent
+      .patch('/api/taskforge/v1/tasks/board/move')
+      .set('Authorization', `Bearer ${auth.tokens.accessToken}`)
+      .send(payload)
+      .expect(200);
+
+    expect(moveTaskOnBoard).toHaveBeenCalledWith(expect.any(String), payload);
   });
 
   it('rejects unknown email preference fields', async () => {

--- a/apps/api/tests/email-digest-route.test.ts
+++ b/apps/api/tests/email-digest-route.test.ts
@@ -49,8 +49,11 @@ describe('email digest routes', () => {
 
     await request(app).get('/email/digest/preview?dueSoonDays=0').expect(400);
     await request(app).get('/email/digest/preview?timezone=Not/A_Timezone').expect(400);
+    await request(app).get('/email/digest/preview?maxTasksPerGroup=51').expect(400);
+    await request(app).get('/email/digest/preview?unknown=true').expect(400);
     await request(app).post('/email/digest/send').send({ digestHourUtc: 99 }).expect(400);
     await request(app).post('/email/digest/send').send({ digestHourUtc: null }).expect(400);
+    await request(app).post('/email/digest/send').send({ dryRun: true, unknown: 'field' }).expect(400);
   });
 
   it('treats blank digest hour values as omitted', async () => {

--- a/apps/api/tests/http-config.test.ts
+++ b/apps/api/tests/http-config.test.ts
@@ -1,4 +1,10 @@
-import { getHttpServerConfig, parseCorsAllowedOrigins, parseTrustProxySetting } from '../src/config/http';
+import {
+  DEFAULT_JSON_BODY_LIMIT,
+  getHttpServerConfig,
+  parseCorsAllowedOrigins,
+  parseJsonBodyLimit,
+  parseTrustProxySetting,
+} from '../src/config/http';
 
 describe('http config', () => {
   it('leaves trust proxy unset when TRUST_PROXY is absent or blank', () => {
@@ -54,6 +60,17 @@ describe('http config', () => {
     );
   });
 
+
+
+  it('parses explicit JSON body size limits', () => {
+    expect(parseJsonBodyLimit(undefined)).toBe(DEFAULT_JSON_BODY_LIMIT);
+    expect(parseJsonBodyLimit(' 128KB ')).toBe('128kb');
+    expect(parseJsonBodyLimit('1024b')).toBe('1024b');
+    expect(parseJsonBodyLimit('1mb')).toBe('1mb');
+    expect(() => parseJsonBodyLimit('large')).toThrow('API_JSON_BODY_LIMIT must be a size');
+    expect(() => parseJsonBodyLimit('1gb')).toThrow('API_JSON_BODY_LIMIT must be a size');
+  });
+
   it('resolves default and configured CORS origins', () => {
     expect(getHttpServerConfig({ NODE_ENV: 'development' }).corsAllowedOrigins).toEqual([
       'http://localhost:3000',
@@ -64,5 +81,6 @@ describe('http config', () => {
       NODE_ENV: 'production',
       CORS_ALLOWED_ORIGINS: 'https://app.example.com',
     }).corsAllowedOrigins).toEqual(['https://app.example.com']);
+    expect(getHttpServerConfig({ NODE_ENV: 'production', API_JSON_BODY_LIMIT: '32kb' }).jsonBodyLimit).toBe('32kb');
   });
 });

--- a/apps/api/tests/jobs-route.test.ts
+++ b/apps/api/tests/jobs-route.test.ts
@@ -144,6 +144,51 @@ describe('jobs router', () => {
     consoleWarn.mockRestore();
   });
 
+  it('does not spend job rate-limit budget on missing or incorrect secrets', async () => {
+    const run = jest.fn().mockResolvedValue({ attempted: 1, sent: 1, skipped: 0, failed: 0 });
+    const app = express();
+    app.use(express.json());
+    app.use('/jobs', createJobsRouter(createRunner(run), { defaultSendLimit: 90, secret: 'job-secret' }));
+
+    for (let index = 0; index < 6; index += 1) {
+      await request(app)
+        .post('/jobs/digest')
+        .set('x-job-secret', `wrong-secret-${index}`)
+        .send({ digestDate: '2026-05-19' })
+        .expect(401);
+    }
+
+    await request(app)
+      .post('/jobs/digest')
+      .set('x-job-secret', 'job-secret')
+      .send({ digestDate: '2026-05-19' })
+      .expect(200);
+
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it('rate limits valid protected job runs after secret validation', async () => {
+    const run = jest.fn().mockResolvedValue({ attempted: 0, sent: 0, skipped: 0, failed: 0 });
+    const app = express();
+    app.use('/jobs', createJobsRouter(createRunner(run), { defaultSendLimit: 90, secret: 'job-secret' }));
+
+    for (let index = 0; index < 5; index += 1) {
+      await request(app)
+        .get(`/jobs/digest?digestDate=2026-05-${20 + index}&dryRun=true`)
+        .set('Authorization', 'Bearer job-secret')
+        .expect(200);
+    }
+
+    const limited = await request(app)
+      .get('/jobs/digest?digestDate=2026-05-25&dryRun=true')
+      .set('Authorization', 'Bearer job-secret')
+      .expect(429);
+
+    expect(limited.body).toEqual({ error: 'Too many requests, please try again later.' });
+    expect(limited.headers['ratelimit-limit']).toBe('5');
+    expect(run).toHaveBeenCalledTimes(5);
+  });
+
   it('rejects unknown job query and body fields', async () => {
     const run = jest.fn();
     const app = express();

--- a/apps/api/tests/jobs-route.test.ts
+++ b/apps/api/tests/jobs-route.test.ts
@@ -112,6 +112,62 @@ describe('jobs router', () => {
     expect(run).not.toHaveBeenCalled();
   });
 
+
+
+  it('rejects missing and incorrect job secrets without logging or echoing supplied values', async () => {
+    const run = jest.fn();
+    const app = express();
+    app.use(express.json());
+    app.use('/jobs', createJobsRouter(createRunner(run), { defaultSendLimit: 90, secret: 'job-secret' }));
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const consoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    const missing = await request(app).post('/jobs/digest').send({ digestDate: '2026-05-19' }).expect(401);
+    const wrongHeader = await request(app)
+      .post('/jobs/digest')
+      .set('x-job-secret', 'definitely-wrong-secret')
+      .send({ digestDate: '2026-05-19' })
+      .expect(401);
+    const wrongBearer = await request(app)
+      .get('/jobs/digest?digestDate=2026-05-19')
+      .set('Authorization', 'Bearer definitely-wrong-bearer')
+      .expect(401);
+
+    expect(missing.body).toEqual({ error: 'Unauthorized' });
+    expect(wrongHeader.text).not.toContain('definitely-wrong-secret');
+    expect(wrongBearer.text).not.toContain('definitely-wrong-bearer');
+    expect(consoleError).not.toHaveBeenCalled();
+    expect(consoleWarn).not.toHaveBeenCalled();
+    expect(run).not.toHaveBeenCalled();
+
+    consoleError.mockRestore();
+    consoleWarn.mockRestore();
+  });
+
+  it('rejects unknown job query and body fields', async () => {
+    const run = jest.fn();
+    const app = express();
+    app.use(express.json());
+    app.use('/jobs', createJobsRouter(createRunner(run), { defaultSendLimit: 90, secret: 'job-secret' }));
+
+    await request(app)
+      .get('/jobs/digest?digestDate=2026-05-19&unexpected=true')
+      .set('Authorization', 'Bearer job-secret')
+      .expect(400);
+    await request(app)
+      .post('/jobs/digest')
+      .set('x-job-secret', 'job-secret')
+      .send({ digestDate: '2026-05-19', unexpected: true })
+      .expect(400);
+    await request(app)
+      .post('/jobs/digest')
+      .set('x-job-secret', 'job-secret')
+      .send({ digestDate: '2026-05-19', sendLimit: 501 })
+      .expect(400);
+
+    expect(run).not.toHaveBeenCalled();
+  });
+
   it('rejects blank string send limits instead of coercing them to zero', async () => {
     const run = jest.fn();
     const app = express();

--- a/apps/api/tests/jobs-route.test.ts
+++ b/apps/api/tests/jobs-route.test.ts
@@ -144,19 +144,28 @@ describe('jobs router', () => {
     consoleWarn.mockRestore();
   });
 
-  it('does not spend job rate-limit budget on missing or incorrect secrets', async () => {
+  it('rate limits invalid job-secret attempts without spending the valid job budget', async () => {
     const run = jest.fn().mockResolvedValue({ attempted: 1, sent: 1, skipped: 0, failed: 0 });
     const app = express();
     app.use(express.json());
     app.use('/jobs', createJobsRouter(createRunner(run), { defaultSendLimit: 90, secret: 'job-secret' }));
 
-    for (let index = 0; index < 6; index += 1) {
+    for (let index = 0; index < 5; index += 1) {
       await request(app)
         .post('/jobs/digest')
         .set('x-job-secret', `wrong-secret-${index}`)
         .send({ digestDate: '2026-05-19' })
         .expect(401);
     }
+
+    const limited = await request(app)
+      .post('/jobs/digest')
+      .set('x-job-secret', 'wrong-secret-5')
+      .send({ digestDate: '2026-05-19' })
+      .expect(429);
+
+    expect(limited.body).toEqual({ error: 'Too many requests, please try again later.' });
+    expect(limited.headers['ratelimit-limit']).toBe('5');
 
     await request(app)
       .post('/jobs/digest')

--- a/apps/api/tests/utils/test-app.ts
+++ b/apps/api/tests/utils/test-app.ts
@@ -1,7 +1,7 @@
 import request, { type SuperTest, type Test } from 'supertest';
 
 import { PrismaUserStore, type UserStore } from '../../src/auth/user-store';
-import { createApp } from '../../src/app';
+import { createApp, type CreateAppOptions } from '../../src/app';
 import type { WelcomeEmailDeliveryDispatcher } from '../../src/notifications/welcome-email';
 import { createTaskRepository, type TaskRepository } from '../../src/repositories/task-repository';
 import type { EmailAdapter } from '../../src/email/types';
@@ -24,6 +24,9 @@ export interface CreateTestAgentOptions {
   welcomeEmailAdapter?: EmailAdapter;
   welcomeEmailDeliveryDispatcher?: WelcomeEmailDeliveryDispatcher;
   welcomeEmailPendingAttemptStaleAfterMs?: number;
+  authRateLimit?: CreateAppOptions['authRateLimit'];
+  digestJobSecret?: string;
+  digestDailySendLimit?: number;
 }
 
 export function createTestAgent(options: CreateTestAgentOptions = {}): TestAgentContext {
@@ -40,6 +43,9 @@ export function createTestAgent(options: CreateTestAgentOptions = {}): TestAgent
     welcomeEmailAdapter: options.welcomeEmailAdapter ?? { sendMail: async () => undefined },
     welcomeEmailDeliveryDispatcher: options.welcomeEmailDeliveryDispatcher ?? (task => task()),
     welcomeEmailPendingAttemptStaleAfterMs: options.welcomeEmailPendingAttemptStaleAfterMs,
+    authRateLimit: options.authRateLimit,
+    digestJobSecret: options.digestJobSecret,
+    digestDailySendLimit: options.digestDailySendLimit,
   });
 
   return { agent: request(app), prisma, userStore, taskRepository };

--- a/apps/api/tests/utils/test-app.ts
+++ b/apps/api/tests/utils/test-app.ts
@@ -25,6 +25,7 @@ export interface CreateTestAgentOptions {
   welcomeEmailDeliveryDispatcher?: WelcomeEmailDeliveryDispatcher;
   welcomeEmailPendingAttemptStaleAfterMs?: number;
   authRateLimit?: CreateAppOptions['authRateLimit'];
+  sessionBridgeRateLimit?: CreateAppOptions['sessionBridgeRateLimit'];
   digestJobSecret?: string;
   digestDailySendLimit?: number;
 }
@@ -44,6 +45,7 @@ export function createTestAgent(options: CreateTestAgentOptions = {}): TestAgent
     welcomeEmailDeliveryDispatcher: options.welcomeEmailDeliveryDispatcher ?? (task => task()),
     welcomeEmailPendingAttemptStaleAfterMs: options.welcomeEmailPendingAttemptStaleAfterMs,
     authRateLimit: options.authRateLimit,
+    sessionBridgeRateLimit: options.sessionBridgeRateLimit,
     digestJobSecret: options.digestJobSecret,
     digestDailySendLimit: options.digestDailySendLimit,
   });

--- a/apps/web/app/(protected)/dashboard/dashboard-content.tsx
+++ b/apps/web/app/(protected)/dashboard/dashboard-content.tsx
@@ -84,7 +84,8 @@ import {
 } from "@/lib/email-preferences-hooks";
 import { useDigestPreviewQuery } from "@/lib/digest-preview-hooks";
 import { cn } from "@/lib/utils";
-import { sanitizeTags } from "@/lib/task-tags";
+import { sanitizeTaskInputTags, sanitizeValidTaskTags } from "@/lib/task-tags";
+import { TASK_QUERY_MAX_LENGTH } from "@/lib/task-limits";
 import { TaskTagSelector } from "@/components/tasks/task-tag-selector";
 
 import type { DashboardUser } from "./types";
@@ -232,7 +233,7 @@ function normalizeDueWindow(value: string | null | undefined): DueWindow | null 
 }
 
 function parseBoardFiltersFromSearchParams(searchParams: URLSearchParams): BoardFilterState {
-  const state = createDefaultBoardFilterState(sanitizeTags(searchParams.getAll("tag")));
+  const state = createDefaultBoardFilterState(sanitizeTaskInputTags(searchParams.getAll("tag")));
   const status = searchParams.get("status");
   const priority = searchParams.get("priority");
   const dueWindow = normalizeDueWindow(searchParams.get("dueWindow"));
@@ -255,7 +256,7 @@ function parseBoardFiltersFromSearchParams(searchParams: URLSearchParams): Board
     state.customDueRange = { dueFrom, dueTo };
   }
 
-  state.searchQuery = searchParams.get("q") ?? "";
+  state.searchQuery = (searchParams.get("q") ?? "").slice(0, TASK_QUERY_MAX_LENGTH);
   return state;
 }
 
@@ -315,8 +316,10 @@ function readBoardFiltersFromStorage(): BoardFilterState | null {
       };
     }
 
-    state.searchQuery = typeof parsed.searchQuery === "string" ? parsed.searchQuery : "";
-    state.tagFilters = Array.isArray(parsed.tagFilters) ? sanitizeTags(parsed.tagFilters) : [];
+    state.searchQuery = typeof parsed.searchQuery === "string"
+      ? parsed.searchQuery.slice(0, TASK_QUERY_MAX_LENGTH)
+      : "";
+    state.tagFilters = Array.isArray(parsed.tagFilters) ? sanitizeTaskInputTags(parsed.tagFilters) : [];
     return state;
   } catch {
     return null;
@@ -1168,7 +1171,7 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
 
   const handleTagFiltersChange = useCallback(
     (nextTags: string[]) => {
-      const nextTagFilters = sanitizeTags(nextTags);
+      const nextTagFilters = sanitizeTaskInputTags(nextTags);
       setTagFilters((previous) =>
         previous.length === nextTagFilters.length &&
         previous.every((value, index) => value === nextTagFilters[index])
@@ -1188,7 +1191,7 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
     for (const tag of tagFilters) {
       collected.push(tag);
     }
-    return sanitizeTags(collected);
+    return sanitizeValidTaskTags(collected);
   }, [tagFilters, tagsQuery.tags]);
 
   const firstName = user.name?.split(" ")[0] ?? "there";
@@ -1894,8 +1897,9 @@ export function DashboardContent({ user }: { user: DashboardUser }) {
             <Input
               id="board-task-search"
               value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
+              onChange={(e) => setSearchQuery(e.target.value.slice(0, TASK_QUERY_MAX_LENGTH))}
               placeholder="Search title or description"
+              maxLength={TASK_QUERY_MAX_LENGTH}
               className="h-9 w-64"
             />
             <DropdownMenu>

--- a/apps/web/app/api/auth/me/route.test.ts
+++ b/apps/web/app/api/auth/me/route.test.ts
@@ -4,6 +4,7 @@ const cookieGet = vi.fn();
 const getCurrentUser = vi.fn();
 const getFreshBridgedAccessToken = vi.fn();
 const getBridgedAccessToken = vi.fn();
+let devBypassEnabled = true;
 
 vi.mock('next/headers', () => ({
   cookies: () => ({
@@ -17,7 +18,7 @@ vi.mock('@/lib/env', () => ({
 }));
 
 vi.mock('@/lib/dev-auth-bypass', () => ({
-  isDevAuthBypassEnabled: () => true,
+  isDevAuthBypassEnabled: () => devBypassEnabled,
 }));
 
 vi.mock('@/lib/server-auth', () => ({
@@ -56,6 +57,7 @@ describe('/api/auth/me', () => {
         }),
       }),
     );
+    devBypassEnabled = true;
     cookieGet.mockReturnValue({ value: 'stale-api-cookie' });
     getCurrentUser.mockResolvedValue({
       id: 'dev-bypass-user',
@@ -100,5 +102,23 @@ describe('/api/auth/me', () => {
       '[auth] Failed to bridge dev bypass session',
       expect.any(Error),
     );
+  });
+
+  it('does not resolve a current user through dev bypass when the bypass helper is disabled', async () => {
+    devBypassEnabled = false;
+    const { GET } = await import('./route');
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(getCurrentUser).not.toHaveBeenCalled();
+    expect(getFreshBridgedAccessToken).not.toHaveBeenCalled();
+    expect(getBridgedAccessToken).not.toHaveBeenCalled();
+    expect(body).toEqual({
+      user: {
+        id: 'stale-cookie-user',
+        email: 'stale@example.com',
+      },
+    });
   });
 });

--- a/apps/web/components/tasks/hooks-demo.tsx
+++ b/apps/web/components/tasks/hooks-demo.tsx
@@ -39,7 +39,8 @@ import {
   TASK_STATUS_LABELS,
   TASK_STATUS_OPTIONS,
 } from '@/lib/task-copy';
-import { sanitizeTags } from '@/lib/task-tags';
+import { sanitizeTaskInputTags, sanitizeValidTaskTags } from '@/lib/task-tags';
+import { TASK_QUERY_MAX_LENGTH } from '@/lib/task-limits';
 
 const FILTER_STORAGE_KEY = 'taskforge.tasksDemo.filters';
 
@@ -256,11 +257,11 @@ function parseFiltersFromSearchParams(
   }
 
   if (search?.trim()) {
-    next.search = search.trim();
+    next.search = search.trim().slice(0, TASK_QUERY_MAX_LENGTH);
   }
 
   if (tags.length > 0) {
-    next.tags = sanitizeTags(tags);
+    next.tags = sanitizeTaskInputTags(tags);
   }
 
   return Object.keys(next).length > 0 ? next : null;
@@ -293,11 +294,11 @@ function readFiltersFromStorage(): Partial<TaskFilterState> | null {
     }
 
     if (Array.isArray(parsed.tags)) {
-      next.tags = sanitizeTags(parsed.tags);
+      next.tags = sanitizeTaskInputTags(parsed.tags);
     }
 
     if (typeof parsed.search === 'string' && parsed.search.trim()) {
-      next.search = parsed.search.trim();
+      next.search = parsed.search.trim().slice(0, TASK_QUERY_MAX_LENGTH);
     }
 
     const dueFromDay =
@@ -697,7 +698,7 @@ export function TasksHooksDemo() {
   const deleteTask = useDeleteTask();
 
   const hasMutationError = createTask.error ?? updateTask.error ?? deleteTask.error;
-  const [availableTags, setAvailableTags] = useState<string[]>(() => sanitizeTags(filters.tags));
+  const [availableTags, setAvailableTags] = useState<string[]>(() => sanitizeValidTaskTags(filters.tags));
 
   const mergeAvailableTags = useCallback((items: TaskListItem[] | undefined) => {
     if (!items || items.length === 0) {
@@ -714,7 +715,7 @@ export function TasksHooksDemo() {
     }
 
     setAvailableTags((previous) => {
-      const next = sanitizeTags([...previous, ...collected]);
+      const next = sanitizeValidTaskTags([...previous, ...collected]);
       if (next.length === previous.length && next.every((tag, index) => tag === previous[index])) {
         return previous;
       }
@@ -842,10 +843,11 @@ export function TasksHooksDemo() {
                   value={filters.search}
                   placeholder="Search by title or description"
                   className="pl-9"
+                  maxLength={TASK_QUERY_MAX_LENGTH}
                   onChange={(event) =>
                     setFilters((previous) => ({
                       ...previous,
-                      search: event.target.value,
+                      search: event.target.value.slice(0, TASK_QUERY_MAX_LENGTH),
                     }))
                   }
                 />

--- a/apps/web/components/tasks/task-create-dialog.tsx
+++ b/apps/web/components/tasks/task-create-dialog.tsx
@@ -10,7 +10,7 @@ import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 import { Form } from '@/components/ui/form';
 import { useToast } from '@/components/ui/use-toast';
-import { sanitizeTags } from '@/lib/task-tags';
+import { sanitizeTaskInputTags } from '@/lib/task-tags';
 import { useCreateTask, toTaskOperationError } from '@/lib/tasks-hooks';
 import type { TaskRecordDTO } from '@/lib/tasks-client';
 
@@ -92,7 +92,7 @@ export function TaskCreateDialog({ trigger, availableTags = [], onCreated, open,
       status: values.status,
       priority: values.priority,
       dueDate: values.dueDate,
-      tags: sanitizeTags(values.tags),
+      tags: sanitizeTaskInputTags(values.tags),
     });
   }
 

--- a/apps/web/components/tasks/task-dialog-host.tsx
+++ b/apps/web/components/tasks/task-dialog-host.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useState } from 'react';
 
 import { useToast } from '@/components/ui/use-toast';
-import { sanitizeTags } from '@/lib/task-tags';
+import { sanitizeValidTaskTags } from '@/lib/task-tags';
 import { useTagsQuery } from '@/lib/tasks-hooks';
 
 import { TaskCreateDialog } from './task-create-dialog';
@@ -15,7 +15,7 @@ export function TaskDialogHost() {
   const [activeDialog, setActiveDialog] = useState<ActiveDialog>(null);
   const { toast } = useToast();
   const tagsQuery = useTagsQuery();
-  const availableTags = sanitizeTags(tagsQuery.tags.map((tag) => tag.label));
+  const availableTags = sanitizeValidTaskTags(tagsQuery.tags.map((tag) => tag.label));
 
   const handleDocumentClick = useCallback(
     (event: MouseEvent) => {

--- a/apps/web/components/tasks/task-edit-dialog.tsx
+++ b/apps/web/components/tasks/task-edit-dialog.tsx
@@ -10,7 +10,7 @@ import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Form } from '@/components/ui/form';
 import { useToast } from '@/components/ui/use-toast';
-import { sanitizeTags } from '@/lib/task-tags';
+import { sanitizeTaskInputTags } from '@/lib/task-tags';
 import {
   useTaskFromCache,
   useTaskRecordQuery,
@@ -188,7 +188,7 @@ export function TaskEditDialog({ taskId, open, onOpenChange, onTaskIdChange, ava
         status: values.status,
         priority: values.priority,
         dueDate: values.dueDate ?? null,
-        tags: sanitizeTags(values.tags),
+        tags: sanitizeTaskInputTags(values.tags),
       },
     });
   }

--- a/apps/web/components/tasks/task-edit-dialog.tsx
+++ b/apps/web/components/tasks/task-edit-dialog.tsx
@@ -10,7 +10,6 @@ import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Form } from '@/components/ui/form';
 import { useToast } from '@/components/ui/use-toast';
-import { sanitizeTaskInputTags } from '@/lib/task-tags';
 import {
   useTaskFromCache,
   useTaskRecordQuery,
@@ -27,6 +26,7 @@ import {
   type TaskFormValues,
   applyTaskIssuesToForm,
 } from './task-form';
+import { taskFormValuesToUpdateInput } from './task-form-payload';
 
 interface TaskEditDialogProps {
   taskId: string | null;
@@ -182,14 +182,9 @@ export function TaskEditDialog({ taskId, open, onOpenChange, onTaskIdChange, ava
 
     updateTask.mutate({
       id: taskId,
-      input: {
-        title: values.title.trim(),
-        description: values.description?.trim() ? values.description.trim() : null,
-        status: values.status,
-        priority: values.priority,
-        dueDate: values.dueDate ?? null,
-        tags: sanitizeTaskInputTags(values.tags),
-      },
+      input: taskFormValuesToUpdateInput(values, {
+        includeTags: Boolean(form.formState.dirtyFields.tags),
+      }),
     });
   }
   const lastUpdatedLabel = useMemo(() => {

--- a/apps/web/components/tasks/task-form-payload.test.ts
+++ b/apps/web/components/tasks/task-form-payload.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import type { TaskFormValues } from './task-form';
+import { taskFormValuesToUpdateInput } from './task-form-payload';
+
+const baseValues: TaskFormValues = {
+  title: '  Updated title  ',
+  description: '  Updated description  ',
+  status: 'IN_PROGRESS',
+  priority: 'HIGH',
+  dueDate: undefined,
+  tags: ['legacy-a', 'legacy-b'],
+};
+
+describe('taskFormValuesToUpdateInput', () => {
+  it('omits tags when the edit form tag field was not changed', () => {
+    expect(taskFormValuesToUpdateInput(baseValues, { includeTags: false })).toEqual({
+      title: 'Updated title',
+      description: 'Updated description',
+      status: 'IN_PROGRESS',
+      priority: 'HIGH',
+      dueDate: null,
+    });
+  });
+
+  it('includes sanitized tags when the edit form tag field was changed', () => {
+    expect(
+      taskFormValuesToUpdateInput(
+        {
+          ...baseValues,
+          tags: ['api', 'API', '  frontend  ', 'x'.repeat(65)],
+        },
+        { includeTags: true },
+      ),
+    ).toEqual({
+      title: 'Updated title',
+      description: 'Updated description',
+      status: 'IN_PROGRESS',
+      priority: 'HIGH',
+      dueDate: null,
+      tags: ['api', 'frontend'],
+    });
+  });
+});

--- a/apps/web/components/tasks/task-form-payload.ts
+++ b/apps/web/components/tasks/task-form-payload.ts
@@ -1,0 +1,23 @@
+import type { UpdateTaskInput } from '@/lib/tasks-client';
+import { sanitizeTaskInputTags } from '@/lib/task-tags';
+
+import type { TaskFormValues } from './task-form';
+
+export function taskFormValuesToUpdateInput(
+  values: TaskFormValues,
+  options: { includeTags: boolean },
+): UpdateTaskInput {
+  const input: UpdateTaskInput = {
+    title: values.title.trim(),
+    description: values.description?.trim() ? values.description.trim() : null,
+    status: values.status,
+    priority: values.priority,
+    dueDate: values.dueDate ?? null,
+  };
+
+  if (options.includeTags) {
+    input.tags = sanitizeTaskInputTags(values.tags);
+  }
+
+  return input;
+}

--- a/apps/web/components/tasks/task-form.tsx
+++ b/apps/web/components/tasks/task-form.tsx
@@ -12,22 +12,35 @@ import { TaskDueDatePicker } from '@/components/tasks/task-due-date-picker';
 import { TaskTagSelector } from '@/components/tasks/task-tag-selector';
 import { TASK_PRIORITY_FORM_OPTIONS, TASK_PRIORITY_LABELS, TASK_STATUS_FORM_OPTIONS, TASK_STATUS_LABELS } from '@/lib/task-copy';
 import type { TaskRecordDTO } from '@/lib/tasks-client';
-import { sanitizeTags } from '@/lib/task-tags';
+import { sanitizeTaskInputTags, sanitizeValidTaskTags } from '@/lib/task-tags';
+import {
+  isValidTaskTagLabel,
+  TASK_DESCRIPTION_MAX_LENGTH,
+  TASK_TAG_LABEL_MAX_LENGTH,
+  TASK_TAGS_MAX_LENGTH,
+  TASK_TITLE_MAX_LENGTH,
+} from '@/lib/task-limits';
 
 export const taskFormSchema = z.object({
   title: z
     .string({ required_error: 'Title is required' })
     .trim()
-    .min(3, 'Title must be at least 3 characters long'),
+    .min(3, 'Title must be at least 3 characters long')
+    .max(TASK_TITLE_MAX_LENGTH, `Title must be ${TASK_TITLE_MAX_LENGTH} characters or fewer`),
   description: z
     .string()
-    .max(2000, 'Description must be 2000 characters or fewer')
+    .max(TASK_DESCRIPTION_MAX_LENGTH, `Description must be ${TASK_DESCRIPTION_MAX_LENGTH} characters or fewer`)
     .transform((value) => value.trim())
     .optional(),
   status: z.enum(['TODO', 'IN_PROGRESS', 'DONE']).default('TODO'),
   priority: z.enum(['LOW', 'MEDIUM', 'HIGH']).default('MEDIUM'),
   dueDate: z.string().datetime().optional(),
-  tags: z.array(z.string().trim().min(1)).default([]),
+  tags: z
+    .array(z.string().trim().min(1).refine(isValidTaskTagLabel, {
+      message: `Tag label must be ${TASK_TAG_LABEL_MAX_LENGTH} characters or fewer`,
+    }))
+    .max(TASK_TAGS_MAX_LENGTH, `Use ${TASK_TAGS_MAX_LENGTH} tags or fewer`)
+    .default([]),
 });
 
 export type TaskFormValues = z.infer<typeof taskFormSchema>;
@@ -52,7 +65,7 @@ export function taskRecordToFormValues(task?: TaskRecordDTO | null): TaskFormVal
     status: task.status ?? 'TODO',
     priority: task.priority ?? 'MEDIUM',
     dueDate: task.dueDate ?? undefined,
-    tags: sanitizeTags(task.tags ?? []),
+    tags: sanitizeTaskInputTags(task.tags ?? []),
   } satisfies TaskFormValues;
 }
 
@@ -81,7 +94,10 @@ interface TaskFormFieldsProps {
 }
 
 export function TaskFormFields({ form, availableTags = [] }: TaskFormFieldsProps) {
-  const sanitizedTags = useMemo(() => sanitizeTags(availableTags), [availableTags]);
+  const sanitizedTags = useMemo(
+    () => sanitizeValidTaskTags(availableTags),
+    [availableTags],
+  );
 
   return (
     <>
@@ -92,7 +108,12 @@ export function TaskFormFields({ form, availableTags = [] }: TaskFormFieldsProps
           <FormItem>
             <FormLabel>Title</FormLabel>
             <FormControl>
-              <Input placeholder="Plan launch campaign" autoComplete="off" {...field} />
+              <Input
+                placeholder="Plan launch campaign"
+                autoComplete="off"
+                maxLength={TASK_TITLE_MAX_LENGTH}
+                {...field}
+              />
             </FormControl>
             <FormDescription>Required. Use a clear, action-oriented title.</FormDescription>
             <FormMessage />
@@ -106,9 +127,13 @@ export function TaskFormFields({ form, availableTags = [] }: TaskFormFieldsProps
           <FormItem>
             <FormLabel>Description</FormLabel>
             <FormControl>
-              <Textarea placeholder="Outline the context, goals, or acceptance criteria" {...field} />
+              <Textarea
+                placeholder="Outline the context, goals, or acceptance criteria"
+                maxLength={TASK_DESCRIPTION_MAX_LENGTH}
+                {...field}
+              />
             </FormControl>
-            <FormDescription>Optional. Keep it under 2000 characters.</FormDescription>
+            <FormDescription>Optional. Keep it under {TASK_DESCRIPTION_MAX_LENGTH} characters.</FormDescription>
             <FormMessage />
           </FormItem>
         )}
@@ -192,9 +217,11 @@ export function TaskFormFields({ form, availableTags = [] }: TaskFormFieldsProps
                 availableTags={sanitizedTags}
                 placeholder="Add tags"
                 emptyHint="Tags are optional. Use them to group related work."
+                maxTags={TASK_TAGS_MAX_LENGTH}
+                maxTagLength={TASK_TAG_LABEL_MAX_LENGTH}
               />
             </FormControl>
-            <FormDescription>Optional. Tags help with filtering and reporting.</FormDescription>
+            <FormDescription>Optional. Use up to {TASK_TAGS_MAX_LENGTH} tags.</FormDescription>
             <FormMessage />
           </FormItem>
         )}

--- a/apps/web/components/tasks/task-tag-selector.test.tsx
+++ b/apps/web/components/tasks/task-tag-selector.test.tsx
@@ -50,4 +50,25 @@ describe('TaskTagSelector', () => {
 
     expect(screen.queryByRole('button', { name: 'Create "api"' })).not.toBeInTheDocument();
   });
+
+  it('enforces tag count and label length limits before creating tags', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(
+      <TaskTagSelector
+        value={Array.from({ length: 10 }, (_, index) => `tag-${index}`)}
+        onChange={onChange}
+        placeholder="Select tags"
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Select tags' }));
+    const input = screen.getByRole('combobox');
+
+    expect(input).toHaveAttribute('maxLength', '64');
+    await user.type(input, 'new-tag{Enter}');
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/components/tasks/task-tag-selector.tsx
+++ b/apps/web/components/tasks/task-tag-selector.tsx
@@ -8,6 +8,11 @@ import { Button } from '@/components/ui/button';
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@/components/ui/command';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { sanitizeTags } from '@/lib/task-tags';
+import {
+  isValidTaskTagLabel,
+  TASK_TAG_LABEL_MAX_LENGTH,
+  TASK_TAGS_MAX_LENGTH,
+} from '@/lib/task-limits';
 
 interface TaskTagSelectorProps {
   value: string[];
@@ -16,6 +21,8 @@ interface TaskTagSelectorProps {
   placeholder?: string;
   emptyHint?: string;
   ariaLabel?: string;
+  maxTags?: number;
+  maxTagLength?: number;
 }
 
 type CommandInputProps = ComponentPropsWithoutRef<typeof CommandInput>;
@@ -55,13 +62,19 @@ export function TaskTagSelector({
   placeholder = 'Select tags',
   emptyHint = 'Use tags to organize related work.',
   ariaLabel,
+  maxTags = TASK_TAGS_MAX_LENGTH,
+  maxTagLength = TASK_TAG_LABEL_MAX_LENGTH,
 }: TaskTagSelectorProps) {
   const [open, setOpen] = useState(false);
   const [inputValue, setInputValue] = useState('');
   const [debouncedInput, setDebouncedInput] = useState('');
 
   const normalizedSelected = useMemo(() => value.map((tag) => tag.toLowerCase()), [value]);
-  const options = useMemo(() => sanitizeTags([...availableTags, ...value]), [availableTags, value]);
+  const selectedTags = useMemo(() => sanitizeTags(value), [value]);
+  const options = useMemo(
+    () => sanitizeTags([...availableTags, ...value]).filter(isValidTaskTagLabel),
+    [availableTags, value],
+  );
   const filteredOptions = useMemo(() => {
     if (!debouncedInput.trim()) {
       return options;
@@ -76,8 +89,13 @@ export function TaskTagSelector({
       return false;
     }
 
-    return !options.some((tag) => tag.toLowerCase() === search);
-  }, [inputValue, options]);
+    return (
+      selectedTags.length < maxTags &&
+      inputValue.trim().length <= maxTagLength &&
+      isValidTaskTagLabel(inputValue) &&
+      !options.some((tag) => tag.toLowerCase() === search)
+    );
+  }, [inputValue, maxTagLength, maxTags, options, selectedTags.length]);
 
   useEffect(() => {
     const timeout = window.setTimeout(() => {
@@ -88,7 +106,7 @@ export function TaskTagSelector({
   }, [inputValue]);
 
   const buttonLabel =
-    value.length > 0 ? `${value.length} tag${value.length === 1 ? '' : 's'} selected` : placeholder;
+    selectedTags.length > 0 ? `${selectedTags.length} tag${selectedTags.length === 1 ? '' : 's'} selected` : placeholder;
 
   function toggleTag(tag: string) {
     const trimmed = tag.trim();
@@ -99,8 +117,10 @@ export function TaskTagSelector({
     const key = trimmed.toLowerCase();
     if (normalizedSelected.includes(key)) {
       onChange(value.filter((existing) => existing.toLowerCase() !== key));
+    } else if (selectedTags.length >= maxTags || trimmed.length > maxTagLength || !isValidTaskTagLabel(trimmed)) {
+      return;
     } else {
-      onChange(sanitizeTags([...value, trimmed]));
+      onChange(sanitizeTags([...value, trimmed]).slice(0, maxTags));
     }
 
     setInputValue('');
@@ -166,6 +186,7 @@ export function TaskTagSelector({
               onValueChange={setInputValue}
               placeholder="Search or create tags"
               aria-label="Search available tags"
+              maxLength={maxTagLength}
               canCreate={canCreateTag}
               onCreate={handleCreateTag}
               onKeyDown={handleInputKeyDown}
@@ -183,7 +204,13 @@ export function TaskTagSelector({
               </CommandEmpty>
               <CommandGroup heading="Tags">
                 {filteredOptions.map((tag) => (
-                  <CommandItem key={tag} value={tag} onSelect={(value) => toggleTag(value)} aria-checked={isTagSelected(tag)}>
+                  <CommandItem
+                    key={tag}
+                    value={tag}
+                    onSelect={(value) => toggleTag(value)}
+                    aria-checked={isTagSelected(tag)}
+                    disabled={!isTagSelected(tag) && selectedTags.length >= maxTags}
+                  >
                     <span className="flex-1 text-sm capitalize">{tag}</span>
                     {isTagSelected(tag) ? <span className="text-xs text-primary">Selected</span> : null}
                   </CommandItem>

--- a/apps/web/lib/task-limits.ts
+++ b/apps/web/lib/task-limits.ts
@@ -1,0 +1,12 @@
+import { isValidNormalizedTagLabel, TAG_LABEL_MAX_LENGTH } from '@taskforge/shared';
+
+export const TASK_TITLE_MAX_LENGTH = 160;
+export const TASK_DESCRIPTION_MAX_LENGTH = 5_000;
+export const TASK_TAGS_MAX_LENGTH = 10;
+export const TASK_QUERY_MAX_LENGTH = 200;
+export const TASK_BOARD_TARGET_INDEX_MAX = 1_000;
+export const TASK_TAG_LABEL_MAX_LENGTH = TAG_LABEL_MAX_LENGTH;
+
+export function isValidTaskTagLabel(label: string): boolean {
+  return isValidNormalizedTagLabel(label);
+}

--- a/apps/web/lib/task-limits.ts
+++ b/apps/web/lib/task-limits.ts
@@ -4,7 +4,6 @@ export const TASK_TITLE_MAX_LENGTH = 160;
 export const TASK_DESCRIPTION_MAX_LENGTH = 5_000;
 export const TASK_TAGS_MAX_LENGTH = 10;
 export const TASK_QUERY_MAX_LENGTH = 200;
-export const TASK_BOARD_TARGET_INDEX_MAX = 1_000;
 export const TASK_TAG_LABEL_MAX_LENGTH = TAG_LABEL_MAX_LENGTH;
 
 export function isValidTaskTagLabel(label: string): boolean {

--- a/apps/web/lib/task-tags.ts
+++ b/apps/web/lib/task-tags.ts
@@ -1,3 +1,5 @@
+import { isValidTaskTagLabel, TASK_TAGS_MAX_LENGTH } from './task-limits';
+
 export function sanitizeTags(tags: string[] | undefined): string[] {
   if (!tags || tags.length === 0) {
     return [];
@@ -22,4 +24,13 @@ export function sanitizeTags(tags: string[] | undefined): string[] {
   }
 
   return normalized.sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }));
+}
+
+export function sanitizeValidTaskTags(tags: string[] | undefined): string[] {
+  return sanitizeTags(tags)
+    .filter(isValidTaskTagLabel);
+}
+
+export function sanitizeTaskInputTags(tags: string[] | undefined): string[] {
+  return sanitizeValidTaskTags(tags).slice(0, TASK_TAGS_MAX_LENGTH);
 }

--- a/apps/web/lib/tasks-client.test.ts
+++ b/apps/web/lib/tasks-client.test.ts
@@ -387,7 +387,40 @@ describe('tasks-client', () => {
   });
 
   describe('moveTaskOnBoard', () => {
-    it('rejects oversized target indexes before sending a request', async () => {
+    it('serializes large target indexes so the API can validate lane length', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        jsonResponse({
+          columns: [],
+          summary: {
+            totalsByStatus: { TODO: 0, IN_PROGRESS: 0, DONE: 0 },
+            overdueByStatus: { TODO: 0, IN_PROGRESS: 0, DONE: 0 },
+            totalTasks: 0,
+            totalOverdue: 0,
+          },
+          updatedAt: '2026-06-01T00:00:00.000Z',
+          generatedAt: '2026-06-01T00:00:00.000Z',
+        }),
+      );
+
+      await moveTaskOnBoard(
+        {
+          taskId: sampleTask.id,
+          targetStatus: 'DONE',
+          targetIndex: 1_001,
+        },
+        { baseUrl: API_BASE_URL, fetchImpl: fetchMock },
+      );
+
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe(`${API_BASE_URL}/v1/tasks/board/move`);
+      expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+        taskId: sampleTask.id,
+        targetStatus: 'DONE',
+        targetIndex: 1_001,
+      });
+    });
+
+    it('rejects negative target indexes before sending a request', async () => {
       const fetchMock = vi.fn();
 
       await expect(
@@ -395,7 +428,7 @@ describe('tasks-client', () => {
           {
             taskId: sampleTask.id,
             targetStatus: 'DONE',
-            targetIndex: 1_001,
+            targetIndex: -1,
           },
           { baseUrl: API_BASE_URL, fetchImpl: fetchMock },
         ),

--- a/apps/web/lib/tasks-client.test.ts
+++ b/apps/web/lib/tasks-client.test.ts
@@ -9,6 +9,7 @@ import {
   getTaskBoard,
   listTags,
   listTasks,
+  moveTaskOnBoard,
   setBrowserTaskClientAuthState,
   TaskClientError,
   updateTask,
@@ -103,14 +104,42 @@ describe('tasks-client', () => {
     });
 
     it('throws a validation error when filters are invalid', async () => {
+      const fetchMock = vi.fn();
+
       await expect(
         listTasks(
           {
             page: 0,
           },
-          { baseUrl: API_BASE_URL, fetchImpl: vi.fn() },
+          { baseUrl: API_BASE_URL, fetchImpl: fetchMock },
         ),
       ).rejects.toMatchObject({ kind: 'validation' satisfies TaskClientError['kind'] });
+      await expect(
+        listTasks(
+          {
+            q: 'x'.repeat(201),
+          },
+          { baseUrl: API_BASE_URL, fetchImpl: fetchMock },
+        ),
+      ).rejects.toMatchObject({ kind: 'validation' satisfies TaskClientError['kind'] });
+      await expect(
+        listTasks(
+          {
+            tag: 'x'.repeat(65),
+          },
+          { baseUrl: API_BASE_URL, fetchImpl: fetchMock },
+        ),
+      ).rejects.toMatchObject({ kind: 'validation' satisfies TaskClientError['kind'] });
+      await expect(
+        listTasks(
+          {
+            tag: Array.from({ length: 11 }, (_, index) => `tag-${index}`),
+          },
+          { baseUrl: API_BASE_URL, fetchImpl: fetchMock },
+        ),
+      ).rejects.toMatchObject({ kind: 'validation' satisfies TaskClientError['kind'] });
+
+      expect(fetchMock).not.toHaveBeenCalled();
     });
 
     it('attaches the dev bypass token header on the browser when present', async () => {
@@ -130,14 +159,53 @@ describe('tasks-client', () => {
 
   describe('createTask', () => {
     it('performs client-side validation before sending the request', async () => {
+      const fetchMock = vi.fn();
+
       await expect(
         createTask(
           {
             title: '   ',
           },
-          { baseUrl: API_BASE_URL, fetchImpl: vi.fn() },
+          { baseUrl: API_BASE_URL, fetchImpl: fetchMock },
         ),
       ).rejects.toMatchObject({ kind: 'validation' satisfies TaskClientError['kind'] });
+      await expect(
+        createTask(
+          {
+            title: 'x'.repeat(161),
+          },
+          { baseUrl: API_BASE_URL, fetchImpl: fetchMock },
+        ),
+      ).rejects.toMatchObject({ kind: 'validation' satisfies TaskClientError['kind'] });
+      await expect(
+        createTask(
+          {
+            title: 'Valid title',
+            description: 'x'.repeat(5_001),
+          },
+          { baseUrl: API_BASE_URL, fetchImpl: fetchMock },
+        ),
+      ).rejects.toMatchObject({ kind: 'validation' satisfies TaskClientError['kind'] });
+      await expect(
+        createTask(
+          {
+            title: 'Valid title',
+            tags: ['x'.repeat(65)],
+          },
+          { baseUrl: API_BASE_URL, fetchImpl: fetchMock },
+        ),
+      ).rejects.toMatchObject({ kind: 'validation' satisfies TaskClientError['kind'] });
+      await expect(
+        createTask(
+          {
+            title: 'Valid title',
+            tags: Array.from({ length: 11 }, (_, index) => `tag-${index}`),
+          },
+          { baseUrl: API_BASE_URL, fetchImpl: fetchMock },
+        ),
+      ).rejects.toMatchObject({ kind: 'validation' satisfies TaskClientError['kind'] });
+
+      expect(fetchMock).not.toHaveBeenCalled();
     });
 
     it('sends the session cookie when running on the server', async () => {
@@ -286,6 +354,52 @@ describe('tasks-client', () => {
       ).rejects.toMatchObject({
         kind: 'validation' satisfies TaskClientError['kind'],
       });
+
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects oversized board filters before sending a request', async () => {
+      const fetchMock = vi.fn();
+
+      await expect(
+        getTaskBoard(
+          {
+            q: 'x'.repeat(201),
+          },
+          { baseUrl: API_BASE_URL, fetchImpl: fetchMock },
+        ),
+      ).rejects.toMatchObject({
+        kind: 'validation' satisfies TaskClientError['kind'],
+      });
+      await expect(
+        getTaskBoard(
+          {
+            tag: 'x'.repeat(65),
+          },
+          { baseUrl: API_BASE_URL, fetchImpl: fetchMock },
+        ),
+      ).rejects.toMatchObject({
+        kind: 'validation' satisfies TaskClientError['kind'],
+      });
+
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('moveTaskOnBoard', () => {
+    it('rejects oversized target indexes before sending a request', async () => {
+      const fetchMock = vi.fn();
+
+      await expect(
+        moveTaskOnBoard(
+          {
+            taskId: sampleTask.id,
+            targetStatus: 'DONE',
+            targetIndex: 1_001,
+          },
+          { baseUrl: API_BASE_URL, fetchImpl: fetchMock },
+        ),
+      ).rejects.toMatchObject({ kind: 'validation' satisfies TaskClientError['kind'] });
 
       expect(fetchMock).not.toHaveBeenCalled();
     });

--- a/apps/web/lib/tasks-client.ts
+++ b/apps/web/lib/tasks-client.ts
@@ -15,7 +15,6 @@ import type { AsyncLocalStorage } from 'async_hooks';
 import { getApiBaseUrl } from './env';
 import {
   isValidTaskTagLabel,
-  TASK_BOARD_TARGET_INDEX_MAX,
   TASK_DESCRIPTION_MAX_LENGTH,
   TASK_QUERY_MAX_LENGTH,
   TASK_TAG_LABEL_MAX_LENGTH,
@@ -147,7 +146,7 @@ const BoardResponseSchema = z.object({
 const BoardMoveSchema = z.object({
   taskId: z.string().uuid(),
   targetStatus: TaskStatusSchema,
-  targetIndex: z.number().int().min(0).max(TASK_BOARD_TARGET_INDEX_MAX),
+  targetIndex: z.number().int().min(0),
 });
 
 const TaskListResponseSchema = z.object({

--- a/apps/web/lib/tasks-client.ts
+++ b/apps/web/lib/tasks-client.ts
@@ -13,6 +13,15 @@ import { z } from 'zod';
 import type { AsyncLocalStorage } from 'async_hooks';
 
 import { getApiBaseUrl } from './env';
+import {
+  isValidTaskTagLabel,
+  TASK_BOARD_TARGET_INDEX_MAX,
+  TASK_DESCRIPTION_MAX_LENGTH,
+  TASK_QUERY_MAX_LENGTH,
+  TASK_TAG_LABEL_MAX_LENGTH,
+  TASK_TAGS_MAX_LENGTH,
+  TASK_TITLE_MAX_LENGTH,
+} from './task-limits';
 
 const SESSION_COOKIE_NAME = getSessionCookieName();
 
@@ -30,6 +39,12 @@ const TaskPrioritySchema = z.union([z.literal('LOW'), z.literal('MEDIUM'), z.lit
 const QueryDateTimeSchema = z.string().datetime({ offset: true });
 
 const NonEmptyTrimmedString = z.string().trim().min(1);
+const TaskTitleString = NonEmptyTrimmedString.max(TASK_TITLE_MAX_LENGTH);
+const TaskDescriptionString = NonEmptyTrimmedString.max(TASK_DESCRIPTION_MAX_LENGTH);
+const TaskTagString = NonEmptyTrimmedString.refine(isValidTaskTagLabel, {
+  message: `Tag label must be ${TASK_TAG_LABEL_MAX_LENGTH} characters or fewer after normalization.`,
+});
+const TaskQueryString = NonEmptyTrimmedString.max(TASK_QUERY_MAX_LENGTH);
 
 const NullableDateString = z
   .string()
@@ -132,7 +147,7 @@ const BoardResponseSchema = z.object({
 const BoardMoveSchema = z.object({
   taskId: z.string().uuid(),
   targetStatus: TaskStatusSchema,
-  targetIndex: z.number().int().min(0),
+  targetIndex: z.number().int().min(0).max(TASK_BOARD_TARGET_INDEX_MAX),
 });
 
 const TaskListResponseSchema = z.object({
@@ -160,12 +175,12 @@ const TaskIdSchema = z.string().uuid({ message: 'Task id must be a valid UUID.' 
 
 const TaskCreateSchema = z
   .object({
-    title: NonEmptyTrimmedString,
-    description: NullableString,
+    title: TaskTitleString,
+    description: TaskDescriptionString.optional().nullable().transform((value) => value ?? undefined),
     status: TaskStatusSchema.optional(),
     priority: TaskPrioritySchema.optional(),
     dueDate: NullableDateString,
-    tags: z.array(NonEmptyTrimmedString).optional(),
+    tags: z.array(TaskTagString).max(TASK_TAGS_MAX_LENGTH).optional(),
   })
   .transform((value) => ({
     ...value,
@@ -174,12 +189,12 @@ const TaskCreateSchema = z
 
 const TaskUpdateSchema = z
   .object({
-    title: NonEmptyTrimmedString.optional(),
-    description: z.union([NonEmptyTrimmedString, z.null()]).optional(),
+    title: TaskTitleString.optional(),
+    description: z.union([TaskDescriptionString, z.null()]).optional(),
     status: TaskStatusSchema.optional(),
     priority: TaskPrioritySchema.optional(),
     dueDate: z.union([z.string().datetime(), z.null()]).optional(),
-    tags: z.array(NonEmptyTrimmedString).optional(),
+    tags: z.array(TaskTagString).max(TASK_TAGS_MAX_LENGTH).optional(),
   })
   .superRefine((value, ctx) => {
     if (Object.values(value).every((entry) => entry === undefined)) {
@@ -202,7 +217,7 @@ const TaskListQuerySchema = z
     status: TaskStatusSchema.optional(),
     priority: TaskPrioritySchema.optional(),
     tag: z
-      .union([NonEmptyTrimmedString, z.array(NonEmptyTrimmedString)])
+      .union([TaskTagString, z.array(TaskTagString).max(TASK_TAGS_MAX_LENGTH)])
       .optional()
       .transform((value) => {
         if (!value) {
@@ -210,7 +225,7 @@ const TaskListQuerySchema = z
         }
         return Array.isArray(value) ? value : [value];
       }),
-    q: z.string().trim().min(1).optional().transform((value) => value?.trim()),
+    q: TaskQueryString.optional().transform((value) => value?.trim()),
     dueFrom: QueryDateTimeSchema.optional(),
     dueTo: QueryDateTimeSchema.optional(),
   })
@@ -233,7 +248,7 @@ const BoardQuerySchema = z
     status: TaskStatusSchema.optional(),
     priority: TaskPrioritySchema.optional(),
     tag: z
-      .union([NonEmptyTrimmedString, z.array(NonEmptyTrimmedString)])
+      .union([TaskTagString, z.array(TaskTagString).max(TASK_TAGS_MAX_LENGTH)])
       .optional()
       .transform((value) => {
         if (!value) {
@@ -241,7 +256,7 @@ const BoardQuerySchema = z
         }
         return Array.isArray(value) ? value : [value];
       }),
-    q: z.string().trim().min(1).optional().transform((value) => value?.trim()),
+    q: TaskQueryString.optional().transform((value) => value?.trim()),
     dueFrom: QueryDateTimeSchema.optional(),
     dueTo: QueryDateTimeSchema.optional(),
   })

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -765,7 +765,7 @@
           "targetIndex": {
             "type": "integer",
             "minimum": 0,
-            "maximum": 1000
+            "description": "Zero-based destination index in the target lane. The repository validates this against the lane length."
           }
         },
         "required": [

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2544,7 +2544,7 @@
           "Jobs"
         ],
         "summary": "Run the protected daily digest job",
-        "description": "Protected scheduler endpoint. Requires `DIGEST_JOB_SECRET` via `Authorization: Bearer <secret>` or `x-job-secret`; invalid secrets return `401` before the job rate limiter is evaluated.",
+        "description": "Protected scheduler endpoint. Requires `DIGEST_JOB_SECRET` via `Authorization: Bearer <secret>` or `x-job-secret`; missing or incorrect secrets are throttled separately from valid scheduler invocations.",
         "security": [
           {
             "jobSecretBearer": []
@@ -2694,7 +2694,7 @@
           "Jobs"
         ],
         "summary": "Run the protected daily digest job",
-        "description": "Protected scheduler endpoint. Requires `DIGEST_JOB_SECRET` via `Authorization: Bearer <secret>` or `x-job-secret`; invalid secrets return `401` before the job rate limiter is evaluated.",
+        "description": "Protected scheduler endpoint. Requires `DIGEST_JOB_SECRET` via `Authorization: Bearer <secret>` or `x-job-secret`; missing or incorrect secrets are throttled separately from valid scheduler invocations.",
         "security": [
           {
             "jobSecretBearer": []

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -17,6 +17,24 @@
         "in": "cookie",
         "name": "tf_session",
         "description": "HttpOnly session cookie issued by the auth routes. The cookie carries the same JWT used for bearer authentication."
+      },
+      "sessionBridgeSecret": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-session-bridge-secret",
+        "description": "Shared server-side secret used by the web app to exchange a NextAuth session for API JWTs."
+      },
+      "jobSecretHeader": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-job-secret",
+        "description": "Shared secret required by protected background job routes."
+      },
+      "jobSecretBearer": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "shared-secret",
+        "description": "Alternative protected job authentication using `Authorization: Bearer <DIGEST_JOB_SECRET>`."
       }
     },
     "schemas": {
@@ -39,6 +57,43 @@
         "example": {
           "email": "user@example.com",
           "password": "StrongPassword123"
+        }
+      },
+      "AuthRefreshRequest": {
+        "type": "object",
+        "properties": {
+          "refreshToken": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "refreshToken"
+        ],
+        "additionalProperties": false,
+        "example": {
+          "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.refresh-token"
+        }
+      },
+      "SessionBridgeRequest": {
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "email": {
+            "type": "string",
+            "format": "email"
+          }
+        },
+        "required": [
+          "userId"
+        ],
+        "additionalProperties": false,
+        "example": {
+          "userId": "26f26639-05ad-40b6-8248-379644dcdf18",
+          "email": "user@example.com"
         }
       },
       "AuthTokens": {
@@ -709,7 +764,8 @@
           },
           "targetIndex": {
             "type": "integer",
-            "minimum": 0
+            "minimum": 0,
+            "maximum": 1000
           }
         },
         "required": [
@@ -717,6 +773,7 @@
           "targetStatus",
           "targetIndex"
         ],
+        "additionalProperties": false,
         "example": {
           "taskId": "9e22c508-1383-4609-9bbd-2e09b7a2d108",
           "targetStatus": "DONE",
@@ -728,11 +785,13 @@
         "properties": {
           "title": {
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "maxLength": 160
           },
           "description": {
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "maxLength": 5000
           },
           "status": {
             "type": "string",
@@ -756,6 +815,7 @@
           },
           "tags": {
             "type": "array",
+            "maxItems": 10,
             "items": {
               "type": "string",
               "minLength": 1,
@@ -767,6 +827,7 @@
         "required": [
           "title"
         ],
+        "additionalProperties": false,
         "example": {
           "title": "Book product sync",
           "description": "Coordinate roadmap review with stakeholders",
@@ -783,11 +844,13 @@
         "properties": {
           "title": {
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "maxLength": 160
           },
           "description": {
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "maxLength": 5000
           },
           "status": {
             "type": "string",
@@ -811,6 +874,7 @@
           },
           "tags": {
             "type": "array",
+            "maxItems": 10,
             "items": {
               "type": "string",
               "minLength": 1,
@@ -1215,6 +1279,53 @@
           "dryRun": true
         }
       },
+      "DailyDigestJobRunRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "digestDate": {
+            "type": "string",
+            "format": "date",
+            "description": "Optional local digest calendar date. When omitted, the job derives local dates per user."
+          },
+          "digestHourUtc": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 23,
+            "description": "Optional UTC hour filter. Users configured for a different hour are skipped."
+          },
+          "dryRun": {
+            "description": "When true, reports the digest run without sending email or recording delivery success.",
+            "oneOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "string",
+                "enum": [
+                  "true",
+                  "false",
+                  "1",
+                  "0"
+                ]
+              }
+            ],
+            "default": false
+          },
+          "sendLimit": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 500,
+            "description": "Optional per-run send cap. Defaults to the configured job send limit."
+          }
+        },
+        "example": {
+          "digestDate": "2026-05-21",
+          "digestHourUtc": 13,
+          "dryRun": true,
+          "sendLimit": 5
+        }
+      },
       "DailyDigestRunResponse": {
         "type": "object",
         "properties": {
@@ -1423,6 +1534,23 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Authentication rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "rateLimited": {
+                    "value": {
+                      "error": "Too many authentication attempts. Please try again later."
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -1516,6 +1644,293 @@
                   "invalidCredentials": {
                     "value": {
                       "error": "Invalid credentials"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Authentication rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "rateLimited": {
+                    "value": {
+                      "error": "Too many authentication attempts. Please try again later."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/taskforge/v1/auth/session-bridge": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Exchange a web session for API JWTs",
+        "description": "Server-to-server endpoint used by the web app after OAuth sign-in. Requires `x-session-bridge-secret` and returns the same auth token envelope as credential login.",
+        "security": [
+          {
+            "sessionBridgeSecret": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SessionBridgeRequest"
+              },
+              "examples": {
+                "default": {
+                  "value": {
+                    "userId": "26f26639-05ad-40b6-8248-379644dcdf18",
+                    "email": "user@example.com"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Session exchanged successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthSuccessResponse"
+                },
+                "examples": {
+                  "success": {
+                    "value": {
+                      "user": {
+                        "id": "26f26639-05ad-40b6-8248-379644dcdf18",
+                        "email": "user@example.com",
+                        "createdAt": "2024-06-01T12:00:00.000Z"
+                      },
+                      "tokens": {
+                        "tokenType": "Bearer",
+                        "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.access-token",
+                        "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.refresh-token",
+                        "accessTokenExpiresAt": "2024-06-01T13:00:00.000Z",
+                        "refreshTokenExpiresAt": "2024-06-08T12:00:00.000Z"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid payload",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "invalidPayload": {
+                    "value": {
+                      "error": "Invalid payload",
+                      "details": {
+                        "fieldErrors": {
+                          "email": [
+                            "Invalid email address"
+                          ]
+                        },
+                        "formErrors": []
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or incorrect session bridge secret",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unauthorized": {
+                    "value": {
+                      "error": "Unauthorized"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "User not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "notFound": {
+                    "value": {
+                      "error": "User not found"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "User email mismatch",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "conflict": {
+                    "value": {
+                      "error": "User email mismatch"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Authentication rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "rateLimited": {
+                    "value": {
+                      "error": "Too many authentication attempts. Please try again later."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/taskforge/v1/auth/refresh": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Refresh API JWTs",
+        "description": "Exchanges a valid refresh token for a new auth token pair.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AuthRefreshRequest"
+              },
+              "examples": {
+                "default": {
+                  "value": {
+                    "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.refresh-token"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Token pair refreshed successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthSuccessResponse"
+                },
+                "examples": {
+                  "success": {
+                    "value": {
+                      "user": {
+                        "id": "26f26639-05ad-40b6-8248-379644dcdf18",
+                        "email": "user@example.com",
+                        "createdAt": "2024-06-01T12:00:00.000Z"
+                      },
+                      "tokens": {
+                        "tokenType": "Bearer",
+                        "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.access-token",
+                        "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.refresh-token",
+                        "accessTokenExpiresAt": "2024-06-01T13:00:00.000Z",
+                        "refreshTokenExpiresAt": "2024-06-08T12:00:00.000Z"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid payload",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "invalidPayload": {
+                    "value": {
+                      "error": "Invalid payload",
+                      "details": {
+                        "fieldErrors": {
+                          "email": [
+                            "Invalid email address"
+                          ]
+                        },
+                        "formErrors": []
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid refresh token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "invalidRefreshToken": {
+                    "value": {
+                      "error": "Invalid refresh token"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Authentication rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "rateLimited": {
+                    "value": {
+                      "error": "Too many authentication attempts. Please try again later."
                     }
                   }
                 }
@@ -2123,6 +2538,283 @@
         }
       }
     },
+    "/api/taskforge/v1/jobs/digest": {
+      "get": {
+        "tags": [
+          "Jobs"
+        ],
+        "summary": "Run the protected daily digest job",
+        "description": "Protected scheduler endpoint. Requires `DIGEST_JOB_SECRET` via `Authorization: Bearer <secret>` or `x-job-secret`; invalid secrets return `401` before the job rate limiter is evaluated.",
+        "security": [
+          {
+            "jobSecretBearer": []
+          },
+          {
+            "jobSecretHeader": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "digestDate",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            },
+            "description": "Optional local digest calendar date."
+          },
+          {
+            "name": "digestHourUtc",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 23
+            },
+            "description": "Optional UTC hour filter."
+          },
+          {
+            "name": "dryRun",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "true",
+                "false",
+                "1",
+                "0"
+              ]
+            },
+            "description": "When true or 1, reports the run without sending email."
+          },
+          {
+            "name": "sendLimit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 500
+            },
+            "description": "Optional per-run send cap."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Digest job run completed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DailyDigestRunResponse"
+                },
+                "examples": {
+                  "default": {
+                    "value": {
+                      "digestDate": "2026-05-21",
+                      "digestDates": [
+                        "2026-05-21"
+                      ],
+                      "attempted": 1,
+                      "sent": 1,
+                      "skipped": 0,
+                      "failed": 0,
+                      "budgetSkipped": 0,
+                      "providerQuotaSkipped": 0,
+                      "duplicateSkipped": 0,
+                      "preferenceSkipped": 0,
+                      "noContentSkipped": 0
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid query parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "invalidPayload": {
+                    "value": {
+                      "error": "Invalid payload",
+                      "details": {
+                        "fieldErrors": {
+                          "email": [
+                            "Invalid email address"
+                          ]
+                        },
+                        "formErrors": []
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or incorrect job secret",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unauthorized": {
+                    "value": {
+                      "error": "Unauthorized"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "rateLimited": {
+                    "value": {
+                      "error": "Too many requests, please try again later."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Jobs"
+        ],
+        "summary": "Run the protected daily digest job",
+        "description": "Protected scheduler endpoint. Requires `DIGEST_JOB_SECRET` via `Authorization: Bearer <secret>` or `x-job-secret`; invalid secrets return `401` before the job rate limiter is evaluated.",
+        "security": [
+          {
+            "jobSecretBearer": []
+          },
+          {
+            "jobSecretHeader": []
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DailyDigestJobRunRequest"
+              },
+              "examples": {
+                "default": {
+                  "value": {
+                    "digestDate": "2026-05-21",
+                    "digestHourUtc": 13,
+                    "dryRun": true,
+                    "sendLimit": 5
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Digest job run completed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DailyDigestRunResponse"
+                },
+                "examples": {
+                  "default": {
+                    "value": {
+                      "digestDate": "2026-05-21",
+                      "digestDates": [
+                        "2026-05-21"
+                      ],
+                      "attempted": 1,
+                      "sent": 1,
+                      "skipped": 0,
+                      "failed": 0,
+                      "budgetSkipped": 0,
+                      "providerQuotaSkipped": 0,
+                      "duplicateSkipped": 0,
+                      "preferenceSkipped": 0,
+                      "noContentSkipped": 0
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid payload",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "invalidPayload": {
+                    "value": {
+                      "error": "Invalid payload",
+                      "details": {
+                        "fieldErrors": {
+                          "email": [
+                            "Invalid email address"
+                          ]
+                        },
+                        "formErrors": []
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or incorrect job secret",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unauthorized": {
+                    "value": {
+                      "error": "Unauthorized"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "rateLimited": {
+                    "value": {
+                      "error": "Too many requests, please try again later."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/taskforge/v1/tasks": {
       "get": {
         "tags": [
@@ -2193,8 +2885,11 @@
             "explode": true,
             "schema": {
               "type": "array",
+              "maxItems": 10,
               "items": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 64
               }
             },
             "description": "Filter tasks that include the specified tag(s). Repeat the parameter to require multiple tags."
@@ -2204,7 +2899,8 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "minLength": 1
+              "minLength": 1,
+              "maxLength": 200
             },
             "description": "Case-insensitive search over the title and description."
           },
@@ -2482,8 +3178,11 @@
             "explode": true,
             "schema": {
               "type": "array",
+              "maxItems": 10,
               "items": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 64
               }
             },
             "description": "Filter board tasks that include the specified tag(s). Repeat the parameter to require multiple tags."
@@ -2493,7 +3192,8 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "minLength": 1
+              "minLength": 1,
+              "maxLength": 200
             },
             "description": "Case-insensitive search over the title and description."
           },

--- a/docs/tasks/milestone6/03-rate-limit-and-abuse-controls.md
+++ b/docs/tasks/milestone6/03-rate-limit-and-abuse-controls.md
@@ -39,7 +39,7 @@
 
 ## Baseline Audit Follow-ups
 - [x] Set and test an explicit JSON body-size limit instead of relying on Express' default `express.json()` limit.
-- [x] Confirm task, tag, board, email preference, digest preview, and manual digest send schemas reject oversized payloads and unbounded query parameters, with explicit limits for task titles/descriptions, query text, tag array length, tag label length, `pageSize`, board `targetIndex`, digest preview windows, and unknown query/body fields.
+- [x] Confirm task, tag, board, email preference, digest preview, and manual digest send schemas reject oversized payloads and unbounded query parameters, with explicit limits for task titles/descriptions, query text, tag array length, tag label length, `pageSize`, digest preview windows, and unknown query/body fields. Board `targetIndex` remains a nonnegative integer at the schema layer and is bounded against the actual lane length in repository validation.
 - [x] Add focused tests for auth `429` behavior outside the `NODE_ENV=test` bypass or isolate limiter construction so deterministic tests can cover the production limiter settings.
 - [x] Add negative tests for missing/wrong `DIGEST_JOB_SECRET` through both `Authorization: Bearer` and `x-job-secret`, ensuring error bodies and logs never echo supplied secret values.
 - [x] Exercise rate limits with `TRUST_PROXY` disabled and enabled so untrusted clients cannot spoof `X-Forwarded-For` into separate buckets.

--- a/docs/tasks/milestone6/03-rate-limit-and-abuse-controls.md
+++ b/docs/tasks/milestone6/03-rate-limit-and-abuse-controls.md
@@ -21,7 +21,7 @@
 
 ## Verification
 - API abuse-control coverage verifies auth `429` behavior, separate session bridge limiting, JSON body limits, trusted-proxy `req.ip` behavior, task/tag bounds, email preference unknown-field rejection, and production dev-bypass denial.
-- Job route coverage verifies missing and incorrect `DIGEST_JOB_SECRET` through both `Authorization: Bearer` and `x-job-secret`, no secret echoing/logging, valid-job `429` behavior, strict payload/query validation, and auth-before-limiter ordering.
+- Job route coverage verifies missing and incorrect `DIGEST_JOB_SECRET` through both `Authorization: Bearer` and `x-job-secret`, no secret echoing/logging, invalid-attempt throttling that does not spend the valid scheduler bucket, valid-job `429` behavior, and strict payload/query validation.
 - Web client and component coverage verifies task title/description/tag/search/board-index bounds before requests are sent.
 - OpenAPI was regenerated from source so `docs/openapi.json` documents auth/session/job rate-limit and protected-secret behavior.
 - Completed checks:

--- a/docs/tasks/milestone6/03-rate-limit-and-abuse-controls.md
+++ b/docs/tasks/milestone6/03-rate-limit-and-abuse-controls.md
@@ -4,15 +4,15 @@
 - Review endpoint-specific abuse controls before public deployment.
 - Make limits observable enough that legitimate users are not blocked silently.
 
-**Status:** Planned.
+**Status:** Complete.
 
 ## Acceptance Criteria
-- [ ] Auth register/login/session endpoints have reasonable rate limits and consistent `429` responses.
-- [ ] Task and tag mutation endpoints cannot be abused with oversized payloads or unbounded parameters.
-- [ ] Email preference, digest preview, manual digest send, and protected job endpoints retain stricter controls where needed.
-- [ ] Protected job endpoints reject missing or incorrect secrets and do not reveal secrets in logs or error bodies.
-- [ ] Rate limit behavior is tested with trusted proxy settings so `req.ip` cannot be spoofed by untrusted clients.
-- [ ] README or production docs include the operational implication of rate limits for early deployment.
+- [x] Auth register/login/session endpoints have reasonable rate limits and consistent `429` responses.
+- [x] Task and tag mutation endpoints cannot be abused with oversized payloads or unbounded parameters.
+- [x] Email preference, digest preview, manual digest send, and protected job endpoints retain stricter controls where needed.
+- [x] Protected job endpoints reject missing or incorrect secrets and do not reveal secrets in logs or error bodies.
+- [x] Rate limit behavior is tested with trusted proxy settings so `req.ip` cannot be spoofed by untrusted clients.
+- [x] README or production docs include the operational implication of rate limits for early deployment.
 
 ## Notes
 - Avoid relying on rate limits as the only protection for job routes; shared secrets are still required.
@@ -20,14 +20,28 @@
 - Confirm any dev bypass cannot be enabled in production.
 
 ## Verification
-- Add or update API tests for `429` behavior where coverage is missing.
-- Use `docs/testing/milestone6-manual-checklist.md` for a browser/API smoke of important blocked paths.
+- API abuse-control coverage verifies auth `429` behavior, separate session bridge limiting, JSON body limits, trusted-proxy `req.ip` behavior, task/tag bounds, email preference unknown-field rejection, and production dev-bypass denial.
+- Job route coverage verifies missing and incorrect `DIGEST_JOB_SECRET` through both `Authorization: Bearer` and `x-job-secret`, no secret echoing/logging, valid-job `429` behavior, strict payload/query validation, and auth-before-limiter ordering.
+- Web client and component coverage verifies task title/description/tag/search/board-index bounds before requests are sent.
+- OpenAPI was regenerated from source so `docs/openapi.json` documents auth/session/job rate-limit and protected-secret behavior.
+- Completed checks:
+  - `pnpm -C apps/api lint`
+  - `pnpm -C apps/web lint`
+  - `pnpm -C apps/api typecheck`
+  - `pnpm -C apps/web typecheck`
+  - `pnpm -C apps/api test`
+  - `pnpm -C apps/web test`
+  - `pnpm -C apps/api build`
+  - `pnpm -C apps/web build`
+  - `pnpm -C apps/api gen:openapi`
+  - `git diff --check`
+- `docs/testing/milestone6-manual-checklist.md` remains the browser/API smoke checklist for deployment validation.
 
 ## Baseline Audit Follow-ups
-- Set and test an explicit JSON body-size limit instead of relying on Express' default `express.json()` limit.
-- Confirm task, tag, board, email preference, digest preview, and manual digest send schemas reject oversized payloads and unbounded query parameters, with explicit limits for task titles/descriptions, query text, tag array length, tag label length, `pageSize`, board `targetIndex`, digest preview windows, and unknown query/body fields.
-- Add focused tests for auth `429` behavior outside the `NODE_ENV=test` bypass or isolate limiter construction so deterministic tests can cover the production limiter settings.
-- Add negative tests for missing/wrong `DIGEST_JOB_SECRET` through both `Authorization: Bearer` and `x-job-secret`, ensuring error bodies and logs never echo supplied secret values.
-- Exercise rate limits with `TRUST_PROXY` disabled and enabled so untrusted clients cannot spoof `X-Forwarded-For` into separate buckets.
-- Decide whether v1 production is constrained to one API instance or add a shared `express-rate-limit` store; document the decision so limits do not silently reset per instance after horizontal scaling.
-- Confirm dev bypass remains impossible in production by testing `TF_DEV_BYPASS_AUTH=true` with `NODE_ENV=production` on both API middleware and web current-user resolution.
+- [x] Set and test an explicit JSON body-size limit instead of relying on Express' default `express.json()` limit.
+- [x] Confirm task, tag, board, email preference, digest preview, and manual digest send schemas reject oversized payloads and unbounded query parameters, with explicit limits for task titles/descriptions, query text, tag array length, tag label length, `pageSize`, board `targetIndex`, digest preview windows, and unknown query/body fields.
+- [x] Add focused tests for auth `429` behavior outside the `NODE_ENV=test` bypass or isolate limiter construction so deterministic tests can cover the production limiter settings.
+- [x] Add negative tests for missing/wrong `DIGEST_JOB_SECRET` through both `Authorization: Bearer` and `x-job-secret`, ensuring error bodies and logs never echo supplied secret values.
+- [x] Exercise rate limits with `TRUST_PROXY` disabled and enabled so untrusted clients cannot spoof `X-Forwarded-For` into separate buckets.
+- [x] Decide whether v1 production is constrained to one API instance or add a shared `express-rate-limit` store; document the decision so limits do not silently reset per instance after horizontal scaling.
+- [x] Confirm dev bypass remains impossible in production by testing `TF_DEV_BYPASS_AUTH=true` with `NODE_ENV=production` on both API middleware and web current-user resolution.

--- a/docs/testing/milestone6-manual-checklist.md
+++ b/docs/testing/milestone6-manual-checklist.md
@@ -37,6 +37,7 @@ Use this checklist after the automated checks in `docs/testing/milestone6-automa
 ## Rate Limits And Job Secrets
 
 - [ ] Auth endpoints return bounded `429` behavior under the documented safe smoke.
+- [ ] Oversized JSON bodies and overlong task/tag/filter payloads return explicit JSON errors rather than hanging or silently truncating data.
 - [ ] Manual digest send rate limiting still protects the authenticated user path.
 - [ ] Rate-limit documentation matches the API deployment topology: single in-process limiter state or a shared store before horizontal scaling.
 - [ ] Protected digest job endpoint rejects missing and incorrect `DIGEST_JOB_SECRET`.

--- a/infra/env/api.env.example
+++ b/infra/env/api.env.example
@@ -1,6 +1,7 @@
 DATABASE_URL=postgresql://postgres:postgres@db:5432/taskforge?schema=public
 PORT=4000
 CORS_ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
+API_JSON_BODY_LIMIT=64kb
 JWT_SECRET=dev-secret
 SESSION_BRIDGE_SECRET=dev-bridge-secret
 # Development only. Set to true locally only when bypassing normal auth setup.

--- a/infra/env/api.prod.env.example
+++ b/infra/env/api.prod.env.example
@@ -1,6 +1,7 @@
 PORT=4000
 # Exact deployed web origins only; no paths, queries, fragments, or trailing path segments.
 CORS_ALLOWED_ORIGINS=https://<APP_DOMAIN>
+API_JSON_BODY_LIMIT=64kb
 DATABASE_URL=<MANAGED_POSTGRES_URL>
 JWT_SECRET=<ROTATED_API_JWT_SECRET>
 JWT_REFRESH_SECRET=<ROTATED_API_REFRESH_SECRET>


### PR DESCRIPTION
### Motivation
- Protect public-facing endpoints from abuse by making rate limits explicit, observable, and testable before enabling production digests. 
- Prevent oversized or unbounded task/tag/board/digest payloads from being abused by adding explicit JSON/body and schema bounds. 
- Ensure protected job endpoints require shared secrets and do not echo secrets in responses or logs. 
- Make the dev-bypass escape hatch impossible to enable in production and deterministic in tests. 

### Description
- Add an explicit JSON body-size config and parser (`API_JSON_BODY_LIMIT`, default `64kb`) and wire it into `express.json()` via `getHttpServerConfig` and `parseJsonBodyLimit`. 
- Factor and export an auth-rate-limiter constructor (`createAuthAttemptLimiter`) and plumb configurable `authRateLimit` through `createApp` to allow deterministic test limits and consistent JSON `429` envelopes. 
- Harden route-level and schema validation: strict Zod validation and explicit caps for task title/description lengths, tag count/length, query `q` length, `pageSize`, `targetIndex` max, digest preview/send params, and job `sendLimit`, and add `additionalProperties: false` where appropriate. 
- Add/adjust `express-rate-limit` usage for global, auth, email-digest (preview and manual), manual per-user send, and protected jobs (5/min) with JSON `429` responses and standard rate-limit headers. 
- Improve job route auth handling so missing/incorrect `DIGEST_JOB_SECRET` returns `401` without echoing submitted secrets and add request validation to reject unknown fields. 
- Update OpenAPI, env examples, README, and milestone docs to document `API_JSON_BODY_LIMIT`, the rate-limit behavior, `TRUST_PROXY` implications, and the single-instance vs shared-store deployment decision. 
- Add and update automated tests and helpers covering auth `429` behavior, JSON body limits, trusted-proxy spoofing, bounded task/tag/board inputs, email-digest validation and rate limits, job-secret negative cases, and dev-bypass production gating. 

### Testing
- Typechecking passed with `pnpm -C apps/api typecheck` and `pnpm -C apps/web typecheck`. 
- Linting passed for the API with `pnpm -C apps/api lint`. 
- Web unit tests passed: `pnpm -C apps/web test -- app/api/auth/me/route.test.ts lib/dev-auth-bypass.test.ts` succeeded. 
- API tests were exercised with `pnpm -C apps/api test -- abuse-controls.test.ts jobs-route.test.ts email-digest-route.test.ts http-config.test.ts tags.e2e.test.ts tasks.e2e.test.ts email-preferences-route.test.ts`, but the full Jest run could not complete in this environment because Testcontainers could not find a working container runtime strategy; local/CI runs with Docker available should be used to validate the Jest suites end-to-end.
