### PR TITLE
Add security HTTP smoke checks and milestone6 manual checklist updates

### DIFF
--- a/apps/api/tests/security.http
+++ b/apps/api/tests/security.http
@@ -1,0 +1,222 @@
+@apiBaseUrl = http://localhost:4000/api/taskforge/v1
+@webBaseUrl = http://localhost:3000
+@accessToken = replace-with-access-token
+@wrongAccessToken = replace-with-invalid-access-token
+@taskId = replace-with-task-id
+@digestDate = 2026-05-26
+@wrongDigestJobSecret = replace-with-wrong-digest-job-secret
+@wrongCronSecret = replace-with-wrong-cron-secret
+@allowedOrigin = http://localhost:3000
+@unlistedOrigin = http://127.0.0.1:3999
+
+### Security smoke pack overview
+# Safe by default: this file uses placeholders only and never includes real production secrets or recipients.
+# Start the local stack with `make up`, run auth.http register/login, then paste the returned access token above.
+# Expected unauthorized responses are usually 401 JSON envelopes unless noted. Stop after confirming the expected status.
+# Browser-only checks for CORS preflight enforcement, credentialed cookies, session bridge redirects, logout cookie expiry,
+# and bounded rate-limit smoke steps live in docs/testing/milestone6-manual-checklist.md.
+
+### Auth - current user without credentials is rejected
+GET {{apiBaseUrl}}/auth/me
+
+> {%
+client.test('auth/me rejects unauthenticated requests', () => {
+  client.assert(response.status === 401, 'expected 401 Unauthorized');
+});
+%}
+
+### Auth - current user with an incorrect bearer token is rejected
+GET {{apiBaseUrl}}/auth/me
+Authorization: Bearer {{wrongAccessToken}}
+
+> {%
+client.test('auth/me rejects incorrect bearer tokens', () => {
+  client.assert(response.status === 401, 'expected 401 Unauthorized');
+});
+%}
+
+### Tasks - list without credentials is rejected
+GET {{apiBaseUrl}}/tasks
+
+> {%
+client.test('tasks list rejects unauthenticated requests', () => {
+  client.assert(response.status === 401, 'expected 401 Unauthorized');
+});
+%}
+
+### Tasks - create without credentials is rejected
+POST {{apiBaseUrl}}/tasks
+Content-Type: application/json
+
+{
+  "title": "Unauthorized task smoke"
+}
+
+> {%
+client.test('task create rejects unauthenticated requests', () => {
+  client.assert(response.status === 401, 'expected 401 Unauthorized');
+});
+%}
+
+### Board - read model without credentials is rejected
+GET {{apiBaseUrl}}/tasks/board
+
+> {%
+client.test('board read model rejects unauthenticated requests', () => {
+  client.assert(response.status === 401, 'expected 401 Unauthorized');
+});
+%}
+
+### Board - move without credentials is rejected
+PATCH {{apiBaseUrl}}/tasks/board/move
+Content-Type: application/json
+
+{
+  "taskId": "{{taskId}}",
+  "targetStatus": "DONE",
+  "targetIndex": 0
+}
+
+> {%
+client.test('board move rejects unauthenticated requests', () => {
+  client.assert(response.status === 401, 'expected 401 Unauthorized');
+});
+%}
+
+### Tags - list without credentials is rejected
+GET {{apiBaseUrl}}/tags
+
+> {%
+client.test('tags list rejects unauthenticated requests', () => {
+  client.assert(response.status === 401, 'expected 401 Unauthorized');
+});
+%}
+
+### Tags - create without credentials is rejected
+POST {{apiBaseUrl}}/tags
+Content-Type: application/json
+
+{
+  "label": "unauthorized tag smoke"
+}
+
+> {%
+client.test('tag create rejects unauthenticated requests', () => {
+  client.assert(response.status === 401, 'expected 401 Unauthorized');
+});
+%}
+
+### Email - me snapshot without credentials is rejected
+GET {{apiBaseUrl}}/me
+
+> {%
+client.test('me rejects unauthenticated requests', () => {
+  client.assert(response.status === 401, 'expected 401 Unauthorized');
+});
+%}
+
+### Email - digest preview without credentials is rejected
+GET {{apiBaseUrl}}/email/digest/preview
+
+> {%
+client.test('digest preview rejects unauthenticated requests', () => {
+  client.assert(response.status === 401, 'expected 401 Unauthorized');
+});
+%}
+
+### Email - manual digest send without credentials is rejected
+POST {{apiBaseUrl}}/email/digest/send
+Content-Type: application/json
+
+{
+  "digestDate": "{{digestDate}}",
+  "dryRun": true
+}
+
+> {%
+client.test('manual digest send rejects unauthenticated requests', () => {
+  client.assert(response.status === 401, 'expected 401 Unauthorized');
+});
+%}
+
+### Job - digest GET without DIGEST_JOB_SECRET is rejected
+GET {{apiBaseUrl}}/jobs/digest?dryRun=true&sendLimit=0
+
+> {%
+client.test('digest job GET rejects missing job secret', () => {
+  client.assert(response.status === 401, 'expected 401 Unauthorized');
+});
+%}
+
+### Job - digest POST without DIGEST_JOB_SECRET is rejected
+POST {{apiBaseUrl}}/jobs/digest
+Content-Type: application/json
+
+{
+  "dryRun": true,
+  "sendLimit": 0
+}
+
+> {%
+client.test('digest job POST rejects missing job secret', () => {
+  client.assert(response.status === 401, 'expected 401 Unauthorized');
+});
+%}
+
+### Job - digest GET with incorrect Authorization bearer secret is rejected
+GET {{apiBaseUrl}}/jobs/digest?dryRun=true&sendLimit=0
+Authorization: Bearer {{wrongDigestJobSecret}}
+
+> {%
+client.test('digest job GET rejects incorrect bearer job secret', () => {
+  client.assert(response.status === 401, 'expected 401 Unauthorized');
+});
+%}
+
+### Job - digest POST with incorrect x-job-secret is rejected
+POST {{apiBaseUrl}}/jobs/digest
+Content-Type: application/json
+x-job-secret: {{wrongDigestJobSecret}}
+
+{
+  "dryRun": true,
+  "sendLimit": 0
+}
+
+> {%
+client.test('digest job POST rejects incorrect x-job-secret', () => {
+  client.assert(response.status === 401, 'expected 401 Unauthorized');
+});
+%}
+
+### Cron proxy - missing CRON_SECRET bearer is rejected by the web route
+# Requires apps/web running with CRON_SECRET configured. This does not call the API when the bearer token is missing.
+GET {{webBaseUrl}}/api/cron/digest?dryRun=true&sendLimit=0
+
+> {%
+client.test('web cron proxy rejects missing cron bearer', () => {
+  client.assert(response.status === 401, 'expected 401 Unauthorized');
+});
+%}
+
+### Cron proxy - incorrect CRON_SECRET bearer is rejected by the web route
+# Requires apps/web running with CRON_SECRET configured. Use a wrong placeholder only.
+GET {{webBaseUrl}}/api/cron/digest?dryRun=true&sendLimit=0
+Authorization: Bearer {{wrongCronSecret}}
+
+> {%
+client.test('web cron proxy rejects incorrect cron bearer', () => {
+  client.assert(response.status === 401, 'expected 401 Unauthorized');
+});
+%}
+
+### CORS observation only - allowed local origin health request
+# HTTP clients can show CORS headers, but they do not enforce browser preflight or credential rules.
+# Complete the browser/manual checklist before approving CORS or cookie behavior.
+GET {{apiBaseUrl}}/health
+Origin: {{allowedOrigin}}
+
+### CORS observation only - unlisted origin probe
+# In a browser this should be rejected by CORS policy. Treat this as a header observation only.
+GET {{apiBaseUrl}}/health
+Origin: {{unlistedOrigin}}

