### PR TITLE
Milestone-6: Final release-readiness verification

### DIFF
--- a/apps/web/app/auth/session-bridge/route.test.ts
+++ b/apps/web/app/auth/session-bridge/route.test.ts
@@ -66,6 +66,21 @@ describe('/auth/session-bridge', () => {
     expect(mocks.getFreshBridgedAccessToken).not.toHaveBeenCalled();
   });
 
+  it('rejects encoded backslash return paths that resolve as external URLs', async () => {
+    const { GET } = await import('./route');
+
+    const response = await GET(createRequest('/auth/session-bridge?from=%2F%5Cevil.test%2Fdashboard'));
+    const locationHeader = response.headers.get('location') ?? '';
+    const location = new URL(locationHeader, 'https://app.test');
+
+    expect(locationHeader).toBe('/login?from=%2F&reason=session-bridge');
+    expect(location.origin).toBe('https://app.test');
+    expect(location.searchParams.get('from')).toBe('/');
+    expect(response.headers.get('cache-control')).toBe('no-store');
+    expect(fetch).not.toHaveBeenCalled();
+    expect(mocks.getFreshBridgedAccessToken).not.toHaveBeenCalled();
+  });
+
   it('probes a non-expired existing API cookie before redirecting without minting', async () => {
     vi.mocked(fetch).mockResolvedValue(new Response(JSON.stringify({ user: { id: 'user-1' } }), { status: 200 }));
     const { GET } = await import('./route');

--- a/apps/web/app/auth/session-bridge/route.test.ts
+++ b/apps/web/app/auth/session-bridge/route.test.ts
@@ -53,8 +53,10 @@ describe('/auth/session-bridge', () => {
     const { GET } = await import('./route');
 
     const response = await GET(createRequest('/auth/session-bridge?from=%2F%2Fevil.test%2Fdashboard'));
-    const location = new URL(response.headers.get('location') ?? '');
+    const locationHeader = response.headers.get('location') ?? '';
+    const location = new URL(locationHeader, 'https://app.test');
 
+    expect(locationHeader).toBe('/login?from=%2F&reason=session-bridge');
     expect(location.origin).toBe('https://app.test');
     expect(location.pathname).toBe('/login');
     expect(location.searchParams.get('from')).toBe('/');
@@ -71,8 +73,10 @@ describe('/auth/session-bridge', () => {
     const response = await GET(createRequest('/auth/session-bridge?from=/dashboard', {
       cookie: 'taskforge_session=existing-token',
     }));
-    const location = new URL(response.headers.get('location') ?? '');
+    const locationHeader = response.headers.get('location') ?? '';
+    const location = new URL(locationHeader, 'https://app.test');
 
+    expect(locationHeader).toBe('/dashboard');
     expect(location.pathname).toBe('/dashboard');
     expect(response.headers.get('set-cookie')).toBeNull();
     expect(response.headers.get('cache-control')).toBe('no-store');
@@ -92,9 +96,11 @@ describe('/auth/session-bridge', () => {
     const { GET } = await import('./route');
 
     const response = await GET(createRequest('/auth/session-bridge?from=/dashboard'));
-    const location = new URL(response.headers.get('location') ?? '');
+    const locationHeader = response.headers.get('location') ?? '';
+    const location = new URL(locationHeader, 'https://app.test');
     const setCookie = response.headers.get('set-cookie') ?? '';
 
+    expect(locationHeader).toBe('/dashboard');
     expect(location.pathname).toBe('/dashboard');
     expect(response.headers.get('cache-control')).toBe('no-store');
     expect(mocks.getFreshBridgedAccessToken).toHaveBeenCalledWith({ id: 'user-1', email: 'user@example.com' });

--- a/apps/web/app/auth/session-bridge/route.ts
+++ b/apps/web/app/auth/session-bridge/route.ts
@@ -7,20 +7,7 @@ import {
   isSessionTokenExpired,
 } from '@/lib/session-bridge';
 import { getCurrentUser } from '@/lib/server-auth';
-
-function sanitizeReturnPath(value: string | null): string {
-  if (!value) {
-    return '/';
-  }
-
-  const trimmed = value.trim();
-
-  if (!trimmed.startsWith('/') || trimmed.startsWith('//')) {
-    return '/';
-  }
-
-  return trimmed;
-}
+import { sanitizeReturnPath } from '@/lib/auth-return-path';
 
 function redirectNoStore(location: string): NextResponse {
   const response = new NextResponse(null, {

--- a/apps/web/app/auth/session-bridge/route.ts
+++ b/apps/web/app/auth/session-bridge/route.ts
@@ -22,10 +22,24 @@ function sanitizeReturnPath(value: string | null): string {
   return trimmed;
 }
 
-function redirectNoStore(url: URL): NextResponse {
-  const response = NextResponse.redirect(url);
+function redirectNoStore(location: string): NextResponse {
+  const response = new NextResponse(null, {
+    status: 307,
+    headers: {
+      Location: location,
+    },
+  });
   response.headers.set('Cache-Control', 'no-store');
   return response;
+}
+
+function createLoginLocation(fromPath: string): string {
+  const searchParams = new URLSearchParams({
+    from: fromPath,
+    reason: 'session-bridge',
+  });
+
+  return `/login?${searchParams.toString()}`;
 }
 
 type ApiSessionCookieProbe = 'valid' | 'invalid' | 'unknown';
@@ -70,30 +84,23 @@ export async function GET(request: NextRequest) {
     !isSessionTokenExpired(existingCookie.value) &&
     existingCookieProbe !== 'invalid'
   ) {
-    return redirectNoStore(new URL(fromPath, request.nextUrl.origin));
+    return redirectNoStore(fromPath);
   }
 
   const user = await getCurrentUser();
 
   if (!user) {
-    const redirectUrl = new URL('/login', request.nextUrl.origin);
-    redirectUrl.searchParams.set('from', fromPath);
-    redirectUrl.searchParams.set('reason', 'session-bridge');
-    return redirectNoStore(redirectUrl);
+    return redirectNoStore(createLoginLocation(fromPath));
   }
 
   try {
     const accessToken = await getFreshBridgedAccessToken(user);
-    const redirectUrl = new URL(fromPath, request.nextUrl.origin);
-    const response = redirectNoStore(redirectUrl);
+    const response = redirectNoStore(fromPath);
     const options = getSessionCookieOptions();
     response.cookies.set({ ...options, value: accessToken });
     return response;
   } catch (error) {
     console.error('[auth] Failed to ensure API session', error);
-    const redirectUrl = new URL('/login', request.nextUrl.origin);
-    redirectUrl.searchParams.set('from', fromPath);
-    redirectUrl.searchParams.set('reason', 'session-bridge');
-    return redirectNoStore(redirectUrl);
+    return redirectNoStore(createLoginLocation(fromPath));
   }
 }

--- a/apps/web/components/auth/login-form.test.tsx
+++ b/apps/web/components/auth/login-form.test.tsx
@@ -90,6 +90,29 @@ describe('LoginForm', () => {
     expect(mockRouter.refresh).toHaveBeenCalled();
   });
 
+  it('falls back instead of redirecting to an encoded backslash path', async () => {
+    searchParamsString = 'from=%2F%5Cevil.example%2Fdashboard';
+
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        user: { email: 'demo@taskforge.dev' },
+        tokens: { accessToken: 'token' },
+      }),
+    } as Response);
+
+    render(<LoginForm providers={providers} />);
+
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText(/email/i), 'demo@taskforge.dev');
+    await user.type(screen.getByLabelText(/password/i), 'Demo1234!');
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(mockRouter.push).toHaveBeenCalledWith('/dashboard');
+    });
+  });
+
   it('shows validation feedback when the API rejects credentials', async () => {
     fetchMock.mockResolvedValue({
       ok: false,

--- a/apps/web/components/auth/login-form.tsx
+++ b/apps/web/components/auth/login-form.tsx
@@ -15,6 +15,7 @@ import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '
 import { Input } from '@/components/ui/input';
 import { getApiUrl } from '@/lib/env';
 import type { AuthProviderSummary } from '@/lib/auth-config';
+import { sanitizeReturnPath } from '@/lib/auth-return-path';
 
 const loginSchema = z.object({
   email: z
@@ -29,23 +30,6 @@ const loginSchema = z.object({
 
 type LoginValues = z.infer<typeof loginSchema>;
 
-function sanitizeReturnPath(value: string | null | undefined) {
-  if (!value) {
-    return '/dashboard';
-  }
-
-  try {
-    const decoded = decodeURIComponent(value);
-    if (decoded.startsWith('/') && !decoded.startsWith('//')) {
-      return decoded;
-    }
-  } catch {
-    // ignore decode failures and fall back to default
-  }
-
-  return '/dashboard';
-}
-
 type LoginFormProps = {
   providers: ReadonlyArray<AuthProviderSummary>;
 };
@@ -59,7 +43,7 @@ export function LoginForm({ providers }: LoginFormProps) {
 
   const fromParam = searchParams?.get('from');
   const reasonParam = searchParams?.get('reason');
-  const redirectPath = useMemo(() => sanitizeReturnPath(fromParam), [fromParam]);
+  const redirectPath = useMemo(() => sanitizeReturnPath(fromParam, '/dashboard'), [fromParam]);
   const reasonMessage = useMemo(() => {
     if (!reasonParam) {
       return null;

--- a/apps/web/components/auth/register-form.tsx
+++ b/apps/web/components/auth/register-form.tsx
@@ -13,6 +13,7 @@ import { Button } from '@/components/ui/button';
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { getApiUrl } from '@/lib/env';
+import { sanitizeReturnPath } from '@/lib/auth-return-path';
 
 const registerSchema = z
   .object({
@@ -33,23 +34,6 @@ const registerSchema = z
 
 type RegisterValues = z.infer<typeof registerSchema>;
 
-function sanitizeReturnPath(value: string | null | undefined) {
-  if (!value) {
-    return '/dashboard';
-  }
-
-  try {
-    const decoded = decodeURIComponent(value);
-    if (decoded.startsWith('/') && !decoded.startsWith('//')) {
-      return decoded;
-    }
-  } catch {
-    // ignore decode errors and fall back to default
-  }
-
-  return '/dashboard';
-}
-
 export function RegisterForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -57,7 +41,7 @@ export function RegisterForm() {
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const fromParam = searchParams?.get('from');
-  const redirectPath = useMemo(() => sanitizeReturnPath(fromParam), [fromParam]);
+  const redirectPath = useMemo(() => sanitizeReturnPath(fromParam, '/dashboard'), [fromParam]);
 
   const form = useForm<RegisterValues>({
     resolver: zodResolver(registerSchema),

--- a/apps/web/lib/auth-config.test.ts
+++ b/apps/web/lib/auth-config.test.ts
@@ -45,6 +45,10 @@ vi.mock('./welcome-email', () => ({
 import { authConfig } from './auth-config';
 
 describe('authConfig adapter', () => {
+  it('does not install a credentials placeholder provider when OAuth secrets are absent', () => {
+    expect(authConfig.providers).toEqual([]);
+  });
+
   it('does not wait for welcome scheduling before returning an OAuth-created user', async () => {
     mocks.prisma.user.findUnique.mockResolvedValue(null);
 

--- a/apps/web/lib/auth-config.ts
+++ b/apps/web/lib/auth-config.ts
@@ -3,7 +3,6 @@ import 'server-only';
 import type { NextAuthConfig } from 'next-auth';
 import type { Adapter, AdapterAccount, AdapterUser } from 'next-auth/adapters';
 import { PrismaAdapter } from '@auth/prisma-adapter';
-import Credentials from 'next-auth/providers/credentials';
 import GitHub from 'next-auth/providers/github';
 import Google from 'next-auth/providers/google';
 
@@ -49,17 +48,7 @@ const configuredProviders = [
   createGoogleProvider(),
 ].filter(Boolean) as Array<ReturnType<typeof GitHub> | ReturnType<typeof Google>>;
 
-const developmentFallbackProvider = Credentials({
-  id: 'dev-placeholder',
-  name: 'Development Placeholder',
-  credentials: {},
-  authorize: async () => null,
-});
-
-const providers =
-  configuredProviders.length > 0
-    ? configuredProviders
-    : [developmentFallbackProvider];
+const providers = configuredProviders;
 
 const prisma = getPrismaClient();
 

--- a/apps/web/lib/auth-return-path.test.ts
+++ b/apps/web/lib/auth-return-path.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { sanitizeReturnPath } from './auth-return-path';
+
+describe('sanitizeReturnPath', () => {
+  it.each([
+    ['/dashboard', '/dashboard'],
+    ['%2Fdashboard', '/dashboard'],
+    [' /dashboard?filter=upcoming ', '/dashboard?filter=upcoming'],
+  ])('keeps same-site return path %s', (input, expected) => {
+    expect(sanitizeReturnPath(input, '/fallback')).toBe(expected);
+  });
+
+  it.each([
+    null,
+    '',
+    'https://evil.example/dashboard',
+    'evil.example/dashboard',
+    '//evil.example/dashboard',
+    '%2F%2Fevil.example%2Fdashboard',
+    '/\\evil.example/dashboard',
+    '/%5Cevil.example/dashboard',
+    '%2F%5Cevil.example%2Fdashboard',
+    '/dashboard\nSet-Cookie:%20x=y',
+    '/dashboard\r\nLocation:%20https://evil.example',
+  ])('falls back for unsafe return path %s', (input) => {
+    expect(sanitizeReturnPath(input, '/fallback')).toBe('/fallback');
+  });
+});

--- a/apps/web/lib/auth-return-path.ts
+++ b/apps/web/lib/auth-return-path.ts
@@ -1,0 +1,44 @@
+const RETURN_PATH_BASE = 'https://taskforge.local';
+const CONTROL_CHARACTERS = /[\u0000-\u001F\u007F]/;
+
+export function sanitizeReturnPath(
+  value: string | null | undefined,
+  fallback = '/',
+): string {
+  if (!value) {
+    return fallback;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return fallback;
+  }
+
+  let candidate = trimmed;
+  try {
+    candidate = decodeURIComponent(trimmed).trim();
+  } catch {
+    candidate = trimmed;
+  }
+
+  if (
+    !candidate.startsWith('/') ||
+    candidate.startsWith('//') ||
+    candidate.startsWith('/\\') ||
+    candidate.includes('\\') ||
+    CONTROL_CHARACTERS.test(candidate)
+  ) {
+    return fallback;
+  }
+
+  try {
+    const resolved = new URL(candidate, RETURN_PATH_BASE);
+    if (resolved.origin !== RETURN_PATH_BASE) {
+      return fallback;
+    }
+  } catch {
+    return fallback;
+  }
+
+  return candidate;
+}

--- a/docs/tasks/milestone6/08-milestone6-verification.md
+++ b/docs/tasks/milestone6/08-milestone6-verification.md
@@ -4,15 +4,15 @@
 - Run the final automated and manual checks for the security/docs/CI hardening milestone.
 - Record residual risks before moving to Day 7 deployment.
 
-**Status:** Pending final verification.
+**Status:** Completed - final automated gates and local Docker/manual smokes passed on 2026-06-05.
 
 ## Acceptance Criteria
-- [ ] All commands in `docs/testing/milestone6-automated.md` pass or have an explicit documented blocker.
-- [ ] Manual checks in `docs/testing/milestone6-manual-checklist.md` are completed for local Docker and, if available, a preview deployment.
-- [ ] `docs/openapi.json` has no uncommitted drift after generation.
-- [ ] Docker build/compose validation has passed in CI or an equivalent local run is documented.
-- [ ] Release-candidate docs list remaining Day 7 deployment steps and production email gates.
-- [ ] Any unresolved issues are converted into follow-up task docs or release blockers, not buried in chat history.
+- [x] All commands in `docs/testing/milestone6-automated.md` pass or have an explicit documented blocker.
+- [x] Manual checks in `docs/testing/milestone6-manual-checklist.md` are completed for local Docker and, if available, a preview deployment.
+- [x] `docs/openapi.json` has no uncommitted drift after generation.
+- [x] Docker build/compose validation has passed in CI or an equivalent local run is documented.
+- [x] Release-candidate docs list remaining Day 7 deployment steps and production email gates.
+- [x] Any unresolved issues are converted into follow-up task docs or release blockers, not buried in chat history.
 
 ## Notes
 - This task should be the last Milestone 6 task before deployment provisioning starts.
@@ -22,16 +22,65 @@
 - Use `docs/testing/milestone6-automated.md` as the command source of truth.
 - Use `docs/testing/milestone6-manual-checklist.md` for browser and deployment-path checks.
 
-## Baseline Audit Follow-ups
-- Before marking this task complete, verify every follow-up from `01-security-baseline-audit.md` was either implemented in Milestone 6 or converted into an explicit release blocker.
-- Re-run the security-sensitive `rg` inventory for `CORS_ALLOWED_ORIGINS`, `TRUST_PROXY`, `CRON_SECRET`, `DIGEST_JOB_SECRET`, `NEXTAUTH_SECRET`, `COOKIE_DOMAIN`, and `TF_DEV_BYPASS_AUTH` and confirm no undocumented production requirement remains.
-- Confirm `/auth/session-bridge` is included in final web-route verification for authenticated-user checks, redirect sanitization, API-cookie minting, and cache behavior.
-- Confirm production email scheduled sends are still disabled unless all fact-register placeholders and manual-only rollout checks are complete.
-- Confirm release notes list residual risks for CORS fallback, trusted proxy, rate-limit store topology, explicit body/query limits, session-bridge cookie handling, and structured API errors if any remain unresolved.
+## Final Verification Evidence
 
+Automated checks run locally on 2026-06-05:
+
+- `pnpm -C apps/api lint`
+- `pnpm -C apps/api run lint:http`
+- `pnpm -C apps/api typecheck`
+- `pnpm -C apps/api test` - 15 suites, 167 tests passed.
+- `pnpm -C apps/api gen:openapi`
+- `git diff -- docs/openapi.json` - no generated drift.
+- `pnpm -C apps/web lint`
+- `pnpm -C apps/web typecheck`
+- `pnpm -C apps/web test` - 16 files, 87 tests passed after the local auth/session-bridge fixes.
+- `pnpm -C apps/api build`
+- `pnpm -C apps/web build`
+- `docker compose -f infra/docker-compose.yml config --quiet`
+- `docker build -f apps/api/Dockerfile -t taskforge-api:local .`
+- `docker build -f apps/web/Dockerfile -t taskforge-web:local .`
+- `git diff --check`
+
+Local Docker/manual smokes run against the rebuilt compose stack:
+
+- `make up` rebuilt and restarted API/web services from this branch.
+- `docker compose -f infra/docker-compose.yml exec -T api pnpm prisma migrate deploy` reported no pending migrations.
+- `docker compose -f infra/docker-compose.yml exec -T api pnpm tsx prisma/seed.ts` completed.
+- `docker compose -f infra/docker-compose.yml ps` showed API, web, Postgres, and MailHog running; Postgres was healthy.
+- `curl http://localhost:4000/api/taskforge/v1/health` returned `200` with Helmet/security headers.
+- `curl http://localhost:3000/login` returned `200`.
+- `make auth-smoke` passed after rebuilding the Docker web service, including register/login/session-bridge behavior.
+- Signed-out `/auth/session-bridge?from=/dashboard` returned `307`, `Cache-Control: no-store`, and `Location: /login?from=%2Fdashboard&reason=session-bridge`.
+- Signed-out `/auth/session-bridge?from=%2F%2Fevil.example%2Fdashboard` returned `307`, `Cache-Control: no-store`, and sanitized `Location: /login?from=%2F&reason=session-bridge`.
+- Missing and incorrect API `DIGEST_JOB_SECRET` smokes returned `401` for GET bearer and POST `x-job-secret` paths.
+- Missing and incorrect web `CRON_SECRET` smokes returned `401`.
+- Local browser-origin API preflight returned `204` with `Access-Control-Allow-Origin: http://localhost:3000`, credentials, methods, and requested headers.
+- Unlisted-origin API request returned `403` with `{"error":"CORS origin denied"}`.
+- Swagger UI at `/api/taskforge/docs/` returned `200`.
+- Missing auth on `/api/taskforge/v1/tasks` returned `401`.
+- Bounded auth rate-limit smoke returned `429` on attempt 6 and stopped.
+
+No preview deployment was available in this local workspace. Day 7 must repeat the deployed-browser parts of `docs/testing/milestone6-manual-checklist.md` after the web, API, and database are provisioned.
+
+## Baseline Audit Follow-ups
+- Every follow-up from `01-security-baseline-audit.md` is either completed by Milestone 6 tasks 02-07 or remains an explicit release/deployment gate in `README.md`, `docs/PRD.md`, `docs/prod/README.md`, `docs/prod/browser-auth-deployment.md`, `docs/prod/email-production-rollout.md`, and `docs/prod/adr/0008-release-candidate-security-and-deployment-gates.md`.
+- The required security-sensitive `rg` inventory was rerun for `CORS_ALLOWED_ORIGINS`, `TRUST_PROXY`, `CRON_SECRET`, `DIGEST_JOB_SECRET`, `NEXTAUTH_SECRET`, `COOKIE_DOMAIN`, and `TF_DEV_BYPASS_AUTH`. No undocumented production requirement was found.
+- `/auth/session-bridge` is covered by unit tests, local Docker auth smoke, signed-out redirect checks, redirect sanitization checks, API-cookie minting smoke, and no-cache header checks.
+- Production email scheduled sends remain disabled unless all production fact-register placeholders are filled and manual-only Resend/observability checks pass.
+- Remaining `<TBD before enablement>` values are intentional Day 7/pre-launch production email facts, not hidden Milestone 6 requirements.
 
 ## Current Release-Candidate State
 - Documentation gates for README, PRD, ADRs, production placeholders, and Milestone 6 testing references have been refreshed.
-- Final automated command execution and manual browser/deployment-path smoke remain pending until the release reviewer runs `docs/testing/milestone6-automated.md` and `docs/testing/milestone6-manual-checklist.md`.
-- Docker image-build evidence is now covered by CI compose validation plus API/web image builds; final sign-off should inspect the latest CI run or repeat the documented local Docker commands if CI evidence is unavailable.
+- Final automated command execution and local Docker/manual smoke have passed locally; preview/deployed-browser smoke remains a Day 7 provisioning gate because no preview deployment was available for this verification run.
+- Docker image-build evidence is covered by local compose validation plus local API/web image builds; CI also contains compose and API/web image build steps with safe placeholder values.
 - Production email scheduled sends remain disabled unless all production fact-register placeholders are filled and manual-only Resend/observability checks pass.
+
+## Release Notes And Residual Risks
+- CORS no longer has a production fallback origin; Day 7 must set exact deployed web origins in `CORS_ALLOWED_ORIGINS`.
+- Trusted proxy behavior is explicit; Day 7 must set `TRUST_PROXY` only to the actual platform proxy chain.
+- v1 rate limits use in-process state; run one API instance or add a shared limiter store before horizontal scaling.
+- JSON body/query/mutation bounds are implemented and documented; keep `API_JSON_BODY_LIMIT=64kb` unless a reviewed production need requires a larger cap.
+- `/auth/session-bridge` avoids unsupported local placeholder NextAuth providers, uses relative same-site redirects, sanitizes unsafe `from` paths, remains `no-store`, and is covered by unit tests plus local Docker smoke.
+- Structured API errors are implemented for the checked routes; continue treating HTML/stack responses from API routes as release blockers if any new route is added.
+- Production scheduled email sends remain disabled until every `<TBD before enablement>` in `docs/prod/email-production-rollout.md` is replaced and manual-only Resend/observability checks pass.


### PR DESCRIPTION
## Summary
This PR completes the final Milestone 6 release-readiness verification pass before Day 7 deployment provisioning. It fixes two local Docker/manual-smoke issues found during verification: the no-OAuth NextAuth configuration no longer registers an unsupported placeholder Credentials provider, and `/auth/session-bridge` now returns sanitized relative redirects instead of leaking the Docker dev bind host into `Location` headers. The Milestone 6 verification task now records the full automated command evidence, local Docker smoke evidence, OpenAPI drift result, residual risks, and remaining Day 7 production gates.

## What's Included
- [ ] Product behavior / user workflow changes
- [ ] API, schema, or data model changes
- [x] Frontend UI / state management changes
- [x] Tests, fixtures, or CI updates
- [x] Docs updated (README, PRD, ADRs, task docs, testing docs)

## How to Test
1. **Automated**
   ```bash
   pnpm -C apps/api lint
   pnpm -C apps/api run lint:http
   pnpm -C apps/api typecheck
   pnpm -C apps/api test
   pnpm -C apps/api gen:openapi
   pnpm -C apps/web lint
   pnpm -C apps/web typecheck
   pnpm -C apps/web test
   pnpm -C apps/api build
   pnpm -C apps/web build
   docker compose -f infra/docker-compose.yml config --quiet
   docker build -f apps/api/Dockerfile -t taskforge-api:local .
   docker build -f apps/web/Dockerfile -t taskforge-web:local .
   git diff --check
   ```
2. **API / HTTP packs**
   ```bash
   pnpm -C apps/api run lint:http
   ```
   Local verification also covered CORS preflight, unlisted-origin rejection, Swagger UI, missing-auth responses, job-secret rejection, cron-secret rejection, and bounded auth rate-limit smoke.
3. **Manual smoke**
   ```bash
   make up
   docker compose -f infra/docker-compose.yml exec -T api pnpm prisma migrate deploy
   docker compose -f infra/docker-compose.yml exec -T api pnpm tsx prisma/seed.ts
   make auth-smoke
   ```
   Also verify:
   ```bash
   curl -i "http://localhost:3000/auth/session-bridge?from=/dashboard"
   curl -i "http://localhost:3000/auth/session-bridge?from=%2F%2Fevil.example%2Fdashboard"
   ```
   Expected signed-out results are `307`, `Cache-Control: no-store`, and relative sanitized `Location` headers.

## Screenshots / Logs
- API test suite: 15 suites, 167 tests passed.
- Web test suite: 16 files, 87 tests passed.
- `pnpm -C apps/api gen:openapi` produced no `docs/openapi.json` drift.
- `make auth-smoke` passed after rebuilding the Docker web service.
- Bounded auth rate-limit smoke returned `429` on attempt 6 and stopped.
- No preview deployment was available; deployed-browser smoke remains a Day 7 provisioning gate.

## Checklist
- [x] Lints pass (`make lint`)
- [x] Typecheck passes (`make typecheck`)
- [x] Tests pass (`make test` plus any focused suites listed above)
- [x] Build passes (`make build`)
- [x] Updated docs where needed
- [x] No secrets committed

## Notes / Follow-ups
- Day 7 must repeat the deployed-browser portions of `docs/testing/milestone6-manual-checklist.md` after web, API, and database provisioning.
- Production must set exact deployed origins in `CORS_ALLOWED_ORIGINS`.
- Production must set `TRUST_PROXY` to the actual platform proxy chain only.
- v1 rate limits assume one API instance; add a shared limiter store before horizontal scaling.
- Production scheduled email sends remain disabled until every `<TBD before enablement>` in `docs/prod/email-production-rollout.md` is replaced and manual-only Resend/observability checks pass.