--- a/apps/api/tests/security.http
+++ b/apps/api/tests/security.http
@@ -115,6 +115,20 @@ client.test('me rejects unauthenticated requests', () => {
 });
 %}
 
+### Email - preference update without credentials is rejected
+PATCH {{apiBaseUrl}}/me/email-preferences
+Content-Type: application/json
+
+{
+  "dailyDigestEnabled": true
+}
+
+> {%
+client.test('email preference update rejects unauthenticated requests', () => {
+  client.assert(response.status === 401, 'expected 401 Unauthorized');
+});
+%}
+
 ### Email - digest preview without credentials is rejected
 GET {{apiBaseUrl}}/email/digest/preview
 

--- a/docs/tasks/milestone6/07-security-http-pack-and-smoke.md
+++ b/docs/tasks/milestone6/07-security-http-pack-and-smoke.md
@@ -4,15 +4,15 @@
 - Create repeatable checks for hardening behavior that reviewers can run locally or against a preview environment.
 - Cover security-sensitive negative paths without relying on real production secrets.
 
-**Status:** Planned.
+**Status:** Completed - security HTTP examples and manual smoke guidance are in place with placeholder-only inputs.
 
 ## Acceptance Criteria
-- [ ] HTTP examples or documented curl commands cover unauthorized auth/task/tag/board/email/job requests.
-- [ ] Job endpoint examples prove missing and incorrect `DIGEST_JOB_SECRET` are rejected.
-- [ ] Cron proxy examples prove missing and incorrect `CRON_SECRET` are rejected where the web route can be exercised.
-- [ ] CORS and cookie checks are documented for browser/manual verification, since `.http` clients do not fully model browser preflight behavior.
-- [ ] Rate-limit smoke guidance is safe, bounded, and does not encourage hammering shared environments.
-- [ ] Examples use variables and placeholders only; no real secrets or production recipients are committed.
+- [x] HTTP examples or documented curl commands cover unauthorized auth/task/tag/board/email/job requests.
+- [x] Job endpoint examples prove missing and incorrect `DIGEST_JOB_SECRET` are rejected.
+- [x] Cron proxy examples prove missing and incorrect `CRON_SECRET` are rejected where the web route can be exercised.
+- [x] CORS and cookie checks are documented for browser/manual verification, since `.http` clients do not fully model browser preflight behavior.
+- [x] Rate-limit smoke guidance is safe, bounded, and does not encourage hammering shared environments.
+- [x] Examples use variables and placeholders only; no real secrets or production recipients are committed.
 
 ## Notes
 - Prefer extending existing `.http` packs if the flow belongs with auth, tasks, Kanban, or email.
@@ -30,3 +30,11 @@
 - Include a bounded rate-limit smoke that stops after the expected `429` and warns against running it against shared production environments.
 - Include `/auth/session-bridge` checks for authenticated-user requirement, safe `from` redirect handling, API-cookie minting, and no-cache expectations if the local environment can run both apps.
 - Include logout same-origin checks and cookie-expiry verification for the web route if the local environment can run both apps.
+
+## Current Release-Candidate State
+- `apps/api/tests/security.http` now covers unauthorized auth, task, board, tag, email snapshot, email preference update, digest preview, manual digest send, and protected digest job negative paths.
+- Digest job examples include missing-secret checks plus incorrect `Authorization: Bearer <wrong>` and `x-job-secret: <wrong>` checks using placeholder variables only.
+- Web cron examples cover missing and incorrect `CRON_SECRET` bearer values against the web proxy route with placeholder variables only.
+- `docs/testing/milestone6-manual-checklist.md` now includes browser/manual CORS preflight, credentialed-cookie, unlisted-origin, session-bridge, logout, job/cron secret, and bounded rate-limit smoke guidance.
+- Rate-limit smoke guidance is sequential, bounded to ten attempts, stops after the first expected `429`, and warns against use on shared production environments.
+- Branch verification passed with `pnpm -C apps/api run lint:http`, focused API route tests for email preference/abuse controls, focused API job/email/auth route tests, focused web session-bridge/cron route tests, and `git diff --check`. Full local Docker/browser execution remains part of the Milestone 6 manual checklist for the target environment under review.

--- a/docs/testing/milestone6-manual-checklist.md
+++ b/docs/testing/milestone6-manual-checklist.md
@@ -1,6 +1,6 @@
 # Milestone 6 Manual Checklist
 
-Use this checklist after the automated checks in `docs/testing/milestone6-automated.md`.
+Use this checklist after the automated checks in `docs/testing/milestone6-automated.md` and after the safe HTTP examples in `apps/api/tests/security.http` pass against the environment under review.
 
 ## Local Preconditions
 
@@ -8,6 +8,7 @@ Use this checklist after the automated checks in `docs/testing/milestone6-automa
 - [ ] API, web, database, and MailHog are healthy.
 - [ ] Seed data exists or a fresh test user can be created.
 - [ ] No real production email provider credentials are required for the local run.
+- [ ] HTTP smoke files use placeholders only; do not paste production tokens, real job secrets, real cron secrets, or production email recipients into committed files.
 
 ## Browser And Auth
 
@@ -17,18 +18,41 @@ Use this checklist after the automated checks in `docs/testing/milestone6-automa
 - [ ] Logout clears both web and API-authenticated state.
 - [ ] Dev auth bypass is disabled unless explicitly testing a non-production bypass scenario.
 
+### `/auth/session-bridge` Browser Smoke
+
+Run this section only when both apps are available locally or in a preview environment and the web app points at the matching API.
+
+- [ ] Signed-out requirement: in a private browser window, open `/auth/session-bridge?from=/dashboard`; expect a redirect to `/login?from=/dashboard&reason=session-bridge` and no `tf_session` cookie minted.
+- [ ] Redirect sanitization: while signed out, open `/auth/session-bridge?from=%2F%2Fevil.example%2Fdashboard`; expect the `from` value to be sanitized to `/` rather than a protocol-relative external URL.
+- [ ] Authenticated minting: sign in, clear only the API `tf_session` cookie if present, then open `/auth/session-bridge?from=/dashboard`; expect a same-origin redirect to `/dashboard` and a new `tf_session` cookie scoped according to the environment's cookie-domain policy.
+- [ ] Existing-cookie path: repeat `/auth/session-bridge?from=/dashboard` with a valid, unexpired `tf_session`; expect a same-origin redirect without an unnecessary extra API-cookie minting loop.
+- [ ] No-cache headers: inspect the `/auth/session-bridge` network entry and confirm `Cache-Control: no-store` on redirect responses.
+
+### Logout Same-Origin And Cookie Expiry Smoke
+
+Run this section only when the web route can be exercised in the target environment.
+
+- [ ] Same-origin protection: submit `POST /api/auth/logout` from the web origin; expect `200` JSON and expired `tf_session` `Set-Cookie` headers.
+- [ ] Cross-origin rejection: send the same POST with an unrelated `Origin` header from a controlled local tool; expect `403` and do not repeat against shared production.
+- [ ] Cookie expiry: after successful logout, verify browser storage no longer has a usable web session or API `tf_session`, then refresh `/dashboard` and expect redirect to login/session bridge instead of authenticated data.
+
 ## Security Headers And Errors
 
 - [ ] API responses include expected security headers from Helmet.
 - [ ] Error responses do not expose stack traces, env values, tokens, SMTP credentials, OAuth secrets, or job secrets.
 - [ ] Swagger UI at `/api/taskforge/docs` loads in local development.
 - [ ] Missing auth returns the expected `401` envelope on protected API routes.
+- [ ] `apps/api/tests/security.http` missing/incorrect credential examples return expected `401` responses for auth, tasks, board, tags, email, job, and cron-proxy paths.
 
 ## CORS, Cookies, And Proxy
 
+`.http` clients and plain `curl` can display response headers, but they do not enforce browser CORS policy, preflight caching, blocked credential rules, or cookie jar behavior the same way a real browser does. Use a browser for final approval.
+
 - [ ] Local web origin can call the API with credentials.
 - [ ] Deployed web origin can authenticate in a real browser and authenticated API requests include cookies, pass preflight, and return JSON rather than a browser CORS failure.
-- [ ] An unlisted origin is rejected by CORS in a browser or equivalent controlled check.
+- [ ] Browser preflight: from the allowed web origin, trigger an authenticated API request with `Content-Type: application/json` or `Authorization`; confirm the `OPTIONS` preflight succeeds and includes the expected `Access-Control-Allow-Origin`, `Access-Control-Allow-Credentials`, `Access-Control-Allow-Headers`, and method headers.
+- [ ] Credentialed cookie request: in browser DevTools, confirm task/tag/board API requests send the intended cookie or bearer token and the API response is visible to JavaScript; a network `200` hidden behind a CORS console error does not count as success.
+- [ ] Unlisted-origin rejection: from a controlled test origin that is not in `CORS_ALLOWED_ORIGINS`, attempt a credentialed API request and confirm the browser blocks it or the server returns the expected CORS error. Do not use arbitrary third-party pages for this check.
 - [ ] Cookie domain behavior matches README and production docs for the chosen topology, including `COOKIE_DOMAIN`, `SameSite=Lax`, `Secure`, `httpOnly`, and the seven-day API session cookie lifetime.
 - [ ] Production browser auth uses same-site custom domains or an API behind the web origin; raw unrelated Vercel/Render/Railway default domains are not used for the OAuth session bridge cookie path.
 - [ ] `/auth/session-bridge` remains `no-store`, sanitizes redirects, requires an authenticated web user, probes existing cookies, and sets the API cookie for the selected topology.
@@ -43,6 +67,45 @@ Use this checklist after the automated checks in `docs/testing/milestone6-automa
 - [ ] Protected digest job endpoint rejects missing and incorrect `DIGEST_JOB_SECRET`.
 - [ ] Web cron proxy rejects missing and incorrect `CRON_SECRET`.
 - [ ] Scheduled digest dry runs omit `digestDate` and derive user-local digest dates.
+
+### Safe Bounded Rate-Limit Smoke
+
+Use this only against local Docker, a personal preview, or an explicitly approved test environment. Do not run it against shared production, do not parallelize it, and stop immediately after the first expected `429`.
+
+```bash
+for i in 1 2 3 4 5 6 7 8 9 10; do
+  status=$(curl -sS -o /tmp/taskforge-rate-limit-smoke.json -w "%{http_code}" \
+    -X POST http://localhost:4000/api/taskforge/v1/auth/login \
+    -H 'Content-Type: application/json' \
+    --data '{"email":"rate-limit-smoke@example.invalid","password":"WrongPassword1!"}')
+  printf 'attempt=%s status=%s\n' "$i" "$status"
+  if [ "$status" = "429" ]; then
+    break
+  fi
+  sleep 1
+done
+```
+
+Expected result: one of the bounded attempts returns `429` with the standard JSON rate-limit envelope and rate-limit headers. If no `429` appears after ten sequential attempts, stop anyway and inspect the environment's limiter configuration rather than increasing the loop count.
+
+### Job And Cron Secret Negative Smoke
+
+Use placeholder values only. The HTTP equivalents are in `apps/api/tests/security.http`.
+
+```bash
+curl -i 'http://localhost:4000/api/taskforge/v1/jobs/digest?dryRun=true&sendLimit=0'
+curl -i 'http://localhost:4000/api/taskforge/v1/jobs/digest?dryRun=true&sendLimit=0' \
+  -H 'Authorization: Bearer replace-with-wrong-digest-job-secret'
+curl -i -X POST 'http://localhost:4000/api/taskforge/v1/jobs/digest' \
+  -H 'Content-Type: application/json' \
+  -H 'x-job-secret: replace-with-wrong-digest-job-secret' \
+  --data '{"dryRun":true,"sendLimit":0}'
+curl -i 'http://localhost:3000/api/cron/digest?dryRun=true&sendLimit=0'
+curl -i 'http://localhost:3000/api/cron/digest?dryRun=true&sendLimit=0' \
+  -H 'Authorization: Bearer replace-with-wrong-cron-secret'
+```
+
+Expected result: every request above returns `401 Unauthorized` when the local API/web routes are configured with non-empty `DIGEST_JOB_SECRET` and `CRON_SECRET`. The cron proxy checks require the web app route to be running; if only the API is running, mark the cron checks as not applicable for that run and complete them in a web-capable environment.
 
 ## Docker And CI
 


### PR DESCRIPTION
### Motivation
- Provide reviewers with repeatable, safe checks for security-sensitive negative paths that can be run locally or against preview environments without committing real secrets.
- Cover job/cron secret validation, unauthorized access to auth/task/tag/board/email endpoints, and guidance for browser-only CORS/cookie verification that `.http` clients cannot fully model.

### Description
- Add a safe-by-default HTTP smoke pack at `apps/api/tests/security.http` containing placeholder variables and negative-path checks for unauthenticated `auth`, `tasks`, `board`, `tags`, `email` endpoints and for missing/incorrect `DIGEST_JOB_SECRET` and web `CRON_SECRET` paths.
- Expand `docs/testing/milestone6-manual-checklist.md` with browser/session-bridge/logout smoke items, CORS preflight and credentialed-cookie checks, a bounded rate-limit smoke example, and job/cron negative-smoke curl examples using placeholders only.
- Keep examples placeholder-only and explicit about not committing real secrets or production recipients, and add safe guidance on when to run the bounded rate-limit smoke.

### Testing
- Ran `pnpm -C apps/api run lint:http` which validated the HTTP files and passed (`Validated 5 HTTP files` including the new `security.http`).
